### PR TITLE
Tintbattle

### DIFF
--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -2346,7 +2346,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
-    if ((/^tintbattle /i).test(note)) {
+    if ((/^tintbattle\b/i).test(note)) {
       let data = note.split(/\s+/);
       data.splice(0, 1);
       data.map(x => x.trim());
@@ -2548,7 +2548,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       let mapnote = $$.getCLTag(note.trim());
       if (mapnote) {
         mapnote = mapnote.toLowerCase().trim();
-        if ((/^daynight/i).test(mapnote)) {
+        if ((/^daynight\b/i).test(mapnote)) {
           $$.daynightset = true;
           let dnspeed = note.match(/\d+/);
           if (dnspeed) {
@@ -2557,31 +2557,31 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
             $gameVariables.SetDaynightSpeed(daynightspeed);
           }
         }
-        else if ((/^RegionFire/i).test(mapnote)) {
+        else if ((/^RegionFire\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionfire", data);
         }
-        else if ((/^RegionGlow/i).test(mapnote)) {
+        else if ((/^RegionGlow\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionglow", data);
         }
-        else if ((/^RegionLight/i).test(mapnote)) {
+        else if ((/^RegionLight\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionlight", data);
         }
-        else if ((/^RegionBlock/i).test(mapnote)) {
+        else if ((/^RegionBlock\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileBlock("regionblock", data);
         }
-        else if ((/^tint/i).test(mapnote)) {
+        else if ((/^tint\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
@@ -2596,11 +2596,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
           }
           $$.tint(data);
         }
-        else if ((/^defaultBrightness/i).test(mapnote)) {
+        else if ((/^defaultBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) $$.defaultBrightness = Math.max(0, Math.min(Number(brightness[0], 100))) / 100;
         }
-        else if ((/^mapBrightness/i).test(mapnote)) {
+        else if ((/^mapBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) {
             let color = $gameVariables.GetTint();

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -447,8 +447,10 @@ Imported[Community.Lighting.name] = true;
 *
 * defaultbrightness
 * - Sets the default brightness of all the lights in the map
+*
 * Tint set c
 * - Sets the current screen tint to the color (c)
+*
 * Tint daylight
 * - Sets the tint based on the current hour.
 * -------------------------------------------------------------------------------

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -588,6 +588,15 @@ Imported[Community.Lighting.name] = true;
 * Plugin Commands - Battle
 * -------------------------------------------------------------------------------
 *
+* The following tag may be used in a comment field in the first page of a
+* battle event to change the battle tint prior to the first turn:
+*
+* TintBattle set
+* - Sets the current screen tint to the color (c)
+*
+* The following commands may be used at any time in battle events (note, these do
+* not work as tags in comment fields):
+*
 * TintBattle set [c] [s]
 * TintBattle fade [c] [s]
 * - Sets or fades the battle screen to the color (c)
@@ -792,9 +801,8 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   let glow_dir = 1;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = useSmootherLights == true ? "#00000000" : "#000000";
-  $$.getFirstComment = function () {
+  $$.getFirstComment = function (page) {
     let result = null;
-    let page = this.page();
     if (page && page.list[0] != null) {
       if (page.list[0].code === 108) {
         result = page.list[0].parameters[0] || "";
@@ -825,7 +833,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   };
   Game_Event.prototype.getCLTag = function () {
     let result;
-    let pageNote = noteTagKey ? $$.getFirstComment.call(this) : null;
+    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
     let note = this.event().note;
     if (pageNote) result = $$.getCLTag(pageNote);
     if (!result) result = $$.getCLTag(note);
@@ -1133,9 +1141,14 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {String} command
    * @param {String[]} args
    */
-  Game_Interpreter.prototype.tint = function (command, args) {
-    $$.tint(args);
-  };
+  Game_Interpreter.prototype.tint = (command, args) => $$.tint(args);
+
+  /**
+   *
+   * @param {String} command
+   * @param {String[]} args
+   */
+  Game_Interpreter.prototype.tintbattle = (command, args) => $$.tintbattle(args);
 
   /**
    *
@@ -1212,40 +1225,6 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (args[0].equalsIC("events")) {
       $$.ReloadMapEvents();
     }
-  };
-
-  Game_Interpreter.prototype.tintbattle = function (command, args) {
-    if ($gameParty.inBattle()) {
-      let cmd = args[0].trim();
-      if (cmd.equalsIC("set", 'fade')) {
-        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = this.determineBattleTint(args[1]);
-        $gameTemp._BattleTintSpeed = +args[2] || 0;
-      }
-      else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = $gameTemp._MapTint;
-        $gameTemp._BattleTintSpeed = +args[1] || 0;
-      }
-    }
-  };
-
-  Game_Interpreter.prototype.determineBattleTint = function (tintColor) {
-    if (!tintColor || tintColor.length < 7) {
-      return '#666666'; // Not an hex color string
-    }
-    let redhex = tintColor.substring(1, 3);
-    let greenhex = tintColor.substring(3, 5);
-    let bluehex = tintColor.substring(5);
-    let red = parseInt(redhex, 16);
-    let green = parseInt(greenhex, 16);
-    let blue = parseInt(bluehex, 16);
-    let color = red + green + blue;
-    if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
-      return '#666666'; // The player have to see something
-    }
-    return tintColor;
   };
 
   Spriteset_Map.prototype.createLightmask = function () {
@@ -2293,9 +2272,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0) { // If we went there from a map...
       if ($gameVariables.GetScriptActive() === true) {                                        // If the script is active...
         if (options_lighting_on && lightInBattle) {                                           // If configuration autorise using lighting effects
-          if (eventObjId.length > 0) {                                                        // If there is lightsource on this map...
-            $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
-          }
+          $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
         }
         // Add daylight tint?
       }
@@ -2366,6 +2343,16 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       $gameTemp._MapTint = '#666666'; // Prevent the battle scene from being too dark.
     }
     $gameTemp._BattleTint = $$.daynightset ? $gameVariables.GetTintByTime() : $gameTemp._MapTint;
+
+
+    let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
+    if ((/^tintbattle /i).test(note)) {
+      let data = note.split(/\s+/);
+      data.splice(0, 1);
+      data.map(x => x.trim());
+      $$.tintbattle(data, true);
+    }
+
     this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, $gameTemp._BattleTint);
     $gameTemp._BattleTintSpeed = 0;
   };
@@ -2747,6 +2734,44 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       if (speed == 0) $gameVariables.SetTint(currentColor);
       $gameVariables.SetTintTarget(currentColor);
       $gameVariables.SetTintSpeed(speed);
+    }
+  };
+
+  /**
+   *
+   * @param {String[]} args
+   */
+  $$.tintbattle = function (args, overrideInBattleCheck = false) {
+    let determineBattleTint = function (tintColor) {
+      if (!tintColor || tintColor.length < 7) {
+        return '#666666'; // Not an hex color string
+      }
+      let redhex = tintColor.substring(1, 3);
+      let greenhex = tintColor.substring(3, 5);
+      let bluehex = tintColor.substring(5);
+      let red = parseInt(redhex, 16);
+      let green = parseInt(greenhex, 16);
+      let blue = parseInt(bluehex, 16);
+      let color = red + green + blue;
+      if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
+        return '#666666'; // The player have to see something
+      }
+      return tintColor;
+    };
+
+    if ($gameParty.inBattle() || overrideInBattleCheck) {
+      let cmd = args[0].trim();
+      if (cmd.equalsIC("set", 'fade')) {
+        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
+        $gameTemp._BattleTintTimer = 0;
+        $gameTemp._BattleTint = determineBattleTint(args[1]);
+        $gameTemp._BattleTintSpeed = +args[2] || 0;
+      }
+      else if (cmd.equalsIC('reset', 'daylight')) {
+        $gameTemp._BattleTintTimer = 0;
+        $gameTemp._BattleTint = $gameTemp._MapTint;
+        $gameTemp._BattleTintSpeed = +args[1] || 0;
+      }
     }
   };
 

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -860,8 +860,10 @@ Imported[Community.Lighting.name] = true;
 *
 * defaultbrightness
 * - Sets the default brightness of all the lights in the map
+*
 * Tint set c
 * - Sets the current screen tint to the color (c)
+*
 * Tint daylight
 * - Sets the tint based on the current hour.
 *
@@ -2685,7 +2687,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
-    if ((/^tintbattle /i).test(note)) {
+    if ((/^tintbattle\b/i).test(note)) {
       let data = note.split(/\s+/);
       data.splice(0, 1);
       data.map(x => x.trim());
@@ -2887,7 +2889,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       let mapnote = $$.getCLTag(note.trim());
       if (mapnote) {
         mapnote = mapnote.toLowerCase().trim();
-        if ((/^daynight/i).test(mapnote)) {
+        if ((/^daynight\b/i).test(mapnote)) {
           $$.daynightset = true;
           let dnspeed = note.match(/\d+/);
           if (dnspeed) {
@@ -2896,31 +2898,31 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
             $gameVariables.SetDaynightSpeed(daynightspeed);
           }
         }
-        else if ((/^RegionFire/i).test(mapnote)) {
+        else if ((/^RegionFire\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionfire", data);
         }
-        else if ((/^RegionGlow/i).test(mapnote)) {
+        else if ((/^RegionGlow\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionglow", data);
         }
-        else if ((/^RegionLight/i).test(mapnote)) {
+        else if ((/^RegionLight\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionlight", data);
         }
-        else if ((/^RegionBlock/i).test(mapnote)) {
+        else if ((/^RegionBlock\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileBlock("regionblock", data);
         }
-        else if ((/^tint/i).test(mapnote)) {
+        else if ((/^tint\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
@@ -2935,11 +2937,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
           }
           $$.tint(data);
         }
-        else if ((/^defaultBrightness/i).test(mapnote)) {
+        else if ((/^defaultBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) $$.defaultBrightness = Math.max(0, Math.min(Number(brightness[0], 100))) / 100;
         }
-        else if ((/^mapBrightness/i).test(mapnote)) {
+        else if ((/^mapBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) {
             let color = $gameVariables.GetTint();

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -2346,7 +2346,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
-    if ((/^tintbattle /i).test(note)) {
+    if ((/^tintbattle\b/i).test(note)) {
       let data = note.split(/\s+/);
       data.splice(0, 1);
       data.map(x => x.trim());
@@ -2548,7 +2548,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       let mapnote = $$.getCLTag(note.trim());
       if (mapnote) {
         mapnote = mapnote.toLowerCase().trim();
-        if ((/^daynight/i).test(mapnote)) {
+        if ((/^daynight\b/i).test(mapnote)) {
           $$.daynightset = true;
           let dnspeed = note.match(/\d+/);
           if (dnspeed) {
@@ -2557,31 +2557,31 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
             $gameVariables.SetDaynightSpeed(daynightspeed);
           }
         }
-        else if ((/^RegionFire/i).test(mapnote)) {
+        else if ((/^RegionFire\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionfire", data);
         }
-        else if ((/^RegionGlow/i).test(mapnote)) {
+        else if ((/^RegionGlow\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionglow", data);
         }
-        else if ((/^RegionLight/i).test(mapnote)) {
+        else if ((/^RegionLight\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionlight", data);
         }
-        else if ((/^RegionBlock/i).test(mapnote)) {
+        else if ((/^RegionBlock\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileBlock("regionblock", data);
         }
-        else if ((/^tint/i).test(mapnote)) {
+        else if ((/^tint\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
@@ -2596,11 +2596,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
           }
           $$.tint(data);
         }
-        else if ((/^defaultBrightness/i).test(mapnote)) {
+        else if ((/^defaultBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) $$.defaultBrightness = Math.max(0, Math.min(Number(brightness[0], 100))) / 100;
         }
-        else if ((/^mapBrightness/i).test(mapnote)) {
+        else if ((/^mapBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) {
             let color = $gameVariables.GetTint();

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -447,8 +447,10 @@ Imported[Community.Lighting.name] = true;
 *
 * defaultbrightness
 * - Sets the default brightness of all the lights in the map
+*
 * Tint set c
 * - Sets the current screen tint to the color (c)
+*
 * Tint daylight
 * - Sets the tint based on the current hour.
 * -------------------------------------------------------------------------------

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -588,6 +588,15 @@ Imported[Community.Lighting.name] = true;
 * Plugin Commands - Battle
 * -------------------------------------------------------------------------------
 *
+* The following tag may be used in a comment field in the first page of a
+* battle event to change the battle tint prior to the first turn:
+*
+* TintBattle set
+* - Sets the current screen tint to the color (c)
+*
+* The following commands may be used at any time in battle events (note, these do
+* not work as tags in comment fields):
+*
 * TintBattle set [c] [s]
 * TintBattle fade [c] [s]
 * - Sets or fades the battle screen to the color (c)
@@ -792,9 +801,8 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   let glow_dir = 1;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = useSmootherLights == true ? "#00000000" : "#000000";
-  $$.getFirstComment = function () {
+  $$.getFirstComment = function (page) {
     let result = null;
-    let page = this.page();
     if (page && page.list[0] != null) {
       if (page.list[0].code === 108) {
         result = page.list[0].parameters[0] || "";
@@ -825,7 +833,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   };
   Game_Event.prototype.getCLTag = function () {
     let result;
-    let pageNote = noteTagKey ? $$.getFirstComment.call(this) : null;
+    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
     let note = this.event().note;
     if (pageNote) result = $$.getCLTag(pageNote);
     if (!result) result = $$.getCLTag(note);
@@ -1133,9 +1141,14 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {String} command
    * @param {String[]} args
    */
-  Game_Interpreter.prototype.tint = function (command, args) {
-    $$.tint(args);
-  };
+  Game_Interpreter.prototype.tint = (command, args) => $$.tint(args);
+
+  /**
+   *
+   * @param {String} command
+   * @param {String[]} args
+   */
+  Game_Interpreter.prototype.tintbattle = (command, args) => $$.tintbattle(args);
 
   /**
    *
@@ -1212,40 +1225,6 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (args[0].equalsIC("events")) {
       $$.ReloadMapEvents();
     }
-  };
-
-  Game_Interpreter.prototype.tintbattle = function (command, args) {
-    if ($gameParty.inBattle()) {
-      let cmd = args[0].trim();
-      if (cmd.equalsIC("set", 'fade')) {
-        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = this.determineBattleTint(args[1]);
-        $gameTemp._BattleTintSpeed = +args[2] || 0;
-      }
-      else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = $gameTemp._MapTint;
-        $gameTemp._BattleTintSpeed = +args[1] || 0;
-      }
-    }
-  };
-
-  Game_Interpreter.prototype.determineBattleTint = function (tintColor) {
-    if (!tintColor || tintColor.length < 7) {
-      return '#666666'; // Not an hex color string
-    }
-    let redhex = tintColor.substring(1, 3);
-    let greenhex = tintColor.substring(3, 5);
-    let bluehex = tintColor.substring(5);
-    let red = parseInt(redhex, 16);
-    let green = parseInt(greenhex, 16);
-    let blue = parseInt(bluehex, 16);
-    let color = red + green + blue;
-    if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
-      return '#666666'; // The player have to see something
-    }
-    return tintColor;
   };
 
   Spriteset_Map.prototype.createLightmask = function () {
@@ -2293,9 +2272,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0) { // If we went there from a map...
       if ($gameVariables.GetScriptActive() === true) {                                        // If the script is active...
         if (options_lighting_on && lightInBattle) {                                           // If configuration autorise using lighting effects
-          if (eventObjId.length > 0) {                                                        // If there is lightsource on this map...
-            $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
-          }
+          $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
         }
         // Add daylight tint?
       }
@@ -2366,6 +2343,16 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       $gameTemp._MapTint = '#666666'; // Prevent the battle scene from being too dark.
     }
     $gameTemp._BattleTint = $$.daynightset ? $gameVariables.GetTintByTime() : $gameTemp._MapTint;
+
+
+    let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
+    if ((/^tintbattle /i).test(note)) {
+      let data = note.split(/\s+/);
+      data.splice(0, 1);
+      data.map(x => x.trim());
+      $$.tintbattle(data, true);
+    }
+
     this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, $gameTemp._BattleTint);
     $gameTemp._BattleTintSpeed = 0;
   };
@@ -2747,6 +2734,44 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       if (speed == 0) $gameVariables.SetTint(currentColor);
       $gameVariables.SetTintTarget(currentColor);
       $gameVariables.SetTintSpeed(speed);
+    }
+  };
+
+  /**
+   *
+   * @param {String[]} args
+   */
+  $$.tintbattle = function (args, overrideInBattleCheck = false) {
+    let determineBattleTint = function (tintColor) {
+      if (!tintColor || tintColor.length < 7) {
+        return '#666666'; // Not an hex color string
+      }
+      let redhex = tintColor.substring(1, 3);
+      let greenhex = tintColor.substring(3, 5);
+      let bluehex = tintColor.substring(5);
+      let red = parseInt(redhex, 16);
+      let green = parseInt(greenhex, 16);
+      let blue = parseInt(bluehex, 16);
+      let color = red + green + blue;
+      if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
+        return '#666666'; // The player have to see something
+      }
+      return tintColor;
+    };
+
+    if ($gameParty.inBattle() || overrideInBattleCheck) {
+      let cmd = args[0].trim();
+      if (cmd.equalsIC("set", 'fade')) {
+        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
+        $gameTemp._BattleTintTimer = 0;
+        $gameTemp._BattleTint = determineBattleTint(args[1]);
+        $gameTemp._BattleTintSpeed = +args[2] || 0;
+      }
+      else if (cmd.equalsIC('reset', 'daylight')) {
+        $gameTemp._BattleTintTimer = 0;
+        $gameTemp._BattleTint = $gameTemp._MapTint;
+        $gameTemp._BattleTintSpeed = +args[1] || 0;
+      }
     }
   };
 

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2628,9 +2628,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0) { // If we went there from a map...
       if ($gameVariables.GetScriptActive() === true) {                                        // If the script is active...
         if (options_lighting_on && lightInBattle) {                                           // If configuration autorise using lighting effects
-          if (eventObjId.length > 0) {                                                        // If there is lightsource on this map...
-            $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
-          }
+          $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
         }
         // Add daylight tint?
       }

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2685,7 +2685,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
-    if ((/^tintbattle /i).test(note)) {
+    if ((/^tintbattle\b/i).test(note)) {
       let data = note.split(/\s+/);
       data.splice(0, 1);
       data.map(x => x.trim());
@@ -2887,7 +2887,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       let mapnote = $$.getCLTag(note.trim());
       if (mapnote) {
         mapnote = mapnote.toLowerCase().trim();
-        if ((/^daynight/i).test(mapnote)) {
+        if ((/^daynight\b/i).test(mapnote)) {
           $$.daynightset = true;
           let dnspeed = note.match(/\d+/);
           if (dnspeed) {
@@ -2896,31 +2896,31 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
             $gameVariables.SetDaynightSpeed(daynightspeed);
           }
         }
-        else if ((/^RegionFire/i).test(mapnote)) {
+        else if ((/^RegionFire\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionfire", data);
         }
-        else if ((/^RegionGlow/i).test(mapnote)) {
+        else if ((/^RegionGlow\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionglow", data);
         }
-        else if ((/^RegionLight/i).test(mapnote)) {
+        else if ((/^RegionLight\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileLight("regionlight", data);
         }
-        else if ((/^RegionBlock/i).test(mapnote)) {
+        else if ((/^RegionBlock\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
           $gameMap._interpreter.addTileBlock("regionblock", data);
         }
-        else if ((/^tint/i).test(mapnote)) {
+        else if ((/^tint\b/i).test(mapnote)) {
           let data = mapnote.split(/\s+/);
           data.splice(0, 1);
           data.map(x => x.trim());
@@ -2935,11 +2935,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
           }
           $$.tint(data);
         }
-        else if ((/^defaultBrightness/i).test(mapnote)) {
+        else if ((/^defaultBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) $$.defaultBrightness = Math.max(0, Math.min(Number(brightness[0], 100))) / 100;
         }
-        else if ((/^mapBrightness/i).test(mapnote)) {
+        else if ((/^mapBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) {
             let color = $gameVariables.GetTint();

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -860,8 +860,10 @@ Imported[Community.Lighting.name] = true;
 *
 * defaultbrightness
 * - Sets the default brightness of all the lights in the map
+*
 * Tint set c
 * - Sets the current screen tint to the color (c)
+*
 * Tint daylight
 * - Sets the tint based on the current hour.
 *

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -895,14 +895,27 @@ Imported[Community.Lighting.name] = true;
 * Plugin Commands - Battle
 * -------------------------------------------------------------------------------
 *
-* Set Tint [c] [s]
+* The following tag may be used in a comment field in the first page of a
+* battle event to change the battle tint prior to the first turn:
+*
+* TintBattle set
+* - Sets the current screen tint to the color (c)
+*
+* The following commands may be used at any time in battle events (note, these do
+* not work as tags in comment fields):
+*
+* TintBattle set [c] [s]
+* TintBattle fade [c] [s]
 * - Sets or fades the battle screen to the color (c)
 * - The optional argument speed (s) sets the fade speed (1 = fast, 20 = very slow)
 * - Automatically set too dark color to '#666666' (dark gray).
+* - Both commands operate identically.
 *
-* Reset Battle Tint [s]
+* TintBattle reset [s]
+* TintBattle daylight [s]
 * - Resets or fades the battle screen to its original color.
 * - The optional argument speed (s) sets the fade speed (1 = fast, 20 = very slow)
+* - Both commands operate identically.
 *
 * --------------------------------------------------------------------------
 * Lights Active Radius
@@ -1095,9 +1108,8 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   let glow_dir = 1;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = useSmootherLights == true ? "#00000000" : "#000000";
-  $$.getFirstComment = function () {
+  $$.getFirstComment = function (page) {
     let result = null;
-    let page = this.page();
     if (page && page.list[0] != null) {
       if (page.list[0].code === 108) {
         result = page.list[0].parameters[0] || "";
@@ -1128,7 +1140,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   };
   Game_Event.prototype.getCLTag = function () {
     let result;
-    let pageNote = noteTagKey ? $$.getFirstComment.call(this) : null;
+    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
     let note = this.event().note;
     if (pageNote) result = $$.getCLTag(pageNote);
     if (!result) result = $$.getCLTag(note);
@@ -1468,9 +1480,14 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {String} command
    * @param {String[]} args
    */
-  Game_Interpreter.prototype.tint = function (command, args) {
-    $$.tint(args);
-  };
+  Game_Interpreter.prototype.tint = (command, args) => $$.tint(args);
+
+  /**
+   *
+   * @param {String} command
+   * @param {String[]} args
+   */
+  Game_Interpreter.prototype.tintbattle = (command, args) => $$.tintbattle(args);
 
   /**
    *
@@ -1547,40 +1564,6 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (args[0].equalsIC("events")) {
       $$.ReloadMapEvents();
     }
-  };
-
-  Game_Interpreter.prototype.tintbattle = function (command, args) {
-    if ($gameParty.inBattle()) {
-      let cmd = args[0].trim();
-      if (cmd.equalsIC("set", 'fade')) {
-        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = this.determineBattleTint(args[1]);
-        $gameTemp._BattleTintSpeed = +args[2] || 0;
-      }
-      else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = $gameTemp._MapTint;
-        $gameTemp._BattleTintSpeed = +args[1] || 0;
-      }
-    }
-  };
-
-  Game_Interpreter.prototype.determineBattleTint = function (tintColor) {
-    if (!tintColor || tintColor.length < 7) {
-      return '#666666'; // Not an hex color string
-    }
-    let redhex = tintColor.substring(1, 3);
-    let greenhex = tintColor.substring(3, 5);
-    let bluehex = tintColor.substring(5);
-    let red = parseInt(redhex, 16);
-    let green = parseInt(greenhex, 16);
-    let blue = parseInt(bluehex, 16);
-    let color = red + green + blue;
-    if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
-      return '#666666'; // The player have to see something
-    }
-    return tintColor;
   };
 
   Spriteset_Map.prototype.createLightmask = function () {
@@ -2699,6 +2682,16 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       $gameTemp._MapTint = '#666666'; // Prevent the battle scene from being too dark.
     }
     $gameTemp._BattleTint = $$.daynightset ? $gameVariables.GetTintByTime() : $gameTemp._MapTint;
+
+
+    let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
+    if ((/^tintbattle /i).test(note)) {
+      let data = note.split(/\s+/);
+      data.splice(0, 1);
+      data.map(x => x.trim());
+      $$.tintbattle(data, true);
+    }
+
     this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, $gameTemp._BattleTint);
     $gameTemp._BattleTintSpeed = 0;
   };
@@ -3080,6 +3073,44 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       if (speed == 0) $gameVariables.SetTint(currentColor);
       $gameVariables.SetTintTarget(currentColor);
       $gameVariables.SetTintSpeed(speed);
+    }
+  };
+
+  /**
+   *
+   * @param {String[]} args
+   */
+  $$.tintbattle = function (args, overrideInBattleCheck = false) {
+    let determineBattleTint = function (tintColor) {
+      if (!tintColor || tintColor.length < 7) {
+        return '#666666'; // Not an hex color string
+      }
+      let redhex = tintColor.substring(1, 3);
+      let greenhex = tintColor.substring(3, 5);
+      let bluehex = tintColor.substring(5);
+      let red = parseInt(redhex, 16);
+      let green = parseInt(greenhex, 16);
+      let blue = parseInt(bluehex, 16);
+      let color = red + green + blue;
+      if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
+        return '#666666'; // The player have to see something
+      }
+      return tintColor;
+    };
+
+    if ($gameParty.inBattle() || overrideInBattleCheck) {
+      let cmd = args[0].trim();
+      if (cmd.equalsIC("set", 'fade')) {
+        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
+        $gameTemp._BattleTintTimer = 0;
+        $gameTemp._BattleTint = determineBattleTint(args[1]);
+        $gameTemp._BattleTintSpeed = +args[2] || 0;
+      }
+      else if (cmd.equalsIC('reset', 'daylight')) {
+        $gameTemp._BattleTintTimer = 0;
+        $gameTemp._BattleTint = $gameTemp._MapTint;
+        $gameTemp._BattleTintSpeed = +args[1] || 0;
+      }
     }
   };
 

--- a/README.md
+++ b/README.md
@@ -226,8 +226,19 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	*             numbers are faster, and 0 stops the flow of time entirely.
 	*             If speed is not specified, then the current speed is used.
 	*
+	* TileLight id ON c r
+	* RegionLight id ON c r
+	* - Turns on lights for tile tag or region tag (id) using color (c) and radius (r)
+	* - Replace ON with OFF to turn them off
+	*
 	* RegionFire, RegionGlow
 	* - Same as above, but different lighting effects
+	*
+	* RegionBlock id ON color
+	* - Turns on light blocking for tile with region id (id) using color (color)
+	*
+	* RegionBlock id OFF
+	* - Turns off light blocking for tile with region id (id)
 	*
 	* defaultbrightness
 	* - Sets the default brightness of all the lights in the map
@@ -277,10 +288,10 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* - Turn off the flashlight.  yup.
 	*
 	* Daynight speed n
-	* - Changes the speed by which hours pass ingame in relation to real life seconds
+	* - Changes the speed by which hours pass in game in relation to real life seconds
 	*
 	* Daynight hour h m
-	* - Sets the ingame time to hh:mm
+	* - Sets the in game time to hh:mm
 	*
 	* Daynight color h c
 	* - Sets the hour (h) to use color (c)
@@ -373,6 +384,15 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* -------------------------------------------------------------------------------
 	* Plugin Commands - Battle
 	* -------------------------------------------------------------------------------
+	*
+	* The following tag may be used in a comment field in the first page of a
+	* battle event to change the battle tint prior to the first turn:
+	*
+	* TintBattle set
+	* - Sets the current screen tint to the color (c)
+	*
+	* The following commands may be used at any time in battle events (note, these do
+	* not work as tags in comment fields):
 	*
 	* TintBattle set [c] [s]
 	* TintBattle fade [c] [s]


### PR DESCRIPTION
Features:
- Adds support for battletint note tags in the first comment of the first page of a battle event, which allows for instantly setting the tint prior to the first combat turn.

Bug fixes:
- removes check for light events in battle when attempting to determine whether to use the map tint. Maps can be tinted without event lights so the check is faulty.
- fixes partial tag matches e.g. 'tintdfsfsdfds set' would no longer be matched as a 'tint set' tag in map notes..
