### PR TITLE
Update setupEvents and check "isErased"

### DIFF
--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -1070,8 +1070,8 @@ Imported[Community.Lighting.name] = true;
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
 
   Game_Map.prototype.setupEvents = function () {
-    $$.ReloadMapEvents();
     _Game_Map_prototype_setupEvents.call(this);
+    $$.ReloadMapEvents();
   }
 
   /**

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -2387,7 +2387,7 @@ Imported[Community.Lighting.name] = true;
 
     for (let i = 0; i < event_eventcount; i++) {
       if ($gameMap.events()[i]) {
-        if ($gameMap.events()[i].event()) {
+        if ($gameMap.events()[i].event() && !$gameMap.events()[i]._erased) {
           let note = $gameMap.events()[i].getCLTag();
 
           let note_args = note.split(" ");

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -3091,7 +3091,7 @@ Imported[Community.Lighting.name] = true;
 
 		for (let i = 0; i < event_eventcount; i++) {
 			if ($gameMap.events()[i]) {
-				if ($gameMap.events()[i].event()) {
+				if ($gameMap.events()[i].event() && !$gameMap.events()[i]._erased) {
 					let note = $gameMap.events()[i].getCLTag();
 
 					let note_args = note.split(" ");

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -1070,8 +1070,8 @@ Imported[Community.Lighting.name] = true;
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
 
   Game_Map.prototype.setupEvents = function () {
-    $$.ReloadMapEvents();
     _Game_Map_prototype_setupEvents.call(this);
+    $$.ReloadMapEvents();
   }
 
   /**

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -2387,7 +2387,7 @@ Imported[Community.Lighting.name] = true;
 
     for (let i = 0; i < event_eventcount; i++) {
       if ($gameMap.events()[i]) {
-        if ($gameMap.events()[i].event()) {
+        if ($gameMap.events()[i].event() && !$gameMap.events()[i]._erased) {
           let note = $gameMap.events()[i].getCLTag();
 
           let note_args = note.split(" ");

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -3091,7 +3091,7 @@ Imported[Community.Lighting.name] = true;
 
 		for (let i = 0; i < event_eventcount; i++) {
 			if ($gameMap.events()[i]) {
-				if ($gameMap.events()[i].event()) {
+				if ($gameMap.events()[i].event() && !$gameMap.events()[i]._erased) {
 					let note = $gameMap.events()[i].getCLTag();
 
 					let note_args = note.split(" ");


### PR DESCRIPTION
Somebody reported a bug in my Discord Channel when using Community Lighting MV and [RNGMaps](http://aerosys.blog). My plugin substitutes $dataMap with a modified dataMap to inject a generated Map. The bug itself was caused as $dataMap.events and $gameMap.events() were not synchronized. I had to replace these lines of code

```
Game_Map.prototype.setupEvents = function () {
    $$.ReloadMapEvents();
    _Game_Map_prototype_setupEvents.call(this);
}
```

with

```
Game_Map.prototype.setupEvents = function () {
    _Game_Map_prototype_setupEvents.call(this);
    $$.ReloadMapEvents();
}
```
I did not find the corresponding section in MZ.

IMO you need to call the alias FIRST and then do reloading of events. When I did this change the incompatibility has been resolved.

Also, I recommend to check if an event has been erased in "ReloadMapEvents".