### PR TITLE
Fix for color parsing error when "smoother lights" option is checked.

### DIFF
--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -1852,7 +1852,7 @@ Imported[Community.Lighting.name] = true;
         if (brightness > 0) {
           newAlpha = Math.max(0, brightness - distanceFromCenter);
         }
-        this.addColorStop(distanceFromCenter, rgba(newRed, newGreen, newBlue, newAlpha));
+        this.addColorStop(distanceFromCenter, rgba(~~newRed, ~~newGreen, ~~newBlue, newAlpha));
       }
     }
     else {


### PR DESCRIPTION
Rounds down the color values to prevent an error. Sorry if I've already submitted a pull request like this, I forgot if I have or not.