### PR TITLE
Cycle and Conditional light Transitions

### DIFF
--- a/CommunityLightingMVDemo/data/Map001.json
+++ b/CommunityLightingMVDemo/data/Map001.json
@@ -13890,6 +13890,66 @@
       ],
       "x": 15,
       "y": 27
+    },
+    {
+      "id": 15,
+      "name": "Fairy",
+      "note": "<cl: light 10 a#aaaaaa {x1 y-0.2 t120} {x0.2 y0.2 t120} {x1.5 y-0.1 t60} {x1.2 y0.3 t120} {x0.1 y-0.2 t60} {x1.8 y0.2 t60}>",
+      "pages": [
+        {
+          "conditions": {
+            "actorId": 1,
+            "actorValid": false,
+            "itemId": 1,
+            "itemValid": false,
+            "selfSwitchCh": "A",
+            "selfSwitchValid": false,
+            "switch1Id": 1,
+            "switch1Valid": false,
+            "switch2Id": 1,
+            "switch2Valid": false,
+            "variableId": 1,
+            "variableValid": false,
+            "variableValue": 0
+          },
+          "directionFix": false,
+          "image": {
+            "characterIndex": 0,
+            "characterName": "",
+            "direction": 2,
+            "pattern": 0,
+            "tileId": 0
+          },
+          "list": [
+            {
+              "code": 0,
+              "indent": 0,
+              "parameters": []
+            }
+          ],
+          "moveFrequency": 3,
+          "moveRoute": {
+            "list": [
+              {
+                "code": 0,
+                "parameters": []
+              }
+            ],
+            "repeat": true,
+            "skippable": false,
+            "wait": false
+          },
+          "moveSpeed": 3,
+          "moveType": 0,
+          "priorityType": 0,
+          "stepAnime": false,
+          "through": false,
+          "trigger": 0,
+          "walkAnime": true
+        }
+      ],
+      "x": 10,
+      "y": 21
     }
   ]
 }

--- a/CommunityLightingMVDemo/data/Map001.json
+++ b/CommunityLightingMVDemo/data/Map001.json
@@ -12151,7 +12151,7 @@
     {
       "id": 3,
       "name": "EV003",
-      "note": "<cl: light 75 {a#00ff0066 t120} {a#ffffff66 t120}>",
+      "note": "<cl: light 75 {a#00ff0066 t120} {a#ffffff66}>",
       "pages": [
         {
           "conditions": {
@@ -12600,7 +12600,7 @@
     {
       "id": 7,
       "name": "",
-      "note": "<CL: Light 100 {a#ff6666bb t120 X-0.5 Y0.2} {a#66ff66bb t120 x0 y0.5} {a#ff00ffbb t120 X0.5 Y0.2} {a#ff6666bb t120 X0.5 Y-0.2} {a#66ff66bb t120 x0 y-0.5} {a#ff00ffbb t120 X-0.5 Y-0.2}>",
+      "note": "<CL: Light 100 {a#ff6666bb t120 X-0.5 Y0.2} {a#66ff66bb x0 y0.5} {a#ff00ffbb X0.5 Y0.2} {a#ff6666bb X0.5 Y-0.2} {a#66ff66bb x0 y-0.5} {a#ff00ffbb X-0.5 Y-0.2}>",
       "pages": [
         {
           "conditions": {
@@ -13731,7 +13731,7 @@
     {
       "id": 13,
       "name": "EV013",
-      "note": "<cl: light {a#ff009966 r75 t120 p60} {a#ff009999 r85 t120 p60}>",
+      "note": "<cl: light {a#ff009966 r75 t120 p60} {a#ff009999 r85}>",
       "pages": [
         {
           "conditions": {

--- a/CommunityLightingMVDemo/data/Map001.json
+++ b/CommunityLightingMVDemo/data/Map001.json
@@ -12151,7 +12151,7 @@
     {
       "id": 3,
       "name": "EV003",
-      "note": "<cl: light 75 #00ff00>",
+      "note": "<cl: light 75 {a#00ff0066 t120} {a#ffffff66 t120}>",
       "pages": [
         {
           "conditions": {
@@ -12600,7 +12600,7 @@
     {
       "id": 7,
       "name": "",
-      "note": "<CL: Light 100 cycle #ff6666 10 #66ff66 10 #ff00ff 10>",
+      "note": "<CL: Light 100 {a#ff6666bb t120 X-0.5 Y0.2} {a#66ff66bb t120 x0 y0.5} {a#ff00ffbb t120 X0.5 Y0.2} {a#ff6666bb t120 X0.5 Y-0.2} {a#66ff66bb t120 x0 y-0.5} {a#ff00ffbb t120 X-0.5 Y-0.2}>",
       "pages": [
         {
           "conditions": {
@@ -13731,7 +13731,7 @@
     {
       "id": 13,
       "name": "EV013",
-      "note": "<cl: light 75 #00fa21>",
+      "note": "<cl: light {a#ff009966 r75 t120 p60} {a#ff009999 r85 t120 p60}>",
       "pages": [
         {
           "conditions": {

--- a/CommunityLightingMVDemo/data/Map003.json
+++ b/CommunityLightingMVDemo/data/Map003.json
@@ -6058,6 +6058,66 @@
       ],
       "x": 17,
       "y": 18
+    },
+    {
+      "id": 15,
+      "name": "Fairy",
+      "note": "<cl: light 10 a#aaaaaa {x1 y-0.2 t120} {x0.2 y0.2 t120} {x1.5 y-0.1 t60} {x1.2 y0.3 t120} {x0.1 y-0.2 t60} {x1.8 y0.2 t60}>",
+      "pages": [
+        {
+          "conditions": {
+            "actorId": 1,
+            "actorValid": false,
+            "itemId": 1,
+            "itemValid": false,
+            "selfSwitchCh": "A",
+            "selfSwitchValid": false,
+            "switch1Id": 1,
+            "switch1Valid": false,
+            "switch2Id": 1,
+            "switch2Valid": false,
+            "variableId": 1,
+            "variableValid": false,
+            "variableValue": 0
+          },
+          "directionFix": false,
+          "image": {
+            "characterIndex": 0,
+            "characterName": "",
+            "direction": 2,
+            "pattern": 0,
+            "tileId": 0
+          },
+          "list": [
+            {
+              "code": 0,
+              "indent": 0,
+              "parameters": []
+            }
+          ],
+          "moveFrequency": 3,
+          "moveRoute": {
+            "list": [
+              {
+                "code": 0,
+                "parameters": []
+              }
+            ],
+            "repeat": true,
+            "skippable": false,
+            "wait": false
+          },
+          "moveSpeed": 3,
+          "moveType": 0,
+          "priorityType": 0,
+          "stepAnime": false,
+          "through": false,
+          "trigger": 0,
+          "walkAnime": true
+        }
+      ],
+      "x": 10,
+      "y": 21
     }
   ]
 }

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -721,13 +721,13 @@ Imported[Community.Lighting.name] = true;
 const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
 const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
 
-Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
-Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
-Number.prototype.clone        = function()        { return this; };
-Boolean.prototype.clone       = function()        { return this; };
-String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
+Number.prototype.is           = function(...a)     { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max) { return this >= min && this <= max; };
+Number.prototype.clone        = function()         { return this; };
+Boolean.prototype.clone       = function()         { return this; };
+String.prototype.equalsIC     = function(...a)     { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)        { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) =>  minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
@@ -832,7 +832,7 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
  * @param {Number} a
  * @returns {String}
  */
- function rgba(r, g, b, a) {
+function rgba(r, g, b, a) {
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
@@ -2037,8 +2037,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distpart > lightsOnRadius) {
+        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distanceApart > lightsOnRadius) {
           continue;
         }
       }
@@ -2198,7 +2198,7 @@ class ColorDelta {
   * @param {Number} brightness
   * @param {VRGBA} c1
   * @param {VRGBA} c2
-   */
+  */
   CanvasGradient.prototype.addTransparentColorStops = function (brightness, c1, c2) {
     if (brightness) {
       if (!useSmootherLights) {

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -2085,9 +2085,9 @@ class ColorDelta {
             let flashlength = cur.getLightFlashlightLength();
             let flashwidth  = cur.getLightFlashlightWidth();
             if (!isNaN(direction)) ldir = direction;
-            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
+            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.minRGBA(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.minRGBA(), objectflicker,
                                                      brightness, direction);
           }
         }
@@ -2119,7 +2119,7 @@ class ColorDelta {
         tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
         tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.minRGBA(), objectflicker,
                                                tile.brightness);
     });
 
@@ -2627,7 +2627,7 @@ class ColorDelta {
     // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
-            $gameVariables.GetTint() : new VRGBA("#ffffff");
+            $gameVariables.GetTint() : VRGBA.maxRGBA();
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {
@@ -3088,7 +3088,7 @@ Game_Variables.prototype.SetTint = function (value) {
   this._Community_Tint_Value = value.clone();
 };
 Game_Variables.prototype.GetTint = function () {
-  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.empty();
+  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.minRGBA();
   return this._Community_Tint_Value.clone();
 };
 Game_Variables.prototype.SetTintAtHour = function (hour, color) {
@@ -3101,7 +3101,7 @@ Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   while (hours >= hoursinDay) hours -= hoursinDay;
   while (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
-  return result ? result.color.clone() : VRGBA.empty();
+  return result ? result.color.clone() : VRGBA.minRGBA();
 };
 Game_Variables.prototype.SetTintTarget = function (delta) {
   this._Community_TintTarget = delta;
@@ -3141,7 +3141,7 @@ Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if emp
   if (value) this._Community_Lighting_PlayerColor = new VRGBA(value);
 };
 Game_Variables.prototype.GetPlayerColor = function () {
-  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = new VRGBA("#ffffff");
+  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = VRGBA.maxRGBA();
   return this._Community_Lighting_PlayerColor.clone();
 };
 Game_Variables.prototype.SetPlayerBrightness = function (value) { // don't set if invalid.
@@ -3196,7 +3196,7 @@ Game_Variables.prototype.GetDaynightColorArray = function () {
   if (hoursInDay > result.length) { // lazy check bounds before returning and add colors if too small
     let origLength = result.length;
     result.length = hoursInDay;     // more efficient than a for loop
-    result.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+    result.fill({ "color": VRGBA.maxRGBA(), "isNight": false }, origLength);
   }
   this._Community_Lighting_DayNightColorArray = result; // assign reference
   return result;

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -15,7 +15,6 @@ if (typeof require !== "undefined" && typeof module != "undefined") {
   } = require("../rpg_objects");
   var {
     PluginManager,
-    BattleManager,
     ConfigManager,
   } = require("../rpg_managers");
   var { Window_Selectable, Window_Options } = require("../rpg_windows");
@@ -74,7 +73,7 @@ Imported[Community.Lighting.name] = true;
 *
 * @param Daynight Cycle
 * @parent ---General Settings---
-* @desc Should the brightness change over time
+* @desc Should the tint change over time. Must also be enabled in individual maps.
 * @type boolean
 * @default true
 *
@@ -307,18 +306,19 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* DayNight
-* - Activates day/night cycle.  Put in map note or event note
-*
-* Light radius [cycle] color [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color + duration pairs to follow that will be
-*               cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 #0f0 15 #00f 15 ...etc>
-*               In Terrax Lighting, there was a hard limit of 4, but now you can use
-*               as many as you want. [optional]
+* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
+*               that will be cycled through before repeating from the beginning:
+*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
+*               fadeDuration and growRadius are optional argument used to transition between colors
+*               and radius sizes over the provided cycle interval. If growRadius is not provided
+*               the default radius is used for the given color. In Terrax Lighting, there was a hard
+*               limit of 4, but now you can use as many as you want. [optional]
 * - color       #ffffff, #ff0000, etc
+* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
 * - night       Causes the light to only come on during the night [optional]
 * - brightness  B50, B25, etc [optional]
@@ -328,31 +328,40 @@ Imported[Community.Lighting.name] = true;
 *               D11 s.-w. corner, D12 n.-w. corner  [optional]
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
-* - id          1, 2, 2345, etc--an id number for plugin commands [optional]
+* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+*               These should not begin with 'd', 'x' or 'y' otherwise
+*               they will be mistaken for one of the previous optional parameters.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight [bl] [bw] [c] [onoff] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
 * - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
 * - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color + duration pairs to follow that will be
-*             cycled through before repeating from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15 on someId d3>
-*             There's no limit to how many colors can be cycled. [optional]
-* - onoff:    Initial state:  0, 1, off, on
+* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
+*             grow_bw tuples to follow that will be cycled through before repeating
+*             from the beginning:
+*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
+*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
+*             transition between colors and beam lengths & widths over the provided
+*             cycle interval. If grow_bl or grow_bw are not provided, the default
+*             length or width is used for the given color. There's no limit to how
+*             many colors can be cycled. [optional]
+* - color     #ffffff, #ff0000, etc
+* - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - day       Sets the event's light to only show during the day [optional]
+* - night     Sets the event's light to only show during night time [optional]
 * - sdir:     Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
 *             Can be preceded by "D", so D4.  If omitted, defaults to 0
 * - angle:    Forced direction in degrees (optional): must be preceded by "A". If
-*             omitted, sdir is used.
+*             omitted, sdir is used. [optional]
 * - x         x[offset] Work the same as regular light [optional]
 * - y         y[offset] [optional]
-* - day       Sets the event's light to only show during the day [optional]
-* - night     Sets the event's light to only show during night time [optional]
 * - id        1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*             Those should not begin with 'a', 'd', 'x' or 'y' otherwise
+*             These should not begin with 'a', 'd', 'x' or 'y' otherwise
 *             they will be mistaken for one of the previous optional parameters.
 *
 * Example note tags:
@@ -363,10 +372,21 @@ Imported[Community.Lighting.name] = true;
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
+* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
+*
+* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
+* and transitions to the next color and size over 60 frames.
+*
 * <cl: fire 150 #ff8800 b15 night>
 * Creates a fire that only lights up at night.
 *
 * <cl: Flashlight l8 w12 #ff0000 on asdf>
+* Creates a flashlight beam with id asdf which can be turned on or off via
+* plugin commands.
+*
+* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
@@ -454,7 +474,7 @@ Imported[Community.Lighting.name] = true;
 * Tint daylight
 * - Sets the tint based on the current hour.
 * -------------------------------------------------------------------------------
-* Plugin Commands
+* Plugin Commands (for MZ these use the new plugin interface)
 * -------------------------------------------------------------------------------
 * Light deactivate|activate
 * - Completely disables the lighting effects of this plugin
@@ -492,20 +512,31 @@ Imported[Community.Lighting.name] = true;
 * Flashlight off
 * - Turn off the flashlight.  yup.
 *
+* DayNight on|off [instant]
+* - Activates or deactivates the day/night cycle. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
+*
 * Daynight speed n
 * - Changes the speed by which hours pass in game in relation to real life seconds
 *
-* Daynight hour h m
-* - Sets the in game time to hh:mm
+* Daynight hour h m [instant]
+* - Sets the in game time to hh:mm. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Daynight color h c
 * - Sets the hour (h) to use color (c)
 *
-* Daynight add h m
-* - Adds the specified hours (h) and minutes (m) to the in game clock
+* Daynight add h m [instant]
+* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
-* Daynight subtract h m
-* - Subtracts the specified hours (h) and minutes (m) from the in game clock
+* Daynight subtract h m [instant]
+* - Subtracts the specified hours (h) and minutes (m) from the in game clock. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Daynight show
 * - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -516,8 +547,10 @@ Imported[Community.Lighting.name] = true;
 * Daynight hide
 * - Hides the current time of day mini-window
 *
-* Daynight hoursinday h
-* - Sets the number of hours in a day to [h] (set hour colors  if doing this)
+* Daynight hoursinday h [instant]
+* - Sets the number of hours in a day to [h] (set hour colors if doing this), Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Tint set c [s]
 * Tint fade c [s]
@@ -630,9 +663,12 @@ Number.prototype.is           = function (...a) { return a.includes(Number(this)
 Number.prototype.inRange      = function (min, max) { return this >= min && this <= max; };
 String.prototype.equalsIC     = function (...a) { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
 String.prototype.startsWithIC = function (s) { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Math.min(...a) : Math.max(...a); }; // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
+
+let cmpFloat = (x, y) => Math.abs(x - y) < 1e-3; // custom epsilon
 
 function orBoolean(...a) {
   for (let i = 0; i < a.length; i++) {
@@ -646,7 +682,484 @@ function orBoolean(...a) {
 function orNullish(...a) { for (let i = 0; i < a.length; i++) if (a[i] != null) return a[i]; }
 function orNaN(...a)     { for (let i = 0; i < a.length; i++) if (!isNaN(a[i])) return a[i]; }
 
-let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-9A-F]{8}$)/i; // a|A before # for additive lighting
+const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive lighting
+
+/**
+ * @param {Number} r
+ * @param {Number} g
+ * @param {Number} b
+ * @param {Number} a
+ * @returns {String}
+ */
+ function rgba(r, g, b, a) {
+  return "rgba(" + r + "," + g + "," + b + "," + a + ")";
+}
+
+/** Class to handle volumetric/additive coloring with rgba colors uniformly.
+ *  Additive coloring prefixes an 'a' on a normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
+ */
+class VRGBA {
+  /**
+   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a hex String
+   * can be passed with an optional default alternative Hex string, or another VRGBA object can be passed to create a clone.
+   * @param {String|Boolean|VRGBA} vOrHex     - Boolean representing the additive component, or
+   *                                            String representing the hex color, or
+   *                                            other VRGBA object to clone.
+   * @param {String|Number}        rOrDefault - Number representing the red component, or
+   *                                            String representing a default hex string in case the provided one cannot be parsed.
+   * @param {null|Number}          g          - Number representing the green component.
+   * @param {null|Number}          b          - Number representing the blue component.
+   * @param {null|Number}          a          - Number representing the alpha component.
+   * @returns {VRGBA}
+   */
+  constructor(vOrHex, rOrDefault = "#000000ff", g = undefined, b = undefined, a = 0xff) {
+    if (arguments.length == 0) return;                           // return if no arguments (allows construction).
+    else if (typeof vOrHex === "boolean")                        // Passed v, r, g, b, a
+      [this.v, this.r,           this.g,  this.b,  this.a] =     // - assign
+      [vOrHex, +rOrDefault || 0, +g || 0, +b || 0, +a || 0xff];  // -
+    else if (vOrHex == null || typeof vOrHex === "string") {     // passed a hex String or nullish
+      vOrHex = this.normalizeHex(vOrHex, rOrDefault);            //  - parse hex
+      this.v = vOrHex.startsWithIC("a#");                        //  - assign v
+      const shift = this.v ? 1 : 0;                              //  - shift for volumetric/additive prefix
+      this.r = parseInt(vOrHex.slice(1 + shift, 3 + shift), 16); //  - assign red
+      this.g = parseInt(vOrHex.slice(3 + shift, 5 + shift), 16); //  - assign green
+      this.b = parseInt(vOrHex.slice(5 + shift, 7 + shift), 16); //  - assign blue
+      this.a = parseInt(vOrHex.slice(7 + shift, 9 + shift), 16); //  - assign alpha
+    } else {
+      throw Error(`${Community.Lighting.name} - VRGBA constructor given incorrect parameters!`);
+    }
+  }
+
+  /**
+   * Creates a copy of the VRGBA object.
+   * @returns {VRGBA}
+   **/
+  clone() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [this.v, this.r, this.g, this.b, this.a];
+    return that;
+  }
+
+  /**
+   * Creates an empty VRGBA object will all properties initialized to false and 0.
+   * @returns {VRGBA}
+   **/
+  static empty() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
+    return that;
+  }
+
+  /**
+   * Sets the v, r, b, g, or a properties to that of the cooresponding properties in the that Object.
+   * @param {VRGBA} that
+   */
+  set(that) { for (let k in that) if (this[k] != null) this[k] = that[k]; }
+
+  /**
+   * Compares this Object to that Object and returns true if the v, r, g, b, and a properties are equal; otherwise false.
+   * @param {VRGBA} that
+   * @returns {Boolean}
+   */
+  equals(that) { // fastest non-exactness comparison -- only checks v, r, g, b, a properties
+    let [a, b] = [this, that];
+    if (b && cmpFloat(a.v, b.v) && cmpFloat(a.r, b.r) && cmpFloat(a.g, b.g) && cmpFloat(a.b, b.b) && cmpFloat(a.a, b.a))
+      return true;
+    return false;
+  }
+
+  /**
+   * Adds together the r, g, and b properties and returns the result.
+   * @returns {Number}
+   */
+  magnitude() { return this.r + this.g + this.b; }
+
+  /**
+   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String. If invalid, a default
+   * value of "#000000ff" is returned. If either provided String is valid, it will be returned as an 'a#rrggbbaa' formatted color hex String.
+   * @param {String} hex
+   * @param {String} alt
+   * @returns {String}
+   */
+  normalizeHex(hex, altHex) {
+    if (typeof hex !== "string") return this.normalizeHex(altHex, "#000000ff");
+    let h = hex.toLowerCase().trim();
+    const s = hex.startsWithIC("a#") ? 1 : 0;                      // shift
+    if (h.length == 4 + s) h += "f";                               // normalize #RGB format
+    if (h.length == 5 + s) h = h.replace(/(^a?#)|(.)/g, "$1$2$2"); // normalize #RGBA
+    if (h.length == 7 + s) h += "ff";                              // normalize #RRGGBB format
+    if (!isValidColorRegex.test(h)) {
+      console.log(`${Community.Lighting.name} - Invalid Color: ` + hex);
+      return this.normalizeHex(altHex, "#000000ff");
+    }
+    return h;                                                      // return RRGGBBAA
+  }
+
+  /**
+   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the hex is additive or not.
+   * The setWebSafe parameter is used to to strip the additive property (v) so that the resulting color can be used with Canvas APIs. An
+   * override Object can be provided to override the existing v, r, g, b, or a properties in the output.
+   * @param {Boolean} setWebSafe
+   * @param {VRGBA} override
+   * @returns {String}
+   */
+  toHex(setWebSafe = false, override = undefined) {
+    let temp = this.clone(); // create temporary copy
+    for (let k in override) if (temp[k]) temp[k] = override[k]; // assign temporary setters
+    if (temp.r.inRange(0, 255) && temp.g.inRange(0, 255) && temp.b.inRange(0, 255) && temp.a.inRange(0, 255)) {
+      let rHex = (temp.r < 16 ? "0" : "") + Math.floor(temp.r).toString(16); // clamp to whole numbers
+      let gHex = (temp.g < 16 ? "0" : "") + Math.floor(temp.g).toString(16);
+      let bHex = (temp.b < 16 ? "0" : "") + Math.floor(temp.b).toString(16);
+      let aHex = (temp.a < 16 ? "0" : "") + Math.floor(temp.a).toString(16);
+      return (temp.v && !setWebSafe ? "a" : "") + "#" + rHex + gHex + bHex + aHex;
+    }
+    return null; // The hex color code doesn't exist
+  }
+
+  /**
+   * Converts the VRGBA Object into a websafe '#rrggbbaa' formatted color hex string where the v property is stripped.
+   * An override Object can be provided to override the existing r, g, b, or a properties in the output.
+   * @param {Boolean} setWebSafe
+   * @param {VRGBA} override
+   * @returns {String}
+   */
+  toWebHex(override) { return this.toHex(true, override); }
+}
+
+/**
+ * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability to compute deltas
+ * between the current parameter values and the target values, and allows for current values to be extracted.
+ **/
+class ConditionalLight {
+  /**
+   * Creates a ConditionalLight object with the provided parameters
+   * @param {VRGBA}  color
+   * @param {Number} direction
+   * @param {Number} brightness
+   * @param {Number} xOffset
+   * @param {Number} yOffset
+   * @param {Number} radius
+   * @param {Number} beamLength
+   * @param {Number} beamWidth
+   **/
+  constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+    if (arguments.length == 0) return;
+    this.color      = color;
+    this.direction  = direction;
+    this.brightness = brightness;
+    this.xOffset    = xOffset;
+    this.yOffset    = yOffset;
+    this.radius     = radius;
+    this.beamLength = beamLength;
+    this.beamWidth  = beamWidth;
+  }
+
+  /**
+   * Creates a copy of the ConditionalLight object.
+   * @returns {ConditionalLight}
+   **/
+  clone() {
+    let that = new ConditionalLight();
+    // clone properties
+    if (this.color      != null) that.color      = this.color.clone();
+    if (this.direction  != null) that.direction  = this.direction;
+    if (this.brightness != null) that.brightness = this.brightness;
+    if (this.xOffset    != null) that.xOffset    = this.xOffset;
+    if (this.yOffset    != null) that.yOffset    = this.yOffset;
+    if (this.radius     != null) that.radius     = this.radius;
+    if (this.beamLength != null) that.beamLength = this.beamLength;
+    if (this.beamWidth  != null) that.beamWidth  = this.beamWidth;
+    // clone deltas
+    if (this.colorDelta      != null) that.colorDelta      = this.colorDelta     .clone();
+    if (this.directionDelta  != null) that.directionDelta  = this.directionDelta .clone();
+    if (this.brightnessDelta != null) that.brightnessDelta = this.brightnessDelta.clone();
+    if (this.xOffsetDelta    != null) that.xOffsetDelta    = this.xOffsetDelta   .clone();
+    if (this.yOffsetDelta    != null) that.yOffsetDelta    = this.yOffsetDelta   .clone();
+    if (this.radiusDelta     != null) that.radiusDelta     = this.radiusDelta    .clone();
+    if (this.beamLengthDelta != null) that.beamLengthDelta = this.beamLengthDelta.clone();
+    if (this.beamWidthDelta  != null) that.beamWidthDelta  = this.beamWidthDelta .clone();
+    return that;
+  }
+
+  /**
+   * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
+   * @param {Number} fadeDuration
+   * @param {Number} pauseDuration
+   * @param {VRGBA}  tColor
+   * @param {Number} tDirection
+   * @param {Number} tBrightness
+   * @param {Number} tXOffset
+   * @param {Number} tYOffset
+   * @param {Number} tRadius
+   * @param {Number} tBeamLength
+   * @param {Number} tBeamWidth
+   */
+  setupTargets(fadeDuration, pauseDuration, tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
+    if (this.color      != null) this.colorDelta      = ColorDelta.createLight(this.color,  tColor,      fadeDuration, pauseDuration);
+    if (this.direction  != null) this.directionDelta  = NumberDelta.create(this.direction,  tDirection,  fadeDuration);
+    if (this.brightness != null) this.brightnessDelta = NumberDelta.create(this.brightness, tBrightness, fadeDuration);
+    if (this.xOffset    != null) this.xOffsetDelta    = NumberDelta.create(this.xOffset,    tXOffset,    fadeDuration);
+    if (this.yOffset    != null) this.yOffsetDelta    = NumberDelta.create(this.yOffset,    tYOffset,    fadeDuration);
+    if (this.radius     != null) this.radiusDelta     = NumberDelta.create(this.radius,     tRadius,     fadeDuration);
+    if (this.beamLength != null) this.beamLengthDelta = NumberDelta.create(this.beamLength, tBeamLength, fadeDuration);
+    if (this.beamWidth  != null) this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  tBeamWidth,  fadeDuration);
+  }
+
+  /**
+   * Processes and sets current conditional light properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseCondLightProps(properties) {
+    properties.forEach((e) => {
+      if      (e.startsWithIC('#'))  this.color      = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.color      = new VRGBA(e);
+      else if (e.startsWithIC('a'))  this.direction  = orNaN(Math.PI / 180 * +(e.slice(1)));
+      else if (e.startsWithIC('b'))  this.brightness = orNaN(+e.slice(1));
+      else if (e.startsWithIC('x'))  this.xOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('y'))  this.yOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('r'))  this.radius     = orNaN(+e.slice(1));
+      else if (e.startsWithIC('l'))  this.beamLength = orNaN(+e.slice(1));
+      else if (e.startsWithIC('w'))  this.beamWidth  = orNaN(+e.slice(1));
+    });
+  }
+
+  /**
+   * Processes and sets target conditional light properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseTargetCondLightProps(properties) {
+    let fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
+    let pauseDuration = properties.find((e) => (e.startsWithIC('p')));
+    fadeDuration      = fadeDuration ?  +fadeDuration.slice(1)  : 0;
+    pauseDuration     = pauseDuration ? +pauseDuration.slice(1) : 0;
+    properties.forEach((e) => {
+      if      (e.startsWithIC('#'))  this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
+      else if (e.startsWithIC('a#')) this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
+      else if (e.startsWithIC('a'))  this.directionDelta  = NumberDelta.create(this.direction,  Math.PI / 180 * +(e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('b'))  this.brightnessDelta = NumberDelta.create(this.brightness, orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('x'))  this.xOffsetDelta    = NumberDelta.create(this.xOffset,    orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('y'))  this.yOffsetDelta    = NumberDelta.create(this.yOffset,    orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('r'))  this.radiusDelta     = NumberDelta.create(this.radius,     orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('l'))  this.beamLengthDelta = NumberDelta.create(this.beamLength, orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('w'))  this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  orNaN(+e.slice(1)), fadeDuration);
+    });
+  }
+
+  /**
+   * Computes the next deltas in between the current parameters and target parameters.
+   * @returns {this}
+   */
+  next() {
+    if (this.colorDelta      != null) this.color      = this.colorDelta     .next().get();
+    if (this.directionDelta  != null) this.direction  = this.directionDelta .next().get();
+    if (this.brightnessDelta != null) this.brightness = this.brightnessDelta.next().get();
+    if (this.xOffsetDelta    != null) this.xOffset    = this.xOffsetDelta   .next().get();
+    if (this.yOffsetDelta    != null) this.yOffset    = this.yOffsetDelta   .next().get();
+    if (this.radiusDelta     != null) this.radius     = this.radiusDelta    .next().get();
+    if (this.beamLengthDelta != null) this.beamLength = this.beamLengthDelta.next().get();
+    if (this.beamWidthDelta  != null) this.beamWidth  = this.beamWidthDelta .next().get();
+    return this;
+  }
+
+  /**
+   * Returns whether all deltas are finished or not.
+   * @returns {Boolean}
+   */
+  finished() {
+    return this.colorDelta.finished();
+  }
+}
+
+/** Class representing individual number deltas for providing number changes over time at different speeds. **/
+class NumberDelta {
+  /**
+   * Creates a number delta from the start number, target number, and duration.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} duration
+   * @returns {NumberDelta}
+   */
+  constructor(start, target, duration) {
+    if (arguments.length == 0) return;
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta] =
+    [start,        target,      duration,      false,           (target - start) / duration];
+  }
+
+  /**
+   * Creates a copy of the NumberDelta object.
+   * @returns {NumberDelta}
+   **/
+  clone() {
+    let that = new NumberDelta();
+    [that.current, that.target, that.duration, that.lazyEquals, that.delta] =
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta];
+    return that;
+  }
+
+  /**
+   * Creates a number delta from the start number, target number, and duration.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} duration
+   * @returns {NumberDelta}
+   */
+  static create(start, target, duration) { return new NumberDelta(start, target, duration, duration); }
+
+  /**
+   * Computes the next delta number in between the current number and target number.
+   * @returns {this}
+   */
+  next() {
+    if (this.equals()) return this; // lazy-short-circuit
+    this.duration -= 1;
+    this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
+    this.equals();
+    return this;
+  }
+
+  /**
+   * Returns the current delta number.
+   * @returns {Number}
+   **/
+  get() { return this.current; }
+
+  /**
+   * Returns true if the current number is equal to the target number; otherwise false.
+   * @returns {Boolean}
+   */
+  equals() {
+    if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
+    if ((this.lazyEquals = this.duration <= 0))
+      return (this.current = this.target, true); // set cur to refer to target on match
+    return false;
+  }
+}
+
+/** Class representing a color delta for providing color changes over time at different speeds. **/
+class ColorDelta {
+  /**
+   * Create a color delta from the start color, target color, fade & on durations, and
+   * whether to consider the remaining ticks or not for speed purposes.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} fadeDuration
+   * @param {Number} onDuration
+   * @param {Number} useTicksRemaining
+   * @returns {ColorDelta}
+   */
+  constructor(start, target = start, fadeDuration = 0, onDuration = 0, useTicksRemaining = false) {
+    if (arguments.length == 0) return;
+    this.current     = start.clone();           // - deep copy
+    this.target      = target.clone();          // - deep copy
+    this.onDuration  = orNaN(onDuration, 0);    // - parse onDuration
+    this.lazyEquals  = false;                   // - true when current value == target value
+    fadeDuration     = orNaN(fadeDuration, 0);  // - use either the remaining time (of the hour) or total fade duration
+    fadeDuration    -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.delta       = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                (this.target.r - this.current.r) / fadeDuration,
+                                (this.target.g - this.current.g) / fadeDuration,
+                                (this.target.b - this.current.b) / fadeDuration,
+                                (this.target.a - this.current.a) / fadeDuration);
+  }
+  /**
+   * Creates a copy of the ColorDelta object.
+   * @returns {ColorDelta}
+   **/
+  clone() {
+    let that = new ColorDelta();
+    [that.current,           that.target,         that.onDuration, that.lazyEquals, that.delta] =
+    [this.current.clone(),   this.target.clone(), this.onDuration, this.lazyEquals, this.delta.clone()];
+    return that;
+  }
+
+  /**
+   * Creates a light delta from the start color, target color, and fade & on durations.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} fadeDuration
+   * @param {Number} onDuration
+   * @returns {ColorDelta}
+   */
+  static createLight(start, target, fadeDuration, onDuration) {
+    return new ColorDelta(start, target, fadeDuration, onDuration, false /* don't use remaining ticks */);
+  }
+
+  /**
+   * Creates a map color delta from the current map tint, target tint, and fade duration.
+   * @param {VRGBA}  targetTint
+   * @param {Number} fadeDuration
+   * @returns {ColorDelta}
+   */
+  static createTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration, 0, false); }
+
+  /**
+   * Creates a battle color delta from the current battle tint, target tint, and fade duration.
+   * @param {VRGBA}  targetTint
+   * @param {Number} fadeDuration
+   * @returns {ColorDelta}
+   */
+  static createBattleTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration, 0, false); }
+
+  /**
+   * Creates a time color delta from the current time and speed. useCurrentTint specifies whether to
+   * fade from the current color to the target or to have the start color be the color it would
+   * normally be at the given time interval (difference between current hour and next).
+   * @param {Boolean} useCurrentTint
+   * @returns {ColorDelta}
+   */
+  static createTimeTint(useCurrentTint = true) {
+    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
+    if (useCurrentTint) { // delta should fade from current color to target
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, true);
+    } else {              // start color should be the color it would normally be at the given time
+      let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
+      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, false);
+      delta.next(ticks); // get current color based off of ticks elapsed in hour
+      return delta;
+    }
+  }
+
+  /**
+   * Computes the next delta color in between the current color and target color.
+   * Scale is used to scale the delta increment by a factor of the scale amount.
+   * @param {Number} scale
+   * @returns {this}
+   */
+  next(scale = 1) {
+    if (this.equals()) return (this.onDuration = Math.max(this.onDuration - 1, 0), this); // subtract onDuration and lazy-short-circuit
+    this.current.v = this.delta.v;  // Compute next color step and clamp to target
+    this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
+    this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
+    this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
+    this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
+    if (this.equals()) this.onDuration = Math.max(this.onDuration - 1, 0); // check if done and if so subtract onDuration
+    return this;
+  }
+
+  /**
+   * Returns the current delta color.
+   * @returns {Number}
+   **/
+  get() { return this.current.clone(); } // duplicate color so reference can't be messed with
+
+  /**
+   * Returns true if the current color is equal to the target color; otherwise false.
+   * @returns {Boolean}
+   */
+  equals() {
+    if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
+    if ((this.lazyEquals = this.current.equals(this.target)))
+      return (this.current = this.target, true); // set cur to refer to target on match
+    return false;
+  }
+
+  /**
+   * Returns true if the current color is equal to the target and on duration has been reached; otherwise false.
+   * @returns {Boolean}
+   */
+  finished() { return this.equals() && this.onDuration == 0; }
+}
 
 (function ($$) {
   let isOn = (x) => x.toLowerCase() === "on";
@@ -677,7 +1190,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
   const TileType = {
     Terrain: 1, terrain: 1, 1: 1,
-    Region: 2,  region:  2, 2: 2
+    Region:  2, region:  2, 2: 2
   };
 
   const LightType = {
@@ -707,9 +1220,9 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       this.lightType  = LightType[lightType];
       this.id         = +id || 0;
       this.enabled    = isOn(onoff);
-      this.color      = $$.validateColor(color, "#ffffff");
+      this.color      = new VRGBA(color);
       this.radius     = +radius || 0;
-      this.brightness = brightness && (brightness.substr(1, brightness.length) / 100).clamp(0, 1) || $$.defaultBrightness || 0;
+      this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) || $$.defaultBrightness || 0;
     }
   }
 
@@ -718,7 +1231,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       this.tileType    = TileType[tileType];
       this.id          = +id || 0;
       this.enabled     = isOn(onoff);
-      this.color       = $$.validateColor(color, "#ffffff");
+      this.color       = new VRGBA(color);
       this.shape       = +shape || 0;
       this.xOffset     = +xOffset || 0;
       this.yOffset     = +yOffset || 0;
@@ -752,13 +1265,12 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   let player_radius = Number(parameters['Player radius']) || 0;
   let reset_each_map = orBoolean(parameters['Reset Lights'], false);
   let noteTagKey = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
-  let dayNightSaveHours = Number(parameters['Save DaynightHours']) || 0;
-  let dayNightSaveMinutes = Number(parameters['Save DaynightMinutes']) || 0;
   let dayNightSaveSeconds = Number(parameters['Save DaynightSeconds']) || 0;
   let dayNightSaveNight = Number(parameters["Save Night Switch"]) || 0;
   let dayNightNoAutoshadow = orBoolean(parameters["No Autoshadow During Night"], false);
   let hideAutoShadow = false;
-  let brightnessOverTime = orBoolean(parameters['Daynight Cycle'], true);
+  let daynightCycleEnabled = orBoolean(parameters['Daynight Cycle'], true);
+  let daynightTintEnabled = false;
   let dayNightList = (function (dayNight, nightHours) {
     let result = [];
     try {
@@ -766,11 +1278,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       nightHours = nightHours.split(",").map(x => x = +x);
       result = [];
       for (let i = 0; i < dayNight.length; i++)
-        result[i] = { "color": dayNight[i], "isNight": nightHours.contains(i) };
+        result[i] = { "color": new VRGBA(dayNight[i]), "isNight": nightHours.contains(i) };
     }
     catch (e) {
       console.log(`${Community.Lighting.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
-      result = new Array(24).fill(undefined).map(() => ({ "color": "#000000", "isNight": false }));
+      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
     }
     return result;
   })(parameters["DayNight Colors"], parameters["Night Hours"]);
@@ -794,15 +1306,9 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   let battleMaxX = maxX;
   let battleMaxY = maxY;
   if (isRMMZ()) battleMaxY += 24; // Plus 24 for RMMZ Spriteset_Battle.prototype.battleFieldOffsetY
-  let tint_oldseconds = 0;
-  let tint_timer = 0;
-  let oldseconds = 0;
   let event_reload_counter = 0;
-  let tileglow = 0;
-  let glow_oldseconds = 0;
-  let glow_dir = 1;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
-  let radialColor2 = useSmootherLights == true ? "#00000000" : "#000000";
+  let radialColor2 = new VRGBA(useSmootherLights ? "#00000000" : "#000000");
   $$.getFirstComment = function (page) {
     let result = null;
     if (page && page.list[0] != null) {
@@ -841,23 +1347,15 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     if (!result) result = $$.getCLTag(note);
     return result || "";
   };
-  $$.validateColor = function (color, defaultColor = "#ffffff") {
-    let isValid = /^[Aa]?#(?:[A-Fa-f0-9]{3}){1,2}$/.test(color); // a|A before # for additive lighting
-    if (!isValid) console.log("Community_Lighting_MZ - Invalid Color: " + color);
-    let result = isValid ? color : defaultColor;
-    return result.length < 7 ? result[0] + result[1] + result[1] + result[2] + result[2] + result[3] + result[3] : result;
-  };
   $$.getDayNightList = function () {
     return dayNightList;
   };
-  $$.saveTime = function (hh, mm, ss = null) {
-    let dayNightList = $gameVariables.GetDaynightColorArray();
-    if (dayNightSaveHours > 0) $gameVariables.setValue(dayNightSaveHours, hh);
-    if (dayNightSaveMinutes > 0) $gameVariables.setValue(dayNightSaveMinutes, mm);
-    if (dayNightSaveSeconds > 0 && ss !== null) $gameVariables.setValue(dayNightSaveSeconds, ss);
-    if (dayNightSaveNight > 0 && dayNightList[hh] instanceof Object) $gameSwitches.setValue(dayNightSaveNight, dayNightList[hh].isNight);
-    if (dayNightNoAutoshadow && dayNightList[hh] instanceof Object && dayNightList[hh].isNight !== hideAutoShadow) {
-      hideAutoShadow = dayNightList[hh].isNight; // We can not use $$.isNight because DaynightCycle hasn't been updated yet!
+  $$.saveTime = function () {
+    let index = $gameVariables.GetDaynightColorArray()[$$.hours()];
+    if (dayNightSaveSeconds > 0) $gameVariables.setValue(dayNightSaveSeconds, $gameVariables.GetDaynightSeconds());
+    if (dayNightSaveNight > 0 && index instanceof Object) $gameSwitches.setValue(dayNightSaveNight, index.isNight);
+    if (dayNightNoAutoshadow && index instanceof Object && index.isNight !== hideAutoShadow) {
+      hideAutoShadow = index.isNight; // We can not use $$.isNight because DaynightCycle hasn't been updated yet!
       // Update the shadow manually
       if (SceneManager._scene && SceneManager._scene._spriteset && SceneManager._scene._spriteset._tilemap) {
         SceneManager._scene._spriteset._tilemap.refresh();
@@ -865,128 +1363,141 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     }
   };
   $$.isNight = function () {
-    let hour = $gameVariables.GetDaynightCycle();
+    let hour = $$.hours();
     return dayNightList[hour] instanceof Object ? dayNightList[hour].isNight : false;
   };
-  $$.hours = function () {
-    return $gameVariables.GetDaynightCycle();
-  };
-  $$.minutes = function () {
-    return Math.floor($gameVariables.GetDaynightTimer() / $gameVariables.GetDaynightSpeed());
-  };
-  $$.seconds = function () {
-    let speed = $gameVariables.GetDaynightSpeed();
-    let value = Math.floor($gameVariables.GetDaynightTimer() - speed * $$.minutes());
-    return Math.floor(value / speed * 60);
-  };
+  $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
+  $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
+  $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
+  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
     if (showSeconds) result = result + ":" + $$.seconds().padZero(2);
     return result;
   };
+
+  /**
+  * Tests the value at the specified index of the $gameTemp object for equality with the
+  * passed in value and sets it. Returns true if the values match, or false otherwise.
+  * @param {String} index
+  * @param {any}    value
+  * @returns {Boolean}
+  */
+  Game_Temp.prototype.testAndSet = function (index, value) {
+    if (this[index] && (this[index] == value ||
+       (this[index].equals && this[index].equals(value))))
+      return false;
+    return (this[index] = value, true);
+  };
+
   // Event note tag caching
   Game_Event.prototype.resetLightData = function () {
-    this._clType = undefined;
+    this._clType        = undefined;
     this._lastLightPage = undefined;
-    this._clRadius = undefined;
-    this._clColor = undefined;
-    this._clCycle = undefined;
-    this._clBrightness = undefined;
-    this._clSwitch = undefined;
-    this._clDirection = undefined;
-    this._clXOffset = undefined;
-    this._clYOffset = undefined;
-    this._clId = undefined;
-    this._clBeamColor = undefined;
-    this._clBeamLength = undefined;
-    this._clBeamWidth = undefined;
-    this._clFlashlightDirection = undefined;
-    this._clOnOff = undefined;
-    this._clCycleTimer = undefined;
-    this._clCycleIndex = undefined;
+    this._clRadius      = undefined;
+    this._clColor       = undefined;
+    this._clCycle       = undefined;
+    this._clBrightness  = undefined;
+    this._clSwitch      = undefined;
+    this._clDirection   = undefined;
+    this._clXOffset     = undefined;
+    this._clYOffset     = undefined;
+    this._clId          = undefined;
+    this._clBeamLength  = undefined;
+    this._clBeamWidth   = undefined;
+    this._clOnOff       = undefined;
+    this._clCondLight   = {};
     this.initLightData();
   };
   Game_Event.prototype.initLightData = function () {
     this._lastLightPage = this._pageIndex;
-    let tagData = this.getCLTag().toLowerCase().split(/\s+/);
-    let needsCycleDuration = false;
+    let tagData = this.getCLTag().toLowerCase();
+    let CycleGroups = [];
+    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((CycleGroups.push(group.split(/\s+/)), '')));
+    tagData = tagData.split(/\s+/);
     this._clType = LightType[tagData.shift()];
+    // Handle parsing of light, fire, and flashlight
+    if (this._clType) {
+      let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+      let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
+      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
+      let isUndef      = (x)       => x === undefined;
+      let hasCycle = false;
+      tagData.forEach((e) => {
+        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength = +(e.slice(1));
+        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth  = +(e.slice(1));
+        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      hasCycle           = true;
+        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor      = new VRGBA(e);
+        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff      = true;
+        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff      = false;
+        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch     = e;
+        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness = Number(+(e.slice(1)) / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = +(e.slice(1));
+        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = CLDirectionMap[+(e.slice(1))];
+        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection  = Math.PI / 180 * +(e.slice(1));
+        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset    = +(e.slice(1));
+        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset    = +(e.slice(1));
+        else if (           e.length > 0                   && isUndef(this._clId))         this._clId         = e;
+      }, this);
 
-    // Handle parsing of light and fire
-    if (this._clType && this._clType.is(LightType.Light, LightType.Fire)) {
-      this._clRadius = undefined;
-      for (let x of tagData) {
-        if (!isNaN(+x) && this._clRadius === undefined) this._clRadius = +x;
-        else if (x.equalsIC("cycle") && this._clColor === undefined) this._clCycle = [];
-        else if (this._clCycle && !needsCycleDuration && (x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#"))) {
-          this._clCycle.push({ "color": $$.validateColor(x), "duration": 1 });
-          needsCycleDuration = true;
-        }
-        else if (this._clCycle && needsCycleDuration && !isNaN(+x)) {
-          this._clCycle[this._clCycle.length - 1].duration = +x || 1;
-          needsCycleDuration = false;
-        }
-        else if ((x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#")) &&
-                  this._clColor === undefined) this._clColor = $$.validateColor(x);
-        else if (x[0].equalsIC("b") && this._clBrightness === undefined) {
-          this._clBrightness = Number(+(x.substr(1, x.length)) / 100).clamp(0, 1);
-        }
-        else if (x.equalsIC("night", "day") && this._clSwitch === undefined) this._clSwitch = x;
-        else if (x[0].equalsIC("d") && this._clDirection === undefined) this._clDirection = +(x.substr(1, x.length));
-        else if (x[0].equalsIC("x") && this._clXOffset === undefined) this._clXOffset = +(x.substr(1, x.length));
-        else if (x[0].equalsIC("y") && this._clYOffset === undefined) this._clYOffset = +(x.substr(1, x.length));
-        else if (x.length > 0 && this._clId === undefined) this._clId = x;
+      // normalize parameters
+      this._clRadius     = this._clRadius || 0;
+      this._clColor      = orNullish(this._clColor, VRGBA.empty());
+      this._clBrightness = this._clBrightness || 0;
+      this._clDirection  = orNaN(this._clDirection, undefined); // must be undefined for later checks
+      this._clId         = this._clId || 0;
+      this._clBeamLength = this._clBeamLength || 0;
+      this._clBeamWidth  = this._clBeamWidth || 0;
+      this._clOnOff      = orBoolean(this._clOnOff, true);
+      this._clXOffset    = this._clXOffset || 0;
+      this._clYOffset    = this._clYOffset || 0;
+      this._clCycle      = this._clCycle || null;
+
+      // Process cycle parameters
+      if (hasCycle && CycleGroups.length) {             // check if tag included color cycling
+        this._clCycle = [];                             // only define if cycle exists
+        let t = this;                                   // refer to this as t
+        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
+        let condLight = new ConditionalLight(...args);  // create conditional light
+        CycleGroups.forEach((e, i, a) => {              // ------ loop each group
+          condLight = condLight.clone();                // - clone existing conditional light (inherit properties)
+          let n = a[++i < CycleGroups.length ? i : 0];  // - get next element
+          condLight.parseCondLightProps(e);             // - parse for new properties
+          condLight.parseTargetCondLightProps(n);       // - parse for target properties
+          this._clCycle.push(condLight);                // - push to list
+        }, this);                                       // ------
+        condLight = this._clCycle.shift();              // pop front
+        this._clCondLight = condLight.clone();          // clone it to be the current cond light delta
+        this._clCycle.push(condLight);                  // push original on back of list
+      }
+
+      // Process conditional lighting
+      if (this._clId) {                                 // check for a conditional lighting ID
+        let t = this;                                   // refer to this as t
+        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
+        let condLight  = new ConditionalLight(...args); // create conditional light
+        condLight.setupTargets(0, 0, ...args);          // create matching targets
+        condLight.next();                               // compute deltas (zeroes)
+        $gameVariables.GetLightArray()[this._clId] = condLight;
+        t._clCondLight = condLight;
       }
     }
-    // Handle parsing of flashlight
-    else if (this._clType && this._clType.is(LightType.Flashlight)) {
-      this._clBeamLength = undefined;
-      this._clBeamWidth = undefined;
-      this._clOnOff = undefined;
-      this._clFlashlightDirection = undefined;
-      this._clRadius = 1;
-      for (let x of tagData) {
-        if (!isNaN(+x) && this._clBeamLength === undefined) this._clBeamLength = +x;
-        else if (!isNaN(+x) && this._clBeamWidth === undefined) this._clBeamWidth = +x;
-        else if (x[0].equalsIC("l") && this._clBeamLength === undefined) this._clBeamLength = this._clBeamLength = +(x.substr(1, x.length));
-        else if (x[0].equalsIC("w") && this._clBeamWidth === undefined) this._clBeamWidth = this._clBeamWidth = +(x.substr(1, x.length));
-        else if (x.equalsIC("cycle") && this._clColor === undefined) this._clCycle = [];
-        else if (this._clCycle && !needsCycleDuration && (x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#"))) {
-          this._clCycle.push({ "color": $$.validateColor(x), "duration": 1 });
-          needsCycleDuration = true;
-        }
-        else if (this._clCycle && needsCycleDuration && !isNaN(+x)) {
-          this._clCycle[this._clCycle.length - 1].duration = +x || 1;
-          needsCycleDuration = false;
-        }
-        else if ((x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#")) &&
-                  this._clBeamColor === undefined) this._clColor = $$.validateColor(x);
-        else if (!isNaN(+x) && this._clOnOff === undefined) this._clOnOff = +x;
-        else if (!isNaN(+x) && this._clFlashlightDirection === undefined) this._clFlashlightDirection = +x;
-        else if (isOn(x) && this._clOnOff === undefined) this._clOnOff = 1;
-        else if (isOff(x) && this._clOnOff === undefined) this._clOnOff = 0;
-        else if (x.equalsIC("night", "day") && this._clSwitch === undefined) this._clSwitch = x;
-        else if (x[0].equalsIC("d") && this._clFlashlightDirection === undefined) this._clFlashlightDirection = CLDirectionMap[+(x.substr(1, x.length))];
-        else if (x[0].equalsIC("a") && this._clFlashlightDirection === undefined) this._clFlashlightDirection = Math.PI/180*+(x.substr(1, x.length));
-        else if (x[0].equalsIC("x") && this._clXOffset === undefined) this._clXOffset = +(x.substr(1, x.length));
-        else if (x[0].equalsIC("y") && this._clYOffset === undefined) this._clYOffset = +(x.substr(1, x.length));
-        else if (x.length > 0 && this._clId === undefined) this._clId = x;
-      }
+  };
+  Game_Event.prototype.cycleLightingNext = function () {
+    let cycleList = this.getLightCycle();
+    if (cycleList && this._clCondLight.finished()) {
+      let condLight = cycleList.shift();     // pop delta from front
+      this._clCondLight = condLight.clone(); // duplicate delta
+      cycleList.push(condLight);             // push delta on back
     }
-    this._clRadius = this._clRadius || 0;
-    this._clColor = this._clColor || "#000000";
-    this._clBrightness = this._clBrightness || 0;
-    this._clDirection = this._clDirection || 0;
-    this._clId = this._clId || 0;
-    this._clBeamWidth = this._clBeamWidth || 0;
-    this._clBeamLength = this._clBeamLength || 0;
-    this._clOnOff = this._clOnOff || 0;
-    this._clFlashlightDirection = this._clFlashlightDirection || undefined; // Must be undefined.
-    this._clXOffset = this._clXOffset || 0;
-    this._clYOffset = this._clYOffset || 0;
-    this._clCycle = this._clCycle || null;
-    this._clCycleTimer = 0;
-    this._clCycleIndex = 0;
+  };
+  Game_Event.prototype.conditionalLightingNext = function () {
+    if (this._clType === undefined) this.initLightData();
+    if (this.getLightCycle() || this.getLightId()) this._clCondLight.next();
   };
   Game_Event.prototype.getLightType = function () {
     if (this._clType === undefined) this.initLightData();
@@ -994,19 +1505,20 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clRadius;
+    return orNullish(this._clCondLight.radius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clColor;
+    if (!this._clColor) this._clColor = VRGBA.empty();
+    return orNullish(this._clCondLight.color, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clBrightness;
+    return orNullish(this._clCondLight.brightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clDirection;
+    return orNullish(this._clCondLight.direction, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1014,56 +1526,31 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clBeamLength;
+    return orNullish(this._clCondLight.beamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clBeamWidth;
-  };
-  Game_Event.prototype.getLightFlashlightDirection = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clFlashlightDirection;
+    return orNullish(this._clCondLight.beamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clXOffset;
+    return orNullish(this._clCondLight.xOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clYOffset;
+    return orNullish(this._clCondLight.yOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
-    let type = this.getLightType();
-    let result = false;
-    if (this._clSwitch === undefined) {
-      if (type.is(LightType.Flashlight) && this._clOnOff === 1) result = true;
-      else result = true;
-    } else {
-      result = (this._clSwitch.equalsIC("night") && $$.isNight()) ||
-               (this._clSwitch.equalsIC("day") && !$$.isNight());
-    }
-    return result;
+    if (!this._clSwitch) return this._clOnOff;
+    return (this._clSwitch.equalsIC("night") &&  $$.isNight()) ||
+           (this._clSwitch.equalsIC("day")   && !$$.isNight());
   };
   Game_Event.prototype.getLightCycle = function () {
     if (this._clType === undefined) this.initLightData();
     return this._clCycle;
   };
-  Game_Event.prototype.incrementLightCycle = function () {
-    if (this._clCycle) {
-      this._clCycleTimer--;
-      if (this._clCycleTimer < 1) {
-        let cycleList = this.getLightCycle();
-        this._clCycleIndex++;
-        if (this._clCycleIndex >= cycleList.length) this._clCycleIndex = 0;
-        if (this._clCycleIndex < cycleList.length) {
-          this._clColor = cycleList[this._clCycleIndex].color;
-          this._clCycleTimer = cycleList[this._clCycleIndex].duration;
-        }
-      }
-    }
-  };
-  let _Game_Interpreter_pluginCommand = Game_Interpreter.prototype.pluginCommand;
 
+  let _Game_Interpreter_pluginCommand = Game_Interpreter.prototype.pluginCommand;
   /**
    *
    * @param {String} command
@@ -1071,13 +1558,10 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    */
   Game_Interpreter.prototype.pluginCommand = function (command, args) {
     _Game_Interpreter_pluginCommand.call(this, command, args);
-    if (typeof command !== 'undefined') {
-      this.communityLighting_Commands(command, args);
-    }
+    if (typeof command !== 'undefined') this.communityLighting_Commands(command, args);
   };
 
   let _Game_Player_clearTransferInfo = Game_Player.prototype.clearTransferInfo;
-
   Game_Player.prototype.clearTransferInfo = function () {
     _Game_Player_clearTransferInfo.call(this);
     if (reset_each_map) {
@@ -1085,6 +1569,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       $$.defaultBrightness = 0;
       $$.mapBrightness = undefined;
       $gameVariables.SetTint(null);
+      $gameVariables.SetTintTarget(null);
     }
   };
   /**
@@ -1101,10 +1586,41 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       script: 'scriptF', reload: 'reload', tintbattle: 'tintbattle'
     };
     const result = allCommands[command];
-    if (result) {
-      this[result](command, args);
-    }
+    if (result) this[result](command, args);
   };
+
+  if (isRMMZ()) { // RMMZ only command interface
+    let mapOnOff = (args) => args.enabled === "true" ? "on" : "off";
+    let tileType = (args) => (args.tileType === "terrain" ? "tile" : "region") + (args.lightType ? args.lightType : "block");
+    let tintType = (    ) => $gameParty.inBattle() ? "tintbattle" : "tint";
+    let dayMode =  (args) => args.instant === "true" ? "instant" : "";
+    let tintMode = (args) => args.color ? "set" : "reset";
+    let mathMode = (args) => args.mode === "set" ? "hour" : args.mode; // set, add, or subtract.
+    let showMode = (args) => args.enabled.equalsIC("true") ? (args.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
+    let radMode  = (args) => +args.fadeSpeed ? "radiusgrow" : "radius";
+
+    let reg = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
+    let f = (cmd, args) => $gameMap._interpreter.communityLighting_Commands(cmd, args.filter(_ => _ !== "")); //command wrapper.
+
+    reg("masterSwitch",       (a)  => f("script",     [mapOnOff(a)]));
+    reg("tileBlock",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.shape,          a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
+    reg("tileLight",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.radius,         a.brightness]));
+    reg("setTint",            (a)  => f(tintType(),   [tintMode(a),     a.color,         a.fadeSpeed]));
+    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a),     dayMode(a)]));
+    reg("setTimeSpeed",       (a)  => f("dayNight",   ["speed",         a.speed]));
+    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes,      dayMode(a)]));
+    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours,         dayMode(a)]));
+    reg("showTime",           (a)  => f("dayNight",   [showMode(a)]));
+    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color,         dayMode(a)]));
+    reg("flashlight",         (a)  => f("flashLight", [mapOnOff(a),     a.beamLength,    a.beamWidth,    a.color,          a.density]));
+    reg("setFire",            (a)  => f("setFire",    [a.radiusShift,   a.redYellowShift]));
+    reg("playerLightRadius",  (a)  => f("light",      [radMode(a),      a.radius,        a.color,        "B"+a.brightness, a.fadeSpeed]));
+    reg("activateById",       (a)  => f("light",      [mapOnOff(a),     a.id]));
+    reg("lightColor",         (a)  => f("light",      ["color",         a.id,            a.color]));
+    reg("resetLightSwitches", ( )  => f("light",      ["switch",        "reset"]));
+    reg("resetTint",          (a)  => f(tintType(),   ["reset",         a.fadeSpeed]));
+    reg("condLight",          (a)  => f("light",      ["cond",          a.id,            a.properties]));
+  }
 
   /**
    *
@@ -1157,18 +1673,14 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {String} command
    * @param {String[]} args
    */
-  Game_Interpreter.prototype.dayNight = function (command, args) {
-    $$.DayNight(args);
-  };
+  Game_Interpreter.prototype.dayNight = (command, args) => $$.DayNight(args);
 
   /**
      *
      * @param {String} command
      * @param {String[]} args
      */
-  Game_Interpreter.prototype.flashLight = function (command, args) {
-    $$.flashlight(args);
-  };
+  Game_Interpreter.prototype.flashLight = (command, args) => $$.flashlight(args);
 
   /**
    *
@@ -1234,9 +1746,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     this.addChild(this._lightmask);
   };
 
-  function Lightmask() {
-    this.initialize.apply(this, arguments);
-  }
+  function Lightmask() { this.initialize.apply(this, arguments); }
 
   Lightmask.prototype = Object.create(PIXI.Container.prototype);
   Lightmask.prototype.constructor = Lightmask;
@@ -1251,14 +1761,10 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
   //Updates the Lightmask for each frame.
 
-  Lightmask.prototype.update = function () {
-    this._updateMask();
-  };
+  Lightmask.prototype.update = function () { this._updateMask(); };
 
   //@method _createBitmaps
-  Lightmask.prototype._createBitmaps = function () {
-    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
-  };
+  Lightmask.prototype._createBitmaps = function () { this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY); };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
   Game_Map.prototype.setupEvents = function () {
@@ -1285,19 +1791,13 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     }
 
     // reload mapevents if event_data has changed (deleted or spawned events/saves)
-    if (event_eventcount != $gameMap.events().length) {
-      $$.ReloadMapEvents();
-    }
+    if (event_eventcount != $gameMap.events().length) $$.ReloadMapEvents();
 
-    // remove old sprites
-    for (let i = 0, len = this._sprites.length; i < len; i++) { // remove all old sprites
-      this._removeSprite();
-    }
+    // remove all old sprites
+    for (let i = 0, len = this._sprites.length; i < len; i++) this._removeSprite();
 
-    if (map_id <= 0) return;                               // No lighting on map 0
-    if (options_lighting_on !== true) return;              // Plugin deactivated in the option
-    if ($gameVariables.GetScriptActive() !== true) return; // Plugin deactivated by plugin command
-
+    // No lighting on maps less than 1 || Plugin deactivated in options || Plugin deactivated by plugin command
+    if (map_id <= 0 || !options_lighting_on || !$gameVariables.GetScriptActive()) return;
 
     // reload map events every 200 cycles just in case or when a refresh is requested
     event_reload_counter++;
@@ -1306,10 +1806,12 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       $$.ReloadMapEvents();
     }
 
-    if (light_event_required && eventObjId.length <= 0) return; // If no lightsources on this map, no lighting if light_event_required set to true.
+    // If no lightsources on this map, no lighting if light_event_required set to true.
+    if (light_event_required && eventObjId.length <= 0) return;
 
     this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.multiply, PIXI.BLEND_MODES.MULTIPLY);
     this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.additive, PIXI.BLEND_MODES.ADD);
+
     // ******** GROW OR SHRINK GLOBE PLAYER *********
     let firstrun = $gameVariables.GetFirstRun();
     if (firstrun === true) {
@@ -1319,31 +1821,16 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     } else {
       player_radius = $gameVariables.GetRadius();
     }
-    let lightgrow_value = player_radius;
+
+    // compute radius lightgrow.
     let lightgrow_target = $gameVariables.GetRadiusTarget();
-    let lightgrow_speed = $gameVariables.GetRadiusSpeed();
-
-    if (lightgrow_value < lightgrow_target) {
-      lightgrow_value = lightgrow_value + lightgrow_speed;
-      if (lightgrow_value > lightgrow_target) {
-        //other wise it can keep fliping back and forth between > and <
-        lightgrow_value = lightgrow_target;
-      }
-      player_radius = lightgrow_value;
+    let lightgrow_speed = (player_radius < lightgrow_target ? 1 : -1) * $gameVariables.GetRadiusSpeed();
+    if (lightgrow_speed != 0 && player_radius != lightgrow_target) {
+      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
+      $gameVariables.SetRadius(player_radius);
     }
-    if (lightgrow_value > lightgrow_target) {
-      lightgrow_value = lightgrow_value - lightgrow_speed;
-      if (lightgrow_value < lightgrow_target) {
-        //other wise it can keep fliping back and forth between > and <
-        lightgrow_value = lightgrow_target;
-      }
-      player_radius = lightgrow_value;
-    }
-
-    $gameVariables.SetRadius(player_radius);
 
     // ****** PLAYER LIGHTGLOBE ********
-
     let ctxMul = this._maskBitmaps.multiply.context;
     let ctxAdd = this._maskBitmaps.additive.context;
     this._maskBitmaps.multiply.fillRect(0, 0, maxX + lightMaskPadding, maxY, '#000000');
@@ -1388,24 +1875,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       y1 = y1 - flashlightYoffset;
       if (iplayer_radius < 100) {
         // dim the light a bit at lower lightradius for a less focused effect.
-        let add = playercolor[0].equalsIC('a') ? 'a' : ''; // additive lighting
-        let c = hex2rgba(playercolor);
-        c.g = c.g - 50;
-        c.r = c.r - 50;
-        c.b = c.b - 50;
-        if (c.g < 0) {
-          c.g = 0;
-        }
-        if (c.r < 0) {
-          c.r = 0;
-        }
-        if (c.b < 0) {
-          c.b = 0;
-        }
-        if (c.a < 0) {
-          c.a = 0;
-        }
-        let newcolor = add + rgba2hex(c.r, c.g, c.b, c.a);
+        let c = playercolor;
+        c.r = Math.max(0, c.r - 50);
+        c.g = Math.max(0, c.g - 50);
+        c.b = Math.max(0, c.b - 50);
+        let newcolor = c;
 
         this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker, playerbrightness);
       } else {
@@ -1414,42 +1888,28 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
     }
 
-
     // *********************************** DAY NIGHT CYCLE TIMER **************************
-
-    let daynightspeed = $gameVariables.GetDaynightSpeed();
-
-    if (daynightspeed > 0 && daynightspeed < 5000 && brightnessOverTime) {
-
-      let datenow = new Date();
-      let seconds = Math.floor(datenow.getTime() / 10);
-      if (seconds > oldseconds) {
-
-        let daynighttimer = $gameVariables.GetDaynightTimer();     // timer = minutes * speed
-        let daynightcycle = $gameVariables.GetDaynightCycle();     // cycle = hours
-        let daynighthoursinday = $gameVariables.GetDaynightHoursinDay();   // 24
-
-        oldseconds = seconds;
-        daynighttimer = daynighttimer + 1;
-        let daynightminutes = Math.floor(daynighttimer / daynightspeed);
-        let daynighttimeover = daynighttimer - (daynightspeed * daynightminutes);
-        let daynightseconds = Math.floor(daynighttimeover / daynightspeed * 60);
-
-        if (daynighttimer >= (daynightspeed * 60)) {
-          daynightcycle = daynightcycle + 1;
-          if (daynightcycle >= daynighthoursinday) daynightcycle = 0;
-          daynighttimer = 0;
+    if (daynightCycleEnabled) { //
+      let speed = $gameVariables.GetDaynightSpeed();
+      if (speed > 0 && speed < 5000) {
+        if ($gameTemp.testAndSet('_daynightTimeout', Math.floor((new Date()).getTime() / 10))) {
+          let seconds = $gameVariables.GetDaynightSeconds();                   // current time in seconds
+          seconds += $gameVariables.GetDaynightTick();                         // add tick amount in (seconds)
+          let secondsinDay = $gameVariables.GetDaynightHoursinDay() * 60 * 60; // convert to total seconds in day
+          if (seconds >= secondsinDay) seconds = 0;                            // clamp
+          $gameVariables.SetDaynightSeconds(seconds);                          // set
+          $$.saveTime();                                                       // save
+          // Set target to the next hour tint if enabled and the tint matches the current target
+          if (daynightTintEnabled && $gameVariables.GetTintTarget().finished()) {
+            let delta = ColorDelta.createTimeTint(true, 60 * speed);
+            $gameVariables.SetTint(delta.get());
+            $gameVariables.SetTintTarget(delta);
+          }
         }
-        $$.saveTime(daynightcycle, daynightminutes, daynightseconds);
-        $gameVariables.SetDaynightTimer(daynighttimer);     // timer = minutes * speed
-        $gameVariables.SetDaynightCycle(daynightcycle);     // cycle = hours
       }
     }
 
     // ********** OTHER LIGHTSOURCES **************
-
-
-
     for (let i = 0, len = eventObjId.length; i < len; i++) {
       let evid = event_id[i];
       let cur = $gameMap.events()[eventObjId[i]];
@@ -1465,93 +1925,61 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
       let lightType = cur.getLightType();
       if (lightType) {
-        let objectflicker = lightType.is(LightType.Fire);
-        let light_radius = cur.getLightRadius();
-        let flashlength = cur.getLightFlashlightLength();
-        let flashwidth = cur.getLightFlashlightWidth();
-        let xoffset = cur.getLightXOffset() * $gameMap.tileWidth();
-        let yoffset = cur.getLightYOffset() * $gameMap.tileHeight();
-        if (light_radius >= 0) {
+        cur.cycleLightingNext();       // Cycle colors
+        cur.conditionalLightingNext(); // conditional lighting
+        let objectflicker  = lightType.is(LightType.Fire);
+        let lightId        = cur.getLightId();
+        let light_radius   = cur.getLightRadius();
+        let color          = cur.getLightColor();      // light color
+        let direction      = cur.getLightDirection();  // direction
+        let brightness     = cur.getLightBrightness(); // brightness
+        let xoffset        = cur.getLightXOffset() * $gameMap.tileWidth();
+        let yoffset        = cur.getLightYOffset() * $gameMap.tileHeight();
+        let state          = cur.getLightEnabled();    // checks for on, off, day, and night
 
-          // light color
-          let colorvalue = cur.getLightColor();
-
-          // Cycle colors
-          cur.incrementLightCycle();
-
-          // brightness and direction
-
-          let brightness = cur.getLightBrightness();
-          let direction = cur.getLightDirection();
-          // conditional lighting
-          let lightid = cur.getLightId();
-          let state = cur.getLightEnabled();
-          if (lightid) {
-            state = false;
-
-            let lightarray = $gameVariables.GetLightArray();
-            if (lightarray[lightid]) {
-              let tcolorvalue;
-              [state, tcolorvalue] = lightarray[lightid];
-              if (tcolorvalue != 'defaultcolor') colorvalue = tcolorvalue;
-            }
-
-            // Set kill switch to ON if the conditional light is deactivated,
-            // or to OFF if it is active.
-            if (killSwitchAuto && killswitch !== 'None') {
-              let key = [map_id, evid, killswitch];
-              if ($gameSelfSwitches.value(key) === state) $gameSelfSwitches.setValue(key, !state);
-            }
+        // Set kill switch to ON if the conditional light is deactivated,
+        // or to OFF if it is active.
+        if (lightId && killSwitchAuto && killswitch !== 'None') {
+          let key = [map_id, evid, killswitch];
+          if ($gameSelfSwitches.value(key) === state) $gameSelfSwitches.setValue(key, !state);
+        }
+        // kill switch
+        if (killswitch !== 'None' && state) {
+          let key = [map_id, evid, killswitch];
+          if ($gameSelfSwitches.value(key) === true) state = false;
+        }
+        // show light
+        if (state === true) {
+          let lx1 = $gameMap.events()[event_stacknumber[i]].screenX();
+          let ly1 = $gameMap.events()[event_stacknumber[i]].screenY() - 24;
+          if (!shift_lights_with_events) {
+            ly1 += $gameMap.events()[event_stacknumber[i]].shiftY();
           }
 
-          // kill switch
-          if (killswitch !== 'None' && state) {
-            let key = [map_id, evid, killswitch];
-            if ($gameSelfSwitches.value(key) === true) state = false;
-          }
+          // apply offsets
+          lx1 += +xoffset;
+          ly1 += +yoffset;
 
-          // show light
-          if (state === true) {
-            let lx1 = $gameMap.events()[event_stacknumber[i]].screenX();
-            let ly1 = $gameMap.events()[event_stacknumber[i]].screenY() - 24;
-            if (!shift_lights_with_events) {
-              ly1 += $gameMap.events()[event_stacknumber[i]].shiftY();
-            }
-
-            // apply offsets
-            lx1 += +xoffset;
-            ly1 += +yoffset;
-
-            if (lightType.is(LightType.Flashlight)) {
-              let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
-
-              let tldir = cur.getLightFlashlightDirection();
-              if (!isNaN(tldir)) ldir = tldir;
-              this._maskBitmaps.radialgradientFlashlight(lx1, ly1, colorvalue, '#000000', ldir, flashlength, flashwidth);
-            } else if(lightType.is(LightType.Light, LightType.Fire)) {
-              this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, colorvalue, '#000000', objectflicker, brightness, direction);
-            }
+          if (lightType.is(LightType.Flashlight)) {
+            let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
+            let flashlength = cur.getLightFlashlightLength();
+            let flashwidth  = cur.getLightFlashlightWidth();
+            if (!isNaN(direction)) ldir = direction;
+            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
+          } else if (lightType.is(LightType.Light, LightType.Fire)) {
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker, brightness, direction);
           }
         }
       }
     }
 
-
     // *************************** TILE TAG *********************
     //glow/colorfade
-    let glowdatenow = new Date();
-    let glowseconds = Math.floor(glowdatenow.getTime() / 100);
-
-    if (glowseconds > glow_oldseconds) {
-      glow_oldseconds = glowseconds;
-      tileglow = tileglow + glow_dir;
-
-      if (tileglow > 120) {
-        glow_dir = -1;
-      }
-      if (tileglow < 1) {
-        glow_dir = 1;
-      }
+    if ($gameTemp.testAndSet('_glowTimeout', Math.floor((new Date()).getTime() / 100))) {
+      $gameTemp._glowDirection = orNaN($gameTemp._glowDirection, 1);
+      $gameTemp._glowAmount    = orNaN($gameTemp._glowAmount, 0) + $gameTemp._glowDirection;
+      if ($gameTemp._glowAmount > 120) $gameTemp._glowDirection = -1;
+      if ($gameTemp._glowAmount < 1)   $gameTemp._glowDirection = 1;
     }
 
     light_tiles = $gameVariables.GetLightTiles();
@@ -1565,24 +1993,14 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       let objectflicker = tile.lightType.is(LightType.Fire);
       let tile_color = tile.color;
       if (tile.lightType.is(LightType.Glow)) {
-        let add = tile.color[0].equalsIC('a') ? 'a' : ''; // additive lighting
-        let c = hex2rgba(tile.color);
-        c.r = Math.floor(c.r + (60 - tileglow));
-        c.g = Math.floor(c.g + (60 - tileglow));
-        c.b = Math.floor(c.b + (60 - tileglow));
-        c.a = Math.floor(c.a + (60 - tileglow));
-
-        if (c.r < 0) c.r = 0;
-        if (c.g < 0) c.g = 0;
-        if (c.b < 0) c.b = 0;
-        if (c.a < 0) c.a = 0;
-        if (c.r > 255) c.r = 255;
-        if (c.g > 255) c.g = 255;
-        if (c.b > 255) c.b = 255;
-        if (c.a > 255) c.a = 255;
-        tile_color = add + rgba2hex(c.r, c.g, c.b, c.a);
+        let c = tile.color.clone();
+        c.r = Math.floor(c.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        c.g = Math.floor(c.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        c.b = Math.floor(c.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color = c;
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, '#000000', objectflicker, tile.brightness);
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker, tile.brightness);
     });
 
     // Tile blocks
@@ -1617,105 +2035,13 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
         y1 = y1 + tile.yOffset;
         this._maskBitmaps.FillEllipse(x1, y1, tile.blockWidth, tile.blockHeight, tile.color);
       }
-    });
+    }, this);
     ctxMul.globalCompositeOperation = 'lighter';
 
-
-    // *********************************** DAY NIGHT CYCLE FILTER **************************
-    if ($$.daynightset) {
-
-      let daynighttimer = $gameVariables.GetDaynightTimer();     // timer = minutes * speed
-      let daynightcycle = $gameVariables.GetDaynightCycle();     // cycle = hours
-      let daynighthoursinday = $gameVariables.GetDaynightHoursinDay();   // 24
-      let daynightcolors = $gameVariables.GetDaynightColorArray();
-      let color1 = daynightcolors[daynightcycle].color;
-      let add = color1[0].equalsIC('a') ? 'a' : ''; // additive lighting
-      let c = hex2rgba(color1);
-      if (daynightspeed > 0) {
-        let nextcolor = daynightcycle + 1;
-        if (nextcolor >= daynighthoursinday) {
-          nextcolor = 0;
-        }
-        let color2 = daynightcolors[nextcolor].color;
-        let c2 = hex2rgba(color2);
-
-        let stepR = (c2.r - c.r) / (60 * daynightspeed);
-        let stepG = (c2.g - c.g) / (60 * daynightspeed);
-        let stepB = (c2.b - c.b) / (60 * daynightspeed);
-        let stepA = (c2.a - c.a) / (60 * daynightspeed);
-
-        c.r = Math.floor(c.r + (stepR * daynighttimer));
-        c.g = Math.floor(c.g + (stepG * daynighttimer));
-        c.b = Math.floor(c.b + (stepB * daynighttimer));
-        c.a = Math.floor(c.a + (stepA * daynighttimer));
-      }
-      color1 = rgba2hex(c.r, c.g, c.b, c.a);
-
-      this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX + lightMaskPadding, maxY, add+color1);
-    }
-    // *********************************** TINT **************************
-    else {
-      let tint_value = $gameVariables.GetTint();
-      let tint_target = $gameVariables.GetTintTarget();
-      let tint_speed = $gameVariables.GetTintSpeed();
-      let tcolor = tint_value;
-      if (tint_value != tint_target) {
-        let tintdatenow = new Date();
-        let tintseconds = Math.floor(tintdatenow.getTime() / 10);
-        if (tintseconds > tint_oldseconds) {
-          tint_oldseconds = tintseconds;
-          tint_timer++;
-        }
-
-        let add = tint_target[0].equalsIC('a') ? 'a' : ''; // additive lighting
-        let c = hex2rgba(tint_value);
-        let c2 = hex2rgba(tint_target);
-
-        let stepR = (c2.r - c.r) / (60 * tint_speed);
-        let stepG = (c2.g - c.g) / (60 * tint_speed);
-        let stepB = (c2.b - c.b) / (60 * tint_speed);
-        let stepA = (c2.a - c.a) / (60 * tint_speed);
-
-        let r3 = Math.floor(c.r + (stepR * tint_timer));
-        let g3 = Math.floor(c.g + (stepG * tint_timer));
-        let b3 = Math.floor(c.b + (stepB * tint_timer));
-        let a3 = Math.floor(c.a + (stepA * tint_timer));
-        if (r3 < 0) r3 = 0;
-        if (g3 < 0) g3 = 0;
-        if (b3 < 0) b3 = 0;
-        if (a3 < 0) a3 = 0;
-        if (r3 > 255) r3 = 255;
-        if (g3 > 255) g3 = 255;
-        if (b3 > 255) b3 = 255;
-        if (a3 > 255) a3 = 255;
-        let reddone = false;
-        let greendone = false;
-        let bluedone = false;
-        let alphadone = false;
-
-        //Greater than
-        if (stepR >= 0 && r3 >= c2.r) reddone = true;
-        if (stepG >= 0 && g3 >= c2.g) greendone = true;
-        if (stepB >= 0 && b3 >= c2.b) bluedone = true;
-        if (stepA >= 0 && a3 >= c2.a) alphadone = true;
-
-        // Less than
-        if (stepR <= 0 && r3 <= c2.r) reddone = true;
-        if (stepG <= 0 && g3 <= c2.g) greendone = true;
-        if (stepB <= 0 && b3 <= c2.b) bluedone = true;
-        if (stepA <= 0 && a3 <= c2.a) alphadone = true;
-
-        if (reddone == true && bluedone == true && greendone == true && alphadone == true) {
-          $gameVariables.SetTint(tint_target);
-        }
-
-        let hex = add + rgba2hex(r3, g3, b3, a3);
-        tcolor = hex;
-      } else {
-        tint_timer = 0;
-      }
-      this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX + lightMaskPadding, maxY, tcolor);
-    }
+    // Compute tint for next frame
+    let tintValue = $gameVariables.GetTintTarget().next().get();
+    $gameVariables.SetTint(tintValue);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX + lightMaskPadding, maxY, tintValue);
 
     // reset drawmode to normal
     ctxMul.globalCompositeOperation = 'source-over';
@@ -1745,34 +2071,59 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @method _removeSprite
    * @private
    */
-  Lightmask.prototype._removeSprite = function () {
-    this.removeChild(this._sprites.pop());
+  Lightmask.prototype._removeSprite = function () { this.removeChild(this._sprites.pop()); };
+
+  // *******************  ADD COLOR STOPS ***********************************
+  /**
+  * @param {Number} brightness
+  * @param {VRGBA} c1
+  * @param {VRGBA} c2
+   */
+  CanvasGradient.prototype.addTransparentColorStops = function (brightness, c1, c2) {
+    if (brightness) {
+      if (!useSmootherLights) {
+        let alpha = Math.floor(brightness * 100 * 2.55).toString(16);
+        if (alpha.length < 2) alpha = "0" + alpha;
+        this.addColorStop(0, '#FFFFFF' + alpha);
+      }
+    }
+
+    if (useSmootherLights) {
+      for (let distanceFromCenter = 0; distanceFromCenter < 1; distanceFromCenter += 0.1) {
+        let newRed   = c1.r - (distanceFromCenter * 100 * 2.55);
+        let newGreen = c1.g - (distanceFromCenter * 100 * 2.55);
+        let newBlue  = c1.b - (distanceFromCenter * 100 * 2.55);
+        let newAlpha = 1 - distanceFromCenter;
+        if (brightness > 0) newAlpha = Math.max(0, brightness - distanceFromCenter);
+        this.addColorStop(distanceFromCenter, rgba(~~newRed, ~~newGreen, ~~newBlue, newAlpha));
+      }
+    } else {
+      this.addColorStop(brightness, c1.toWebHex());
+    }
+
+    this.addColorStop(1, c2.toWebHex());
   };
 
-
   // *******************  NORMAL BOX SHAPE ***********************************
-
   /**
    *
    * @param {Number} x1
    * @param {Number} y1
    * @param {Number} x2
    * @param {Number} y2
-   * @param {String} c
+   * @param {VRGBA} c
    */
   Mask_Bitmaps.prototype.FillRect = function (x1, y1, x2, y2, c) {
     x1 = x1 + lightMaskPadding;
-
-    let bAdd = c[0].equalsIC('a') ? (c = c.slice(1), true) : (false);
-
+    let hex = c.toWebHex();
     let ctxMul = this.multiply._context;
     //ctxMul.save(); // unnecessary significant performance hit
-    ctxMul.fillStyle = c;
+    ctxMul.fillStyle = hex;
     ctxMul.fillRect(x1, y1, x2, y2);
     if (isRMMV()) this.multiply._setDirty(); // doesn't exist in RMMZ
-    if (bAdd) {
+    if (c.v) {
       let ctxAdd = this.additive._context; // Additive lighting context
-      ctxAdd.fillStyle = c;
+      ctxAdd.fillStyle = hex;
       ctxAdd.fillRect(x1, y1, x2, y2);
       if (isRMMV()) this.additive._setDirty(); // doesn't exist in RMMZ
     }
@@ -1785,23 +2136,21 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {Number} centerY
    * @param {Number} xradius
    * @param {Number} yradius
-   * @param {String} c
+   * @param {VRGBA} c
    */
   Mask_Bitmaps.prototype.FillEllipse = function (centerX, centerY, xradius, yradius, c) {
     centerX = centerX + lightMaskPadding;
-
-    let bAdd = c[0].equalsIC('a') ? (c = c.slice(1), true) : (false);
-
+    let hex = c.toWebHex();
     let ctxMul = this.multiply._context;
     //ctxMul.save(); // unnecessary significant performance hit
-    ctxMul.fillStyle = c;
+    ctxMul.fillStyle = hex;
     ctxMul.beginPath();
     ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
     ctxMul.fill();
     if (isRMMV()) this.multiply._setDirty(); // doesn't exist in RMMZ
-    if (bAdd) {
+    if (c.v) {
       let ctxAdd = this.additive._context; // Additive lighting context
-      ctxAdd.fillStyle = c;
+      ctxAdd.fillStyle = hex;
       ctxAdd.beginPath();
       ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
       ctxAdd.fill();
@@ -1810,132 +2159,20 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     //ctxMul.restore();
   };
 
-  /**
-   *
-   * @param {Number} r
-   * @param {Number} g
-   * @param {Number} b
-   * @param {Number} a
-   * @returns {String}
-   */
-  function rgba(r, g, b, a) {
-    return "rgba(" + r + "," + g + "," + b + "," + a + ")";
-  }
-
-
-
-  /**
-   * Function to convert the
-   * RGB code to Hex color code
-   * @param {Number} R
-   * @param {Number} G
-   * @param {Number} B
-   * @param {Number} A
-   * @returns {String}
-   */
-  function rgba2hex(R, G, B, A = 255) {
-    if ((R >= 0 && R <= 255) &&
-        (G >= 0 && G <= 255) &&
-        (B >= 0 && B <= 255) &&
-        (A >= 0 && A <= 255)) {
-
-      let hexCode = "#";
-      let redHex = R.toString(16);
-      if (redHex.length < 2) {
-        redHex = "0" + redHex;
-      }
-
-      let greenHex = G.toString(16);
-      if (greenHex.length < 2) {
-        greenHex = "0" + greenHex;
-      }
-
-      let blueHex = B.toString(16);
-      if (blueHex.length < 2) {
-        blueHex = "0" + blueHex;
-      }
-
-      let alphaHex = A.toString(16);
-      if (alphaHex.length < 2) {
-        alphaHex = "0" + alphaHex;
-      }
-
-      hexCode += redHex;
-      hexCode += greenHex;
-      hexCode += blueHex;
-      hexCode += alphaHex;
-
-      return hexCode;
-    }
-
-    // The hex color code doesn't exist
-    else {
-      return "-1";
-    }
-
-  }
-
-  /**
-  * @param {Number} brightness
-  * @param {String} c1
-  * @param {String} c2
-  */
-  CanvasGradient.prototype.addTransparentColorStops = function (brightness, c1, c2) {
-
-    if (brightness) {
-      if (!useSmootherLights) {
-        let alpha = Math.floor(brightness * 100 * 2.55).toString(16);
-        if (alpha.length < 2) {
-          alpha = "0" + alpha;
-        }
-        this.addColorStop(0, '#FFFFFF' + alpha);
-      }
-    }
-
-    if (useSmootherLights) {
-      for (let distanceFromCenter = 0; distanceFromCenter < 1; distanceFromCenter += 0.1) {
-        let c = hex2rgba(c1);
-        let newRed   = c.r - (distanceFromCenter * 100 * 2.55);
-        let newGreen = c.g - (distanceFromCenter * 100 * 2.55);
-        let newBlue  = c.b - (distanceFromCenter * 100 * 2.55);
-        let newAlpha = 1 - distanceFromCenter;
-        if (brightness > 0) {
-          newAlpha = Math.max(0, brightness - distanceFromCenter);
-        }
-        this.addColorStop(distanceFromCenter, rgba(~~newRed, ~~newGreen, ~~newBlue, newAlpha));
-      }
-    } else {
-      this.addColorStop(brightness, c1);
-    }
-
-    this.addColorStop(1, c2);
-  };
   // *******************  NORMAL LIGHT SHAPE ***********************************
-  // Fill gradient circle
-
   /**
   *
   * @param {Number} x1
   * @param {Number} y1
   * @param {Number}  r1
   * @param {Number} r2
-  * @param {String} c1
-  * @param {String} c2
+  * @param {VRGBA} c1
+  * @param {VRGBA} c2
   * @param {Boolean} flicker
   * @param {Number} brightness
   * @param {Number} direction
   */
   Mask_Bitmaps.prototype.radialgradientFillRect = function (x1, y1, r1, r2, c1, c2, flicker, brightness, direction) {
-
-    let bAdd = c1[0].equalsIC('a') ? (c1 = c1.slice(1), true) : (false);
-    let isValidColor = isValidColorRegex.test(c1.trim());
-    if (!isValidColor) {
-      c1 = '#000000';
-    }
-    let isValidColor2 = isValidColorRegex.test(c2.trim());
-    if (!isValidColor2) {
-      c2 = '#000000';
-    }
 
     x1 = x1 + lightMaskPadding;
 
@@ -1944,29 +2181,11 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     let ny1 = Number(y1);
     let nr2 = Number(r2);
 
-    let clip = false;
+    // if not clipped
+    if (!(nx1 - nr2 > maxX || ny1 - nr2 > maxY || nx1 + nr2 < 0 || nx1 + nr2 < 0)) {
+      if (!brightness) brightness = 0.0;
+      if (!direction) direction = 0;
 
-    if (nx1 - nr2 > maxX) {
-      clip = true;
-    }
-    if (ny1 - nr2 > maxY) {
-      clip = true;
-    }
-    if (nx1 + nr2 < 0) {
-      clip = true;
-    }
-    if (nx1 + nr2 < 0) {
-      clip = true;
-    }
-
-    if (clip == false) {
-
-      if (!brightness) {
-        brightness = 0.0;
-      }
-      if (!direction) {
-        direction = 0;
-      }
       let ctxMul = this.multiply._context;
       let ctxAdd = this.additive._context;  // Additive lighting context
       let wait = Math.floor((Math.random() * 8) + 1);
@@ -1976,15 +2195,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
         let gradrnd = Math.floor((Math.random() * flickerradiusshift) + 1);
         let colorrnd = Math.floor((Math.random() * flickercolorshift) - (flickercolorshift / 2));
 
-        let c = hex2rgba(c1);
-        c.g = c.g + colorrnd;
-        if (c.g < 0) {
-          c.g = 0;
-        }
-        if (c.g > 255) {
-          c.g = 255;
-        }
-        c1 = rgba2hex(c.r, c.g, c.b, c.a);
+        c1.g = (c1.g + colorrnd).clamp(0, 255);
         r2 = r2 - gradrnd;
         if (r2 < 0) r2 = 0;
       }
@@ -2035,32 +2246,30 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       }
 
       ctxMul.fillRect(xS1, yS1, xE1, yE1);
-      if (bAdd) ctxAdd.fillRect(xS1, yS1, xE1, yE1);
+      if (c1.v) ctxAdd.fillRect(xS1, yS1, xE1, yE1);
       if (direction > 8) {
         ctxMul.fillRect(xS2, yS2, xE2, yE2);
-        if (bAdd) ctxAdd.fillRect(xS2, yS2, xE2, yE2);
+        if (c1.v) ctxAdd.fillRect(xS2, yS2, xE2, yE2);
       }
 
       //ctxMul.restore();
       if (isRMMV()) {
         this.multiply._setDirty(); // doesn't exist in RMMZ
-        if (bAdd) this.additive._setDirty(); // doesn't exist in RMMZ
+        if (c1.v) this.additive._setDirty(); // doesn't exist in RMMZ
       }
     }
   };
 
 
   // ********************************** FLASHLIGHT *************************************
-  // Fill gradient Cone
-
   /**
    *
    * @param {Number} x1
    * @param {Number} y1
    * @param {Number} r1
    * @param {Number} r2
-   * @param {String} c1
-   * @param {String} c2
+   * @param {VRGBA} c1
+   * @param {VRGBA} c2
    * @param {Number} direction
    * @param {Number} flashlength
    * @param {Number} flashwidth
@@ -2069,32 +2278,18 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     x1 = x1 + lightMaskPadding;
     x1 = x1 - flashlightXoffset;
     y1 = y1 - flashlightYoffset;
-
-    let bAdd = c1[0].equalsIC('a') ? (c1 = c1.slice(1), true) : (false);
-    let isValidColor = isValidColorRegex.test(c1.trim());
-    if (!isValidColor) {
-      c1 = '#000000';
-    }
-    let isValidColor2 = isValidColorRegex.test(c2.trim());
-    if (!isValidColor2) {
-      c2 = '#000000';
-    }
-
     let ctxMul = this.multiply._context;
     let ctxAdd = this.additive._context; // Additive lighting context
 
     //ctxMul.save(); // unnecessary significant performance hit
 
-    // grab flashlight color
-    let c = hex2rgba(c1);
-
     // small dim glove around player
     // there's no additive light globe for flashlights because it looks bad
     let r1 = 1; let r2 = 40;
     let grad = ctxMul.createRadialGradient(x1, y1, r1, x1, y1, r2);
-    let s = 0x99 / Math.max(0x99 * c.r, 0x99 * c.g, 0x99 * c.b); // scale factor: max should be 0x99
-    grad.addColorStop(0, rgba2hex(s * c.r, s * c.g, s * c.b, 0xFF));
-    grad.addColorStop(1, c2);
+    let s = 0x99 / Math.max(0x99 * c1.r, 0x99 * c1.g, 0x99 * c1.b); // scale factor: max should be 0x99
+    grad.addColorStop(0, c1.toWebHex({ v: false, r: s * c1.r, g: s * c1.g, b: s * c1.b }));
+    grad.addColorStop(1, c2.toWebHex());
     ctxMul.fillStyle = grad;
     ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
 
@@ -2148,8 +2343,8 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       let yRightCtrlPoint = yRightBeamStart + endCtrlPointDistance * Math.sin(rightBeamAngle);
 
       // Grab web colors for beam
-      let outerHex = rgba2hex(c.r, c.g, c.b, Math.round(0.65 * c.a));
-      let innerHex = rgba2hex(c.r, c.g, c.b, Math.round(0.1  * c.a));
+      let outerHex = c1.toWebHex({ a: Math.round(0.65 * c1.a) });
+      let innerHex = c1.toWebHex({ a: Math.round(0.1  * c1.a) });
 
       // Draw outer beam as a shadow
       ctxMul.fillStyle = "#000000"; // Clear fillstyle for drawing beam
@@ -2162,7 +2357,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
-      if (bAdd) {
+      if (c1.v) {
         ctxAdd.fillStyle = "#000000"; // Clear fillstyle for drawing beam
         ctxAdd.shadowColor = outerHex;
         ctxAdd.shadowBlur = 20;
@@ -2185,7 +2380,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
-      if (bAdd) {
+      if (c1.v) {
         // Draw inner beam as a shadow
         ctxAdd.shadowColor = innerHex;
         ctxAdd.shadowBlur = 1;
@@ -2207,7 +2402,7 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       grad.addTransparentColorStops(0, c1, c2);
       ctxMul.shadowColor = "#000000"; // Clear shadow style outside of check as ctxMul state changes always occur
       ctxMul.shadowBlur = 0;
-      if (!bAdd) {
+      if (!c1.v) {
         ctxMul.fillStyle = grad;
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
@@ -2233,93 +2428,50 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
         ctxMul.fillStyle = grad;
         ctxAdd.fillStyle = grad;
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
-        if (bAdd) ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
+        if (c1.v) ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
       }
       ctxMul.fillStyle = grad;
       ctxAdd.fillStyle = grad;
       ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
-      if (bAdd) ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
+      if (c1.v) ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
     }
 
     //ctxMul.restore();
     if (isRMMV()) {
       this.multiply._setDirty(); // doesn't exist in RMMZ
-      if (bAdd) this.additive._setDirty(); // doesn't exist in RMMZ
+      if (c1.v) this.additive._setDirty(); // doesn't exist in RMMZ
     }
-  };
-
-
-  /**
-   *
-   * @param {String} hex
-   * @returns {{r:number,g:number,b:number,a:number}}
-   */
-  function hex2rgba(hex) {
-    let regex = new RegExp(/^[Aa]?#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})?$/i);
-    let result = regex.exec(hex);
-    result = result ? {
-      r: parseInt(result[1], 16),
-      g: parseInt(result[2], 16),
-      b: parseInt(result[3], 16),
-      a: result[4] == null ? 255 : parseInt(result[4], 16)
-    } : null;
-    return result;
-  }
-
-  // ALIASED Begin battle: prepare battle lighting
-
-  let Community_Lighting_BattleManager_setup = BattleManager.setup;
-  BattleManager.setup = function (troopId, canEscape, canLose) {
-    $gameTemp._MapTint = '#FFFFFF';                                          // By default, no darkness during battle
-    if (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0) { // If we went there from a map...
-      if ($gameVariables.GetScriptActive() === true) {                                        // If the script is active...
-        if (options_lighting_on && lightInBattle) {                                           // If configuration autorise using lighting effects
-          $gameTemp._MapTint = $gameVariables.GetTint();                                    // ... Use the tint of the map.
-        }
-        // Add daylight tint?
-      }
-    }
-    Community_Lighting_BattleManager_setup.call(this, troopId, canEscape, canLose);
   };
 
   // ALIASED Scene_Battle initialization: create the light mask.
-
   let Community_Lighting_Spriteset_Battle_createLowerLayer = Spriteset_Battle.prototype.createLowerLayer;
   Spriteset_Battle.prototype.createLowerLayer = function () {
     Community_Lighting_Spriteset_Battle_createLowerLayer.call(this);
-    if (battleMaskPosition.equalsIC('Above')) {
-      this.createBattleLightmask();
-    }
+    if (battleMaskPosition.equalsIC('Above')) this.createBattleLightmask();
   };
-
   let Community_Lighting_Spriteset_Battle_createBattleField = Spriteset_Battle.prototype.createBattleField;
   Spriteset_Battle.prototype.createBattleField = function () {
     Community_Lighting_Spriteset_Battle_createBattleField.call(this);
-    if (battleMaskPosition.equalsIC('Between')) {
-      this.createBattleLightmask();
-    }
+    if (battleMaskPosition.equalsIC('Between')) this.createBattleLightmask();
   };
 
   Spriteset_Battle.prototype.createBattleLightmask = function () {
-    if ($gameVariables.GetScriptActive()) {             // If the script is active
-      if (lightInBattle) {                              // If is active during battles.
-        this._battleLightmask = new BattleLightmask();  // ... Create the light mask.
-        if (battleMaskPosition.equalsIC('Above')) {
-          this.addChild(this._battleLightmask);
-        } else if (battleMaskPosition.equalsIC('Between')) {
-          this._battleField.addChild(this._battleLightmask);
-        }
+    // If the script is active and configuration specifies light
+    // to be active during battle, then create the light mask.
+    if ($gameVariables.GetScriptActive() && lightInBattle) {
+      this._battleLightmask = new BattleLightmask();
+      if (battleMaskPosition.equalsIC('Above')) {
+        this.addChild(this._battleLightmask);
+      } else if (battleMaskPosition.equalsIC('Between')) {
+        this._battleField.addChild(this._battleLightmask);
       }
     }
   };
 
-  function BattleLightmask() {
-    this.initialize.apply(this, arguments);
-  }
+  function BattleLightmask() { this.initialize.apply(this, arguments); }
 
   BattleLightmask.prototype = Object.create(PIXI.Container.prototype);
   BattleLightmask.prototype.constructor = BattleLightmask;
-
   BattleLightmask.prototype.initialize = function () {
     PIXI.Container.call(this);
     this._width = Graphics.width;
@@ -2331,21 +2483,17 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
     this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.multiply, PIXI.BLEND_MODES.MULTIPLY);
     this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.additive, PIXI.BLEND_MODES.ADD);
 
-    this._maskBitmaps.multiply.fillRect(0, 0, maxX + lightMaskPadding, maxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, maxX + lightMaskPadding, maxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
-    let redhex = $gameTemp._MapTint.substring(1, 3);
-    let greenhex = $gameTemp._MapTint.substring(3, 5);
-    let bluehex = $gameTemp._MapTint.substring(5);
-    let red = parseInt(redhex, 16);
-    let green = parseInt(greenhex, 16);
-    let blue = parseInt(bluehex, 16);
-    let color = red + green + blue;
-    if (color < 200 && red < 66 && green < 66 && blue < 66) {
-      $gameTemp._MapTint = '#666666'; // Prevent the battle scene from being too dark.
-    }
-    $gameTemp._BattleTint = $$.daynightset ? $gameVariables.GetTintByTime() : $gameTemp._MapTint;
+    // if we came from a map, script is active, configuration authorizes using lighting effects,
+    // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
+    let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
+             $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
+            $gameVariables.GetTint() : new VRGBA("#ffffff");
 
+    // Set initial tint for battle
+    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {
@@ -2355,83 +2503,35 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       $$.tintbattle(data, true);
     }
 
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, $gameTemp._BattleTint);
-    $gameTemp._BattleTintSpeed = 0;
+    // Prevent the battle scene from being too dark
+    if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66)
+      c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
+
+    $gameTemp._BattleTintInitial = c;
+    $gameTemp._BattleTintTarget = ColorDelta.createTint(c);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
+    this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
+    this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };
 
   //@method _createBitmaps
-
   BattleLightmask.prototype._createBitmaps = function () {
     this._maskBitmaps = new Mask_Bitmaps(battleMaxX + lightMaskPadding, battleMaxY);
   };
 
   BattleLightmask.prototype.update = function () {
-    this._maskBitmaps.multiply.fillRect(0, 0, maxX + lightMaskPadding, maxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, maxX + lightMaskPadding, maxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
-    let color1 = $gameTemp._BattleTint;
-    if ($gameTemp._BattleTintSpeed > 0) {
-
-      $gameTemp._BattleTintTimer += 1;
-
-      let add = $gameTemp._BattleTintFade[0].equalsIC('a') ? 'a' : ''; // additive lighting
-      let c = hex2rgba($gameTemp._BattleTintFade);
-      let c2 = hex2rgba($gameTemp._BattleTint);
-
-      let stepR = (c2.r - c.r) / (60 * $gameTemp._BattleTintSpeed);
-      let stepG = (c2.g - c.g) / (60 * $gameTemp._BattleTintSpeed);
-      let stepB = (c2.b - c.b) / (60 * $gameTemp._BattleTintSpeed);
-      let stepA = (c2.a - c.a) / (60 * $gameTemp._BattleTintSpeed);
-
-      let r3 = Math.floor(c.r + (stepR * $gameTemp._BattleTintTimer));
-      let g3 = Math.floor(c.g + (stepG * $gameTemp._BattleTintTimer));
-      let b3 = Math.floor(c.b + (stepB * $gameTemp._BattleTintTimer));
-      let a3 = Math.floor(c.a + (stepA * $gameTemp._BattleTintTimer));
-      if (r3 < 0) { r3 = 0; }
-      if (g3 < 0) { g3 = 0; }
-      if (b3 < 0) { b3 = 0; }
-      if (a3 < 0) { a3 = 0; }
-      if (r3 > 255) { r3 = 255; }
-      if (g3 > 255) { g3 = 255; }
-      if (b3 > 255) { b3 = 255; }
-      if (a3 > 255) { a3 = 255; }
-      let reddone = false;
-      let greendone = false;
-      let bluedone = false;
-      let alphadone = false;
-      if (stepR >= 0 && r3 >= c2.r) {
-        reddone = true;
-      }
-      if (stepR <= 0 && r3 <= c2.r) {
-        reddone = true;
-      }
-      if (stepG >= 0 && g3 >= c2.g) {
-        greendone = true;
-      }
-      if (stepG <= 0 && g3 <= c2.g) {
-        greendone = true;
-      }
-      if (stepB >= 0 && b3 >= c2.b) {
-        bluedone = true;
-      }
-      if (stepB <= 0 && b3 <= c2.b) {
-        bluedone = true;
-      }
-      if (stepA >= 0 && a3 >= c2.a) {
-        alphadone = true;
-      }
-      if (stepA <= 0 && a3 <= c2.a) {
-        alphadone = true;
-      }
-      if (reddone == true && bluedone == true && greendone == true && alphadone) {
-        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
-        $gameTemp._BattleTintSpeed = 0;
-        $gameTemp._BattleTintTimer = 0;
-      }
-      color1 = add + rgba2hex(r3, g3, b3, a3);
-      $gameTemp._BattleTintFade = color1;
+    // Prevent the battle scene from being too dark
+    let c = $gameTemp._BattleTintTarget.next().get(); // reference
+    if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66) {
+      c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
+      $gameTemp._BattleTintTarget.current = c; // reassign if out of bounds. Shouldn't be possible.
     }
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, color1);
+
+    // Compute tint for next frame
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };
@@ -2460,12 +2560,9 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @method _removeSprite
    * @private
    */
-  BattleLightmask.prototype._removeSprite = function () {
-    this.removeChild(this._sprites.pop());
-  };
+  BattleLightmask.prototype._removeSprite = function () { this.removeChild(this._sprites.pop()); };
 
   // ALIASED Move event location => reload map.
-
   let Alias_Game_Interpreter_command203 = Game_Interpreter.prototype.command203;
   Game_Interpreter.prototype.command203 = function (params) { // API change in RMMZ
     Alias_Game_Interpreter_command203.call(this, params); // extra parameter is ignored by RMMV
@@ -2475,7 +2572,6 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
 
   // ALIASED FROM RPG OBJECTS TO ADD LIGHTING TO CONFIG MENU
-
   ConfigManager.cLighting = true;
 
   Object.defineProperty(ConfigManager, 'cLighting', {
@@ -2536,12 +2632,10 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
             event_stacknumber.push(i);
 
           }
-          // else if (note_command == "daynight") daynightset = true;
         }
       }
     }
     // *********************************** DAY NIGHT Setting **************************
-    $$.daynightset = false;
     let mapNote = $dataMap.note ? $dataMap.note.split("\n") : [];
     mapNote.forEach((note) => {
       /**
@@ -2551,12 +2645,17 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
       if (mapnote) {
         mapnote = mapnote.toLowerCase().trim();
         if ((/^daynight\b/i).test(mapnote)) {
-          $$.daynightset = true;
-          let dnspeed = note.match(/\d+/);
-          if (dnspeed) {
-            let daynightspeed = +dnspeed[0];
-            if (daynightspeed < 1) daynightspeed = 5000;
-            $gameVariables.SetDaynightSpeed(daynightspeed);
+          if (daynightCycleEnabled && !daynightTintEnabled) {
+            daynightTintEnabled = true;
+            let dnspeed = note.match(/\d+/);
+            if (dnspeed) {
+              let daynightspeed = +dnspeed[0];
+              if (daynightspeed < 1) daynightspeed = 5000;
+              $gameVariables.SetDaynightSpeed(daynightspeed);
+            }
+            let delta = ColorDelta.createTimeTint(false, 60 * $gameVariables.GetDaynightSpeed());
+            $gameVariables.SetTint(delta.get());
+            $gameVariables.SetTintTarget(delta);
           }
         }
         else if ((/^RegionFire\b/i).test(mapnote)) {
@@ -2589,12 +2688,9 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
           data.map(x => x.trim());
           if (typeof $$.mapBrightness !== "undefined") {
             let color = data[1];
-            let add = color[0].equalsIC('a') ? 'a' : ''; // additive lighting
-            let c = hex2rgba(color);
-            if (c.a == 255) {
-              c.a = $$.mapBrightness;
-            }
-            data[1] = add + rgba2hex(c.r, c.g, c.b, c.a);
+            let c = new VRGBA(color);
+            if (c.a == 255) c.a = $$.mapBrightness;
+            data[1] = c.toHex();
           }
           $$.tint(data);
         }
@@ -2605,15 +2701,12 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
         else if ((/^mapBrightness\b/i).test(mapnote)) {
           let brightness = note.match(/\d+/);
           if (brightness) {
-            let color = $gameVariables.GetTint();
-            if (color.equalsIC("#000000", "#00000000")) color = "#FFFFFF";
-            let add = color[0].equalsIC('a') ? 'a' : ''; // additive lighting
-            let c = hex2rgba(color);
+            let c = $gameVariables.GetTint();
+            if (!c.r && !c.g && !c.b) { c.r = 255; c.g = 255; c.b = 255; }
             let value = Math.max(0, Math.min(Number(brightness[0], 100)));
-            let alphaNum = Math.floor(value * 2.55);
-            let trueColor = add + rgba2hex(c.r, c.g, c.b, alphaNum);
-            $$.tint(["set", trueColor]);
-            $$.mapBrightness = alphaNum;
+            c.a = Math.floor(value * 2.55);
+            $$.tint(["set", c.toHex()]);
+            $$.mapBrightness = c.a;
           }
         }
       }
@@ -2690,25 +2783,26 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 
     // *********************** TURN SPECIFIC LIGHT ON *********************
     else if (isOn(args[0])) {
-      let lightid = +args[1];
-      let lightarray = $gameVariables.GetLightArray();
-      void (lightarray[lightid] ? lightarray[lightid][0] = true : lightarray[lightid] = [true, 'defaultcolor']);
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.enabled = true; }
     }
 
     // *********************** TURN SPECIFIC LIGHT OFF *********************
     else if (isOff(args[0])) {
-      let lightid = +args[1];
-      let lightarray = $gameVariables.GetLightArray();
-      void (lightarray[lightid] ? lightarray[lightid][0] = false : lightarray[lightid] = [false, 'defaultcolor']);
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.enabled = false; }
     }
 
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
-      let newcolor = args[2];
-      if (!newcolor || newcolor.equalsIC('defaultcolor')) newcolor = 'defaultcolor';
-      let lightid = +args[1];
-      let lightarray = $gameVariables.GetLightArray();
-      void (lightarray[lightid] ? lightarray[lightid][1] = newcolor : lightarray[lightid] = [false, newcolor]);
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for default (i.e. no passed color)
+    }
+
+    // *********************** SET CONDITIONAL LIGHT *********************
+    else if (args[0].equalsIC('cond')) {
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.parseTargetCondLightProps(args[2].split(/\s+/)); }
     }
 
     // **************************** RESET ALL SWITCHES ***********************
@@ -2723,19 +2817,13 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    */
   $$.tint = function (args) {
     let cmd = args[0].trim();
-    if (cmd.equalsIC('set', 'fade')) {
-      let currentColor = args[1];
-      let speed = +args[2] || 0;
-      if (speed == 0) $gameVariables.SetTint(args[1]);
-      $gameVariables.SetTintTarget(currentColor);
-      $gameVariables.SetTintSpeed(speed);
-    }
+    if (cmd.equalsIC('set', 'fade'))
+      $gameVariables.SetTintTarget(ColorDelta.createTint(new VRGBA(args[1]), 60 * (+args[2] || 0)));
     else if (cmd.equalsIC("reset", "daylight")) {
-      let currentColor = $gameVariables.GetTintByTime();
-      let speed = +args[1] || 0;
-      if (speed == 0) $gameVariables.SetTint(currentColor);
-      $gameVariables.SetTintTarget(currentColor);
-      $gameVariables.SetTintSpeed(speed);
+      let fadeDuration = 60 * (+args[1] || 0);
+      let delta = ColorDelta.createTimeTint(false, 0); // get the daynight tint for the current time
+      delta = ColorDelta.createTint(delta.get(), fadeDuration); // use tint for current time as target
+      $gameVariables.SetTintTarget(delta);
     }
   };
 
@@ -2744,35 +2832,12 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {String[]} args
    */
   $$.tintbattle = function (args, overrideInBattleCheck = false) {
-    let determineBattleTint = function (tintColor) {
-      if (!tintColor || tintColor.length < 7) {
-        return '#666666'; // Not an hex color string
-      }
-      let redhex = tintColor.substring(1, 3);
-      let greenhex = tintColor.substring(3, 5);
-      let bluehex = tintColor.substring(5);
-      let red = parseInt(redhex, 16);
-      let green = parseInt(greenhex, 16);
-      let blue = parseInt(bluehex, 16);
-      let color = red + green + blue;
-      if (color < 300 && red < 100 && green < 100 && blue < 100) { // Check for NaN values or too dark colors
-        return '#666666'; // The player have to see something
-      }
-      return tintColor;
-    };
-
     if ($gameParty.inBattle() || overrideInBattleCheck) {
       let cmd = args[0].trim();
-      if (cmd.equalsIC("set", 'fade')) {
-        $gameTemp._BattleTintFade = $gameTemp._BattleTint;
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = determineBattleTint(args[1]);
-        $gameTemp._BattleTintSpeed = +args[2] || 0;
-      }
+      if (cmd.equalsIC("set", 'fade'))
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));
       else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTimer = 0;
-        $gameTemp._BattleTint = $gameTemp._MapTint;
-        $gameTemp._BattleTintSpeed = +args[1] || 0;
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0)); // battle initial color
       }
     }
   };
@@ -2782,86 +2847,50 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
    * @param {String[]} args
    */
   $$.DayNight = function (args) {
-    let daynightspeed = $gameVariables.GetDaynightSpeed();
-    let daynighttimer = $gameVariables.GetDaynightTimer();     // timer = minutes * speed
-    let daynightcycle = $gameVariables.GetDaynightCycle();     // cycle = hours
-    let daynighthoursinday = $gameVariables.GetDaynightHoursinDay();   // 24
-    let daynightcolors = $gameVariables.GetDaynightColorArray();
-
-    if (args[0].equalsIC('speed')) {
-      daynightspeed = +args[1] || 5000;
-      $gameVariables.SetDaynightSpeed(daynightspeed);
-    }
-
-    function addTime(houradd, minuteadd) {
-      let daynightminutes = Math.floor(daynighttimer / daynightspeed);
-      daynightminutes = daynightminutes + minuteadd + 60*(daynightcycle + houradd);
-      daynightcycle = Math.trunc(daynightminutes/60)%daynighthoursinday;
-      daynightminutes = daynightminutes%60;
-
-      if (daynightminutes < 0) { daynightminutes += 60; daynightcycle--; }
-      if (daynightcycle < 0) { daynightcycle += daynighthoursinday; }
-      daynighttimer = daynightminutes * daynightspeed;
-
-      $$.saveTime(daynightcycle, daynightminutes);
-      $gameVariables.SetDaynightTimer(daynighttimer);     // timer = minutes * speed
-      $gameVariables.SetDaynightCycle(daynightcycle);     // cycle = hours
-    }
-
-    if (args[0].equalsIC('add')) {
-      addTime(+args[1], args.length > 2 ? +args[2] : 0);
-    }
-
-    else if (args[0].equalsIC('subtract')) {
-      addTime(+args[1]*-1, args.length > 2 ? +args[2]*-1 : 0);
-    }
-
-    else if (args[0].equalsIC('hour')) {
-      daynightcycle = Math.max(+args[1], 0) || 0;
-      let daynightminutes = Math.max(+args[2], 0) || 0;
-      daynighttimer = daynightminutes * daynightspeed;
-
-      if (daynightcycle >= daynighthoursinday) daynightcycle = daynighthoursinday - 1;
-
-      $$.saveTime(daynightcycle, daynightminutes);
-      $gameVariables.SetDaynightTimer(daynighttimer);     // timer = minutes * speed
-      $gameVariables.SetDaynightCycle(daynightcycle);     // cycle = hours
-    }
-
-    else if (args[0].equalsIC('hoursinday')) {
-      daynighthoursinday = Math.max(orNaN(+args[1], 0), 0);
-      if (daynighthoursinday > daynightcolors.length) {
-        let origLength = daynightcolors.length;
-        daynightcolors.length = daynighthoursinday; // more efficient than a for loop
-        daynightcolors.fill({ "color": "#ffffff", "isNight": false }, origLength);
+    let modTime = (hoursInDay, hours, minutes, seconds) => { // helper function to modify (set/add/subtract) time
+      hoursInDay = Math.max(orNaN(+hoursInDay, 24), 1); // minimum of 1, err results in 24
+      hours = orNaN(hours, 0);
+      minutes = orNaN(minutes, 0);
+      seconds = orNaN(seconds, 0);
+      seconds += hours * 60 * 60 + minutes * 60;
+      let totalSeconds = hoursInDay * 60 * 60;
+      while (seconds >= totalSeconds) seconds -= totalSeconds;
+      while (seconds < 0) seconds += totalSeconds;
+      gV.SetDaynightSeconds(seconds);
+      gV.SetDaynightHoursinDay(hoursInDay);
+      setTimeColorDelta();
+      $$.saveTime();
+    };
+    let setColorDelta = () => {
+      let delta = ColorDelta.createTint(gV.GetTint());
+      $gameVariables.SetTint(delta.get());
+      $gameVariables.SetTintTarget(delta);
+    };
+    let setTimeColorDelta = () => {
+      if (daynightCycleEnabled && daynightTintEnabled) {
+        let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
+        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed()); // whether to change tint instantly
+        $gameVariables.SetTint(delta.get());
+        $gameVariables.SetTintTarget(delta);
       }
-      $gameVariables.SetDaynightColorArray(daynightcolors);
-      $gameVariables.SetDaynightHoursinDay(daynighthoursinday);
-    }
-
-    else if (args[0].equalsIC('show')) {
-      $gameVariables._clShowTimeWindow = true;
-      $gameVariables._clShowTimeWindowSeconds = false;
-    }
-
-    else if (args[0].equalsIC('showseconds')) {
-      $gameVariables._clShowTimeWindow = true;
-      $gameVariables._clShowTimeWindowSeconds = true;
-    }
-
-    else if (args[0].equalsIC('hide')) {
-      $gameVariables._clShowTimeWindow = false;
-      $gameVariables._clShowTimeWindowSeconds = false;
-    }
-
-    else if (args[0].equalsIC('color')) {
-      let hour = (+args[1] || 0).clamp(0, daynighthoursinday - 1);
-      let hourcolor = args[2];
-      let isValidColor = isValidColorRegex.test(hourcolor.trim());
-      if (isValidColor) daynightcolors[hour].color = hourcolor;
-      $gameVariables.SetDaynightColorArray(daynightcolors);
-    }
-  };
+    };
+    let isCmd                      = (s)    => a[0].equalsIC(s);
+    let showTime                   = (w, s) => [gV._clShowTimeWindow, gV._clShowTimeWindowSeconds] = [w, s];
+    let [gV, a]                    = [$gameVariables, args];
+    let [secondsTotal, hoursInDay] = [gV.GetDaynightSeconds(), gV.GetDaynightHoursinDay()];
+    let [hours, minutes, seconds]  = [$$.hours(), $$.minutes(), $$.seconds()];
+    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint changes
+    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disabled daynight tint changes
+    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // daynight speed
+    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to current time
+    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // subtract from current time
+    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the current time
+    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day (must be >0, err = 24)
+    else if (isCmd('show'))        void showTime(true, false);                                          // show clock
+    else if (isCmd('showseconds')) void showTime(true, true);                                           // show clock seconds
+    else if (isCmd('hide'))        void showTime(false, false);                                         // hide clock
+    else if (isCmd('color'))       void (gV.SetTintAtHour(a[1], new VRGBA(a[2])), setTimeColorDelta()); // change hour color
+};
 
   let _Tilemap_drawShadow = Tilemap.prototype._drawShadow;
   Tilemap.prototype._drawShadow = function (bitmap, shadowBits, dx, dy) {
@@ -2886,7 +2915,6 @@ let isValidColorRegex = /(^[Aa]?#[0-9A-F]{6}$)|(^[Aa]?#[0-9A-F]{3}$)|(^[Aa]?#[0-
 Community.Lighting.distance = function (x1, y1, x2, y2) {
   return Math.abs(Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2)));
 };
-
 Game_Variables.prototype.SetActiveRadius = function (value) {
   this._Player_Light_Radius = orNaN(+value);
 };
@@ -2894,7 +2922,6 @@ Game_Variables.prototype.GetActiveRadius = function () {
   if (this._Player_Light_Radius >= 0) return this._Player_Light_Radius;
   return Number(Community.Lighting.parameters['Lights Active Radius']) || 0;
 };
-
 Game_Variables.prototype.GetFirstRun = function () {
   if (typeof this._Community_Lighting_FirstRun === 'undefined') {
     this._Community_Lighting_FirstRun = true;
@@ -2913,7 +2940,6 @@ Game_Variables.prototype.GetScriptActive = function () {
 Game_Variables.prototype.SetScriptActive = function (value) {
   this._Community_Lighting_ScriptActive = value;
 };
-
 Game_Variables.prototype.GetOldMapId = function () {
   if (typeof this._Community_Lighting_OldMapId === 'undefined') {
     this._Community_Lighting_OldMapId = 0;
@@ -2924,26 +2950,30 @@ Game_Variables.prototype.SetOldMapId = function (value) {
   this._Community_Lighting_OldMapId = value;
 };
 Game_Variables.prototype.SetTint = function (value) {
-  this._Community_Tint_Value = value;
+  this._Community_Tint_Value = value.clone();
 };
 Game_Variables.prototype.GetTint = function () {
-  return orNullish(this._Community_Tint_Value, '#000000');
+  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.empty();
+  return this._Community_Tint_Value.clone();
 };
-Game_Variables.prototype.GetTintByTime = function () {
-  let result = this.GetDaynightColorArray()[this.GetDaynightCycle()];
-  return result ? (result.color || "#000000") : "#000000";
+Game_Variables.prototype.SetTintAtHour = function (hour, color) {
+  let result = this.GetDaynightColorArray()[Math.max((+hour || 0), 0)];
+  if (color) result.color = color.clone(); // hour color
 };
-Game_Variables.prototype.SetTintTarget = function (value) {
-  this._Community_TintTarget_Value = value;
+Game_Variables.prototype.GetTintByTime = function (inc = 0) {
+  let hours = Community.Lighting.hours() + inc; // increment from current hour
+  let hoursinDay = this.GetDaynightHoursinDay();
+  while (hours >= hoursinDay) hours -= hoursinDay;
+  while (hours < 0) hours += hoursinDay;
+  let result = this.GetDaynightColorArray()[hours];
+  return result ? result.color.clone() : VRGBA.empty();
+};
+Game_Variables.prototype.SetTintTarget = function (delta) {
+  this._Community_TintTarget = delta;
 };
 Game_Variables.prototype.GetTintTarget = function () {
-  return orNullish(this._Community_TintTarget_Value, '#000000');
-};
-Game_Variables.prototype.SetTintSpeed = function (value) {
-  this._Community_TintSpeed_Value = orNaN(+value);
-};
-Game_Variables.prototype.GetTintSpeed = function () {
-  return orNullish(this._Community_TintSpeed_Value, 60);
+  if (!this._Community_TintTarget) this._Community_TintTarget = new ColorDelta(this.GetTint());
+  return this._Community_TintTarget;
 };
 Game_Variables.prototype.SetFlashlight = function (value) {
   this._Community_Lighting_Flashlight = value;
@@ -2972,12 +3002,12 @@ Game_Variables.prototype.GetFlashlightWidth = function () {
   let value = +this._Community_Lighting_FlashlightWidth;
   return value || 12; // not undefined, null, NaN, or 0
 };
-Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if invalid.
-  if(isValidColorRegex.test(value)) this._Community_Lighting_PlayerColor = value;
+Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if empty
+  if (value) this._Community_Lighting_PlayerColor = new VRGBA(value);
 };
 Game_Variables.prototype.GetPlayerColor = function () {
-  let value = this._Community_Lighting_PlayerColor;
-  return isValidColorRegex.test(value) ? value : '#FFFFFF';
+  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = new VRGBA("#ffffff");
+  return this._Community_Lighting_PlayerColor.clone();
 };
 Game_Variables.prototype.SetPlayerBrightness = function (value) { // don't set if invalid.
   if (value && value[0].equalsIC('b')) { // must exist and be prefixed with b or B
@@ -3003,7 +3033,7 @@ Game_Variables.prototype.SetRadiusTarget = function (value) {
 };
 Game_Variables.prototype.GetRadiusTarget = function () {
   if (this._Community_Lighting_RadiusTarget == null) {
-    return 150;
+    return this.GetRadius();
   } else {
     return this._Community_Lighting_RadiusTarget;
   }
@@ -3016,9 +3046,6 @@ Game_Variables.prototype.SetRadiusSpeed = function (value) { // must use AFTER s
 Game_Variables.prototype.GetRadiusSpeed = function () {
   return orNullish(this._Community_Lighting_RadiusSpeed, 0);
 };
-Game_Variables.prototype.SetDaynightColorArray = function (value) {
-  this._Community_Lighting_DayNightColorArray = value;
-};
 Game_Variables.prototype.GetDaynightColorArray = function () {
   let result = this._Community_Lighting_DayNightColorArray || Community.Lighting.getDayNightList();
   if (!result) {
@@ -3027,50 +3054,51 @@ Game_Variables.prototype.GetDaynightColorArray = function () {
       '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF',
       '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF',
       '#FFFFFF', '#FFFFFF', '#AAAAAA', '#666666',
-      '#000000', '#000000', '#000000', '#000000'].map(x => x = { "color": x, "isNight": false });
+      '#000000', '#000000', '#000000', '#000000'].map(x => x = { "color": new VRGBA(x), "isNight": false });
     this._Community_Lighting_DayNightColorArray = result;
   }
-  if (!this._Community_Lighting_DayNightColorArray) this.SetDaynightColorArray(result);
+  let hoursInDay = this.GetDaynightHoursinDay();
+  if (hoursInDay > result.length) { // lazy check bounds before returning and add colors if too small
+    let origLength = result.length;
+    result.length = hoursInDay;     // more efficient than a for loop
+    result.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+  }
+  this._Community_Lighting_DayNightColorArray = result; // assign reference
   return result;
 };
 Game_Variables.prototype.SetDaynightSpeed = function (value) {
-  this._Community_Lighting_DaynightSpeed = orNaN(+value);
+  this._Community_Lighting_DaynightSpeed = orNaN(+value, 5000);
 };
 Game_Variables.prototype.GetDaynightSpeed = function () {
   if (this._Community_Lighting_DaynightSpeed >= 0) return this._Community_Lighting_DaynightSpeed;
   return orNullish(Number(Community.Lighting.parameters['Daynight Initial Speed']), 10);
 };
-Game_Variables.prototype.SetDaynightCycle = function (value) {
-  this._Community_Lighting_DaynightCycle = orNaN(+value);
+Game_Variables.prototype.GetDaynightTick = function () {
+  return 60 / this.GetDaynightSpeed();
 };
-Game_Variables.prototype.GetDaynightCycle = function () {
-  return orNullish(this._Community_Lighting_DaynightCycle, Number(Community.Lighting.parameters['Daynight Initial Hour']), 0);
-
+Game_Variables.prototype.SetDaynightSeconds = function (value) {
+  this._Community_Lighting_DaynightSeconds = orNaN(+value);
 };
-Game_Variables.prototype.SetDaynightTimer = function (value) {
-  this._Community_Lighting_DaynightTimer = orNaN(+value);
-};
-Game_Variables.prototype.GetDaynightTimer = function () {
-  return orNullish(this._Community_Lighting_DaynightTimer, 0);
+Game_Variables.prototype.GetDaynightSeconds = function () {
+  return orNaN(+this._Community_Lighting_DaynightSeconds, 0);
 };
 Game_Variables.prototype.SetDaynightHoursinDay = function (value) {
   this._Community_Lighting_DaynightHoursinDay = orNaN(+value);
 };
 Game_Variables.prototype.GetDaynightHoursinDay = function () {
-  return orNullish(this._Community_Lighting_DaynightHoursinDay, 24);
+  return orNaN(this._Community_Lighting_DaynightHoursinDay, 24);
 };
-
 Game_Variables.prototype.SetFireRadius = function (value) {
   this._Community_Lighting_FireRadius = orNaN(+value);
 };
 Game_Variables.prototype.GetFireRadius = function () {
-  return orNullish(this._Community_Lighting_FireRadius, 7);
+  return orNaN(this._Community_Lighting_FireRadius, 7);
 };
 Game_Variables.prototype.SetFireColorshift = function (value) {
   this._Community_Lighting_FireColorshift = orNaN(+value);
 };
 Game_Variables.prototype.GetFireColorshift = function () {
-  return orNullish(this._Community_Lighting_FireColorshift, 10);
+  return orNaN(this._Community_Lighting_FireColorshift, 10);
 };
 Game_Variables.prototype.SetFire = function (value) {
   this._Community_Lighting_Fire = value;
@@ -3078,13 +3106,12 @@ Game_Variables.prototype.SetFire = function (value) {
 Game_Variables.prototype.GetFire = function () {
   return orNullish(this._Community_Lighting_Fire, false);
 };
-
 Game_Variables.prototype.SetLightArray = function (value) {
   this._Community_Lighting_LightArray = value;
 };
 Game_Variables.prototype.GetLightArray = function () {
   if (this._Community_Lighting_LightArray == null)
-    this._Community_Lighting_LightArray = {};
+    this._Community_Lighting_LightArray = { 0: {} };
   return this._Community_Lighting_LightArray;
 };
 Game_Variables.prototype.SetTileLightArray = function (value) {

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -1046,20 +1046,20 @@ class LightProperties {
     // properties with no suffix 'clear' the target
     properties.forEach((e) => {
       // clear checks (back to initial value for the given property)
-      if      (        e.equalsIC('t'))        this.transitionDuration = 0;
-      else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
-      else if (        e.equalsIC('#'))        this.color      = void (0);
-      else if (        e.equalsIC('a#'))       this.color      = void (0);
-      else if (        e.equalsIC('e'))        this.enable     = void (0);
-      else if (        e.equalsIC('b'))        this.brightness = void (0);
-      else if (        e.equalsIC('x'))        this.xOffset    = void (0);
-      else if (        e.equalsIC('y'))        this.yOffset    = void (0);
-      else if (isOL && e.equalsIC('r'))        this.radius     = void (0);
-      else if (isFL && e.equalsIC('l'))        this.beamLength = void (0);
-      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void (0);
-      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void (0);
+      if      (        e.equalsIC('t'))  { this.transitionDuration = 0; return; }
+      else if (        e.equalsIC('p'))  { this.pauseDuration      = 0; return; }
+      else if (        e.equalsIC('#'))  { this.color      = void (0); return; }
+      else if (        e.equalsIC('a#')) { this.color      = void (0); return; }
+      else if (        e.equalsIC('e'))  { this.enable     = void (0); return; }
+      else if (        e.equalsIC('b'))  { this.brightness = void (0); return; }
+      else if (        e.equalsIC('x'))  { this.xOffset    = void (0); return; }
+      else if (        e.equalsIC('y'))  { this.yOffset    = void (0); return; }
+      else if (isOL && e.equalsIC('r'))  { this.radius     = void (0); return; }
+      else if (isFL && e.equalsIC('l'))  { this.beamLength = void (0); return; }
+      else if (isFL && e.equalsIC('w'))  { this.beamWidth  = void (0); return; }
+      else if (isFL && e.equalsIC('a'))  { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('+a')) { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('-a')) { this.clockwise  = this.direction = void (0); return; }
 
       // parse suffix (individual & random ranges)
       let suffix, rand = (min, max) => Math.random() * (max - min) + min;
@@ -1667,7 +1667,7 @@ class ColorDelta {
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
       this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
-      this._cl.enable        = orBoolean(this._cl.enable, true);
+      this._cl.enable        = orBoolean(this._cl.enable, this._cl.id ? false : true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
       this._cl.id            = orNullish(this._cl.id, 0); // Alphanumeric

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -307,16 +307,19 @@ Imported[Community.Lighting.name] = true;
 * Events
 * --------------------------------------------------------------------------
 * Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
-*               that will be cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
-*               fadeDuration and growRadius are optional argument used to transition between colors
-*               and radius sizes over the provided cycle interval. If growRadius is not provided
-*               the default radius is used for the given color. In Terrax Lighting, there was a hard
-*               limit of 4, but now you can use as many as you want. [optional]
+* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+*               through before repeating from the beginning. See the examples below for usage.
+*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+*               To cycle any light property or for fade transitions, use the cycleProps
+*               format instead. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
 * - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
@@ -329,40 +332,43 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not begin with 'd', 'x' or 'y' otherwise
-*               they will be mistaken for one of the previous optional parameters.
+*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
+*               where N is a number otherwise they will be mistaken for one of the previous
+*               optional parameters.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
 * Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
-*             grow_bw tuples to follow that will be cycled through before repeating
-*             from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
-*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
-*             transition between colors and beam lengths & widths over the provided
-*             cycle interval. If grow_bl or grow_bw are not provided, the default
-*             length or width is used for the given color. There's no limit to how
-*             many colors can be cycled. [optional]
-* - color     #ffffff, #ff0000, etc
-* - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
-* - day       Sets the event's light to only show during the day [optional]
-* - night     Sets the event's light to only show during night time [optional]
-* - sdir:     Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*             Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:    Forced direction in degrees (optional): must be preceded by "A". If
-*             omitted, sdir is used. [optional]
-* - x         x[offset] Work the same as regular light [optional]
-* - y         y[offset] [optional]
-* - id        1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*             These should not begin with 'a', 'd', 'x' or 'y' otherwise
-*             they will be mistaken for one of the previous optional parameters.
+* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
+* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+*               through before repeating from the beginning. See the examples below for usage.
+*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+*               To cycle any light property or for fade transitions, use the cycleProps
+*               format instead. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
+* - color       #ffffff, #ff0000, etc
+* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - day         Sets the event's light to only show during the day [optional]
+* - night       Sets the event's light to only show during night time [optional]
+* - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
+*               Can be preceded by "D", so D4.  If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               omitted, sdir is used. [optional]
+* - x           x[offset] Work the same as regular light [optional]
+* - y           y[offset] [optional]
+* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
+*               where N is a number otherwise they will be mistaken for one of the previous
+*               optional parameters.
 *
 * Example note tags:
 *
@@ -370,12 +376,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
+* <cl: light 300 {#ff0000 p15} {#ffff00 p15} {#00ff00 p15} {#00ffff p15} {#0000ff p15}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* <cl: light 300 {#ff0000 t30 p60} {#ffff00 t30 p60} {#00ff00 t30 p60} {#00ffff t30 p60}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
-* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* <cl: light {#ff0000 t30 p60 r250} {#ffff00 t30 p60 r300} {#00ff00 t30 p60 r250} {#00ffff t30 p60 r300}>
 * Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
 * and transitions to the next color and size over 60 frames.
 *
@@ -386,9 +393,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
-* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
+* <cl: Flashlight l8 w12 #ff0000 on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
+*
+* <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15>
+* <cl: Flashlight l8 w12 {#f00 p15} {#ff0 p15} {#0f0 p15}>
+* Creates a flashlight beam that rotates every 15 frames.
 *
 * --------------------------------------------------------------------------
 * Additive Lighting Effects
@@ -397,12 +408,54 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 cycle a#990000 15 a#999900 15 a#009900 15 a#009999 15 a#000099 15>
+* <cl: light 300 {a#990000 t15} {a#999900 t15} {a#009900 t15} {a#009999 t15} {a#000099 t15}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
 * Creates a red volumetric flashlight beam with id asdf which can be turned on or off
 * via plugin commands.
+*
+* --------------------------------------------------------------------------
+* Conditional Lighting
+* --------------------------------------------------------------------------
+* Conditional Lighting allows light properties to be changed either cyclically or
+* dynamically over time via properties that consist of a prefix followed by a property
+* value. This is useful for creating any number of transitional lighting effects.
+*
+* The properties are supported in light tags or via the 'light cond' command. Light tags
+* support any number of light properties wrapped in {} brackets See the example note tags
+* above.
+*
+* The 'light cond' command allows for conditional lights to be dynamically changed on demand.
+* See the Plugin Commands section for more details.
+*
+* The following chart shows all supported properties:
+* --------------------------------------------------------------------------------------------------------------------
+* |   Property     |  Prefix   |        Format           | Examples          | Description                            |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     pause      |     p     |           pN            |    p0, p1, p20    | time period in cycles to pause after   |
+* |    duration    |           |                         |                   | transitioning for cycling lights       |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   transition   |     t     |           tN            |    t0, t1, t30    | time period to transition the          |
+* |    duration    |           |                         |                   | specified properties over              |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     color      |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | a#FFEEDD, #ffeedd | color or additive color                |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     angle      | a, +a, -a |       <a|+a|-a>N        |  a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |                |           |                         |                   | clockwise, '-' moves counterclockwise  |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   brightness   |     b     |           bN            |    b0, b1, b5     | brightness                             |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    x offset    |     x     |           xN            |     x2, x-2       | x offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    y offset    |     y     |           yN            |     y2, y-2       | y offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     radius     |     r     |           rN            |    r50, r150      | light radius                           |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam length  |     l     |           lN            |   l8, l9, l10     | flashlight beam length                 |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam width   |     w     |           wN            |  w12, w13, w14    | flashlight beam width                  |
+* --------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
 * Easy hex color references
@@ -484,6 +537,13 @@ Imported[Community.Lighting.name] = true;
 *
 * Light off id
 * - Turn off light with matching id number
+*
+* Light cond id [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+* - transitions a conditional light to the specified properties over the the given
+* - time period in cycles. Supported propreties are color, flashlight angle (a),
+* - brightness (b), x offset (x), y offset (y), radius (r), flashlight beam length (l),
+* - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
+* - ignored. See the Conditional Light section for more detail on each property.
 *
 * Light color id c
 * - Change the color (c) of lightsource with id (id)
@@ -659,16 +719,17 @@ Imported[Community.Lighting.name] = true;
 * ....where # is the max distance you want in tiles.
 */
 
-Number.prototype.is           = function (...a) { return a.includes(Number(this)); };
-Number.prototype.inRange      = function (min, max) { return this >= min && this <= max; };
-String.prototype.equalsIC     = function (...a) { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function (s) { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Math.min(...a) : Math.max(...a); }; // min if positive
+const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
+const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
+
+Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
+String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
-
-let cmpFloat = (x, y) => Math.abs(x - y) < 1e-3; // custom epsilon
 
 function orBoolean(...a) {
   for (let i = 0; i < a.length; i++) {
@@ -681,6 +742,85 @@ function orBoolean(...a) {
 }
 function orNullish(...a) { for (let i = 0; i < a.length; i++) if (a[i] != null) return a[i]; }
 function orNaN(...a)     { for (let i = 0; i < a.length; i++) if (!isNaN(a[i])) return a[i]; }
+
+let isOn         = (x) => x.toLowerCase() === "on";
+let isOff        = (x) => x.toLowerCase() === "off";
+let isActivate   = (x) => x.toLowerCase() === "activate";
+let isDeactivate = (x) => x.toLowerCase() === "deactivate";
+
+// Map community light directions to polar angles (360 degrees)
+const CLDirectionMap = {
+  0: undefined,       // auto
+  1: 3 * Math.PI / 2, // up
+  2: 2 * Math.PI,     // right
+  3: Math.PI / 2,     // down
+  4: Math.PI          // left
+};
+
+// Map RM directions to polar angles (360 degrees)
+const RMDirectionMap = {
+  1: 3 * Math.PI / 4, // down-left
+  2: Math.PI / 2,     // down
+  3: Math.PI / 4,     // down-right
+  4: Math.PI,         // left
+  6: 2 * Math.PI,     // right
+  7: 5 * Math.PI / 4, // up-left
+  8: 3 * Math.PI / 2, // up
+  9: 7 * Math.PI / 4  // up-right
+};
+
+const TileType = {
+  Terrain: 1, terrain: 1, 1: 1,
+  Region:  2, region:  2, 2: 2
+};
+
+const LightType = {
+  Light     : 1, light     : 1, 1: 1,
+  Fire      : 2, fire      : 2, 2: 2,
+  Flashlight: 3, flashlight: 3, 3: 3,
+  Glow      : 4, glow      : 4, 4: 4
+};
+
+const TileLightType = {
+  tilelight:   [TileType.Terrain, LightType.Light],
+  tilefire:    [TileType.Terrain, LightType.Fire],
+  tileglow:    [TileType.Terrain, LightType.Glow],
+  regionlight: [TileType.Region,  LightType.Light],
+  regionfire:  [TileType.Region,  LightType.Fire],
+  regionglow:  [TileType.Region,  LightType.Glow],
+};
+
+const TileBlockType = {
+  tileblock:   TileType.Terrain,
+  regionblock: TileType.Region
+};
+
+class TileLight {
+  constructor(tileType, lightType, id, onoff, color, radius, brightness) {
+    this.tileType   = TileType[tileType];
+    this.lightType  = LightType[lightType];
+    this.id         = +id || 0;
+    this.enabled    = isOn(onoff);
+    this.color      = new VRGBA(color);
+    this.radius     = +radius || 0;
+    this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) ||
+                      Community.Lighting.defaultBrightness || 0;
+  }
+}
+
+class TileBlock {
+  constructor(tileType, id, onoff, color, shape, xOffset, yOffset, blockWidth, blockHeight) {
+    this.tileType    = TileType[tileType];
+    this.id          = +id || 0;
+    this.enabled     = isOn(onoff);
+    this.color       = new VRGBA(color);
+    this.shape       = +shape || 0;
+    this.xOffset     = +xOffset || 0;
+    this.yOffset     = +yOffset || 0;
+    this.blockWidth  = +blockWidth || 0;
+    this.blockHeight = +blockHeight || 0;
+  }
+}
 
 const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive lighting
 
@@ -695,18 +835,18 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
-/** Class to handle volumetric/additive coloring with rgba colors uniformly.
- *  Additive coloring prefixes an 'a' on a normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
+/** Class to handle volumetric/additive coloring with rgba colors uniformly. Additive coloring prefixes an 'a' on a
+ *  normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
  */
 class VRGBA {
   /**
-   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a hex String
-   * can be passed with an optional default alternative Hex string, or another VRGBA object can be passed to create a clone.
+   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a
+   * hex String can be passed with an optional default alternative Hex string which is used in case of parsing failure.
    * @param {String|Boolean|VRGBA} vOrHex     - Boolean representing the additive component, or
    *                                            String representing the hex color, or
    *                                            other VRGBA object to clone.
    * @param {String|Number}        rOrDefault - Number representing the red component, or
-   *                                            String representing a default hex string in case the provided one cannot be parsed.
+   *                                            String representing a default hex string.
    * @param {null|Number}          g          - Number representing the green component.
    * @param {null|Number}          b          - Number representing the blue component.
    * @param {null|Number}          a          - Number representing the alpha component.
@@ -757,26 +897,15 @@ class VRGBA {
   set(that) { for (let k in that) if (this[k] != null) this[k] = that[k]; }
 
   /**
-   * Compares this Object to that Object and returns true if the v, r, g, b, and a properties are equal; otherwise false.
-   * @param {VRGBA} that
-   * @returns {Boolean}
-   */
-  equals(that) { // fastest non-exactness comparison -- only checks v, r, g, b, a properties
-    let [a, b] = [this, that];
-    if (b && cmpFloat(a.v, b.v) && cmpFloat(a.r, b.r) && cmpFloat(a.g, b.g) && cmpFloat(a.b, b.b) && cmpFloat(a.a, b.a))
-      return true;
-    return false;
-  }
-
-  /**
    * Adds together the r, g, and b properties and returns the result.
    * @returns {Number}
    */
   magnitude() { return this.r + this.g + this.b; }
 
   /**
-   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String. If invalid, a default
-   * value of "#000000ff" is returned. If either provided String is valid, it will be returned as an 'a#rrggbbaa' formatted color hex String.
+   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String.
+   * If invalid, a default value of "#000000ff" is returned. If either provided String is valid, it will be returned
+   * as an 'a#rrggbbaa' formatted color hex String.
    * @param {String} hex
    * @param {String} alt
    * @returns {String}
@@ -796,9 +925,10 @@ class VRGBA {
   }
 
   /**
-   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the hex is additive or not.
-   * The setWebSafe parameter is used to to strip the additive property (v) so that the resulting color can be used with Canvas APIs. An
-   * override Object can be provided to override the existing v, r, g, b, or a properties in the output.
+   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the
+   * hex is additive or not. The setWebSafe parameter is used to to strip the additive property (v) so that the
+   * resulting color can be used with Canvas APIs. An override Object can be provided to override the existing v, r, g,
+   * b, or a properties in the output.
    * @param {Boolean} setWebSafe
    * @param {VRGBA} override
    * @returns {String}
@@ -827,31 +957,37 @@ class VRGBA {
 }
 
 /**
- * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability to compute deltas
- * between the current parameter values and the target values, and allows for current values to be extracted.
+ * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability
+ * to compute deltas between the current parameter values and the target values, and allows for current values to be
+ * extracted.
  **/
 class ConditionalLight {
   /**
    * Creates a ConditionalLight object with the provided parameters
-   * @param {VRGBA}  color
-   * @param {Number} direction
-   * @param {Number} brightness
-   * @param {Number} xOffset
-   * @param {Number} yOffset
-   * @param {Number} radius
-   * @param {Number} beamLength
-   * @param {Number} beamWidth
+   * @param {LightType} type
+   * @param {VRGBA}     currentColor
+   * @param {Number}    currentDirection
+   * @param {Number}    currentBrightness
+   * @param {Number}    currentXOffset
+   * @param {Number}    currentYOffset
+   * @param {Number}    currentRadius
+   * @param {Number}    currentBeamLength
+   * @param {Number}    currentBeamWidth
    **/
-  constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
+              currentBeamLength, currentBeamWidth) {
     if (arguments.length == 0) return;
-    this.color      = color;
-    this.direction  = direction;
-    this.brightness = brightness;
-    this.xOffset    = xOffset;
-    this.yOffset    = yOffset;
-    this.radius     = radius;
-    this.beamLength = beamLength;
-    this.beamWidth  = beamWidth;
+    this.transitionDuration = 0;
+    this.pauseDuration      = 0;
+    this.type               = type;
+    this.currentColor       = currentColor;
+    this.currentDirection   = this.isFlashlight() ? currentDirection  : void(0);
+    this.currentBrightness  = currentBrightness;
+    this.currentXOffset     = currentXOffset;
+    this.currentYOffset     = currentYOffset;
+    this.currentRadius      = this.isOtherLight() ? currentRadius     : void(0);
+    this.currentBeamLength  = this.isFlashlight() ? currentBeamLength : void(0);
+    this.currentBeamWidth   = this.isFlashlight() ? currentBeamWidth  : void(0);
   }
 
   /**
@@ -860,89 +996,162 @@ class ConditionalLight {
    **/
   clone() {
     let that = new ConditionalLight();
-    // clone properties
-    if (this.color      != null) that.color      = this.color.clone();
-    if (this.direction  != null) that.direction  = this.direction;
-    if (this.brightness != null) that.brightness = this.brightness;
-    if (this.xOffset    != null) that.xOffset    = this.xOffset;
-    if (this.yOffset    != null) that.yOffset    = this.yOffset;
-    if (this.radius     != null) that.radius     = this.radius;
-    if (this.beamLength != null) that.beamLength = this.beamLength;
-    if (this.beamWidth  != null) that.beamWidth  = this.beamWidth;
+    // clone durations
+    if (this.transitionDuration != null) that.transitionDuration = this.transitionDuration;
+    if (this.pauseDuration      != null) that.pauseDuration      = this.pauseDuration;
+    // clone type
+    if (this.type               != null) that.type               = this.type;
+    // clone currents
+    if (this.currentColor       != null) that.currentColor       = this.currentColor.clone();
+    if (this.currentDirection   != null) that.currentDirection   = this.currentDirection;
+    if (this.currentBrightness  != null) that.currentBrightness  = this.currentBrightness;
+    if (this.currentXOffset     != null) that.currentXOffset     = this.currentXOffset;
+    if (this.currentYOffset     != null) that.currentYOffset     = this.currentYOffset;
+    if (this.currentRadius      != null) that.currentRadius      = this.currentRadius;
+    if (this.currentBeamLength  != null) that.currentBeamLength  = this.currentBeamLength;
+    if (this.currentBeamWidth   != null) that.currentBeamWidth   = this.currentBeamWidth;
+    // clone targets
+    if (this.targetColor        != null) that.targetColor        = this.targetColor.clone();
+    if (this.targetDirection    != null) that.targetDirection    = this.targetDirection;
+    if (this.targetBrightness   != null) that.targetBrightness   = this.targetBrightness;
+    if (this.targetXOffset      != null) that.targetXOffset      = this.targetXOffset;
+    if (this.targetYOffset      != null) that.targetYOffset      = this.targetYOffset;
+    if (this.targetRadius       != null) that.targetRadius       = this.targetRadius;
+    if (this.targetBeamLength   != null) that.targetBeamLength   = this.targetBeamLength;
+    if (this.targetBeamWidth    != null) that.targetBeamWidth    = this.targetBeamWidth;
     // clone deltas
-    if (this.colorDelta      != null) that.colorDelta      = this.colorDelta     .clone();
-    if (this.directionDelta  != null) that.directionDelta  = this.directionDelta .clone();
-    if (this.brightnessDelta != null) that.brightnessDelta = this.brightnessDelta.clone();
-    if (this.xOffsetDelta    != null) that.xOffsetDelta    = this.xOffsetDelta   .clone();
-    if (this.yOffsetDelta    != null) that.yOffsetDelta    = this.yOffsetDelta   .clone();
-    if (this.radiusDelta     != null) that.radiusDelta     = this.radiusDelta    .clone();
-    if (this.beamLengthDelta != null) that.beamLengthDelta = this.beamLengthDelta.clone();
-    if (this.beamWidthDelta  != null) that.beamWidthDelta  = this.beamWidthDelta .clone();
+    if (this.deltaColor         != null) that.deltaColor         = this.deltaColor     .clone();
+    if (this.deltaDirection     != null) that.deltaDirection     = this.deltaDirection .clone();
+    if (this.deltaBrightness    != null) that.deltaBrightness    = this.deltaBrightness.clone();
+    if (this.deltaXOffset       != null) that.deltaXOffset       = this.deltaXOffset   .clone();
+    if (this.deltaYOffset       != null) that.deltaYOffset       = this.deltaYOffset   .clone();
+    if (this.deltaRadius        != null) that.deltaRadius        = this.deltaRadius    .clone();
+    if (this.deltaBeamLength    != null) that.deltaBeamLength    = this.deltaBeamLength.clone();
+    if (this.deltaBeamWidth     != null) that.deltaBeamWidth     = this.deltaBeamWidth .clone();
     return that;
   }
 
   /**
-   * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
-   * @param {Number} fadeDuration
-   * @param {Number} pauseDuration
-   * @param {VRGBA}  tColor
-   * @param {Number} tDirection
-   * @param {Number} tBrightness
-   * @param {Number} tXOffset
-   * @param {Number} tYOffset
-   * @param {Number} tRadius
-   * @param {Number} tBeamLength
-   * @param {Number} tBeamWidth
+   * Returns true if the light type is a flashlight; otherwise false.
    */
-  setupTargets(fadeDuration, pauseDuration, tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
-    if (this.color      != null) this.colorDelta      = ColorDelta.createLight(this.color,  tColor,      fadeDuration, pauseDuration);
-    if (this.direction  != null) this.directionDelta  = NumberDelta.create(this.direction,  tDirection,  fadeDuration);
-    if (this.brightness != null) this.brightnessDelta = NumberDelta.create(this.brightness, tBrightness, fadeDuration);
-    if (this.xOffset    != null) this.xOffsetDelta    = NumberDelta.create(this.xOffset,    tXOffset,    fadeDuration);
-    if (this.yOffset    != null) this.yOffsetDelta    = NumberDelta.create(this.yOffset,    tYOffset,    fadeDuration);
-    if (this.radius     != null) this.radiusDelta     = NumberDelta.create(this.radius,     tRadius,     fadeDuration);
-    if (this.beamLength != null) this.beamLengthDelta = NumberDelta.create(this.beamLength, tBeamLength, fadeDuration);
-    if (this.beamWidth  != null) this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  tBeamWidth,  fadeDuration);
+  isFlashlight() { return this.type.is(LightType.Flashlight); }
+
+  /**
+   * Returns true if the light type is light, fire, or glow; otherwise false.
+   */
+  isOtherLight() { return this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
+
+  /**
+   * Sets up all supported targets.
+   * @param {VRGBA}  targetColor
+   * @param {Number} targetDirection
+   * @param {Number} targetBrightness
+   * @param {Number} targetXOffset
+   * @param {Number} targetYOffset
+   * @param {Number} targetRadius
+   * @param {Number} targetBeamLength
+   * @param {Number} targetBeamWidth
+   */
+  setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
+             targetBeamLength, targetBeamWidth) {
+    if (targetColor       != null) this.targetColor      = targetColor;
+    if (targetDirection   != null) this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
+    if (targetBrightness  != null) this.targetBrightness = targetBrightness;
+    if (targetXOffset     != null) this.targetXOffset    = targetXOffset;
+    if (targetYOffset     != null) this.targetYOffset    = targetYOffset;
+    if (targetRadius      != null) this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
+    if (targetBeamLength  != null) this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
+    if (targetBeamWidth   != null) this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
   }
 
   /**
-   * Processes and sets current conditional light properties from a string array.
+   * Processes and sets target transition and pause duration properties from a string array.
    * @param {String[]} properties
    **/
-  parseCondLightProps(properties) {
-    properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.direction  = orNaN(Math.PI / 180 * +(e.slice(1)));
-      else if (e.startsWithIC('b'))  this.brightness = orNaN(+e.slice(1));
-      else if (e.startsWithIC('x'))  this.xOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('y'))  this.yOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('r'))  this.radius     = orNaN(+e.slice(1));
-      else if (e.startsWithIC('l'))  this.beamLength = orNaN(+e.slice(1));
-      else if (e.startsWithIC('w'))  this.beamWidth  = orNaN(+e.slice(1));
-    });
+  parseDurationProps(properties) {
+    this.transitionDuration = properties.find((e) => (e.startsWithIC('t')));
+    this.pauseDuration      = properties.find((e) => (e.startsWithIC('p')));
+    this.transitionDuration = this.transitionDuration ? +this.transitionDuration.slice(1) : 0;
+    this.pauseDuration      = this.pauseDuration      ? +this.pauseDuration.slice(1)      : 0;
   }
 
   /**
-   * Processes and sets target conditional light properties from a string array.
+   * Processes and sets current properties from a string array.
    * @param {String[]} properties
    **/
-  parseTargetCondLightProps(properties) {
-    let fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
-    let pauseDuration = properties.find((e) => (e.startsWithIC('p')));
-    fadeDuration      = fadeDuration ?  +fadeDuration.slice(1)  : 0;
-    pauseDuration     = pauseDuration ? +pauseDuration.slice(1) : 0;
+  parseCurrentProps(properties) {
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
-      else if (e.startsWithIC('a#')) this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
-      else if (e.startsWithIC('a'))  this.directionDelta  = NumberDelta.create(this.direction,  Math.PI / 180 * +(e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('b'))  this.brightnessDelta = NumberDelta.create(this.brightness, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('x'))  this.xOffsetDelta    = NumberDelta.create(this.xOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('y'))  this.yOffsetDelta    = NumberDelta.create(this.yOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('r'))  this.radiusDelta     = NumberDelta.create(this.radius,     orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('l'))  this.beamLengthDelta = NumberDelta.create(this.beamLength, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('w'))  this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  orNaN(+e.slice(1)), fadeDuration);
-    });
+      if      (                       e.startsWithIC('#'))  this.currentColor      = new VRGBA(e);
+      else if (                       e.startsWithIC('a#')) this.currentColor      = new VRGBA(e);
+      else if (this.isFlashlight() && e.startsWithIC('a'))  this.currentDirection  = M_PI_180 * orNaN(+e.slice(1), 0);
+      else if (this.isFlashlight() && e.startsWithIC('+a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
+      else if (this.isFlashlight() && e.startsWithIC('-a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
+      else if (                       e.startsWithIC('b'))  this.currentBrightness = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('x'))  this.currentXOffset    = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('y'))  this.currentYOffset    = orNaN(+e.slice(1));
+      else if (this.isOtherLight() && e.startsWithIC('r'))  this.currentRadius     = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('l'))  this.currentBeamLength = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('w'))  this.currentBeamWidth  = orNaN(+e.slice(1));
+    }, this);
+  }
+
+  /**
+   * Processes and sets target properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseTargetProps(properties) {
+    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
+
+    let normalizeClockwiseMovement = (target) => {
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
+      if (this.currentDirection > this.targetDirection) this.targetDirection += M_2PI; // clockwise normalize
+    };
+    let normalizeCounterClockwiseMovement = (target) => {
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
+      if (this.currentDirection < this.targetDirection) this.targetDirection -= M_2PI; // c-clockwise normalize
+    };
+    properties.forEach((e) => {
+      if      (                       e.startsWithIC('#'))  this.targetColor = new VRGBA(e);
+      else if (                       e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
+      else if (this.isFlashlight() && e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
+      else if (this.isFlashlight() && e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (this.isFlashlight() && e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (                       e.startsWithIC('b'))  this.targetBrightness = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('x'))  this.targetXOffset    = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('y'))  this.targetYOffset    = orNaN(+e.slice(1));
+      else if (this.isOtherLight() && e.startsWithIC('r'))  this.targetRadius     = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('l'))  this.targetBeamLength = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('w'))  this.targetBeamWidth  = orNaN(+e.slice(1));
+    }, this);
+  }
+
+  /**
+   * Create deltas from currents, targets, and transition duration.
+   **/
+  createDeltas() {
+    let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
+    let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
+    // assign deltas if current & targets exist
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.transitionDuration);
+    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.transitionDuration);
+    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.transitionDuration);
+    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.transitionDuration);
+    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.transitionDuration);
+    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.transitionDuration);
+    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.transitionDuration);
+    // assign new currents for existing deltas (to propagate currents for duration = 0)
+    if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
+    if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
+    if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.get();
+    if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .get();
+    if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .get();
+    if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .get();
+    if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.get();
+    if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .get();
   }
 
   /**
@@ -950,14 +1159,19 @@ class ConditionalLight {
    * @returns {this}
    */
   next() {
-    if (this.colorDelta      != null) this.color      = this.colorDelta     .next().get();
-    if (this.directionDelta  != null) this.direction  = this.directionDelta .next().get();
-    if (this.brightnessDelta != null) this.brightness = this.brightnessDelta.next().get();
-    if (this.xOffsetDelta    != null) this.xOffset    = this.xOffsetDelta   .next().get();
-    if (this.yOffsetDelta    != null) this.yOffset    = this.yOffsetDelta   .next().get();
-    if (this.radiusDelta     != null) this.radius     = this.radiusDelta    .next().get();
-    if (this.beamLengthDelta != null) this.beamLength = this.beamLengthDelta.next().get();
-    if (this.beamWidthDelta  != null) this.beamWidth  = this.beamWidthDelta .next().get();
+    if (this.finished()) return this;
+    if (this.transitionDuration > 0) { // only update if transition duration isn't 0 (finished)
+      if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
+      if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
+      if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
+      if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .next().get();
+      if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .next().get();
+      if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
+      if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
+      if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
+      this.transitionDuration--;
+    } else
+      this.pauseDuration--;
     return this;
   }
 
@@ -965,12 +1179,12 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() {
-    return this.colorDelta.finished();
-  }
+  finished() { return this.transitionDuration <= 0 && this.pauseDuration <= 0; }
 }
 
-/** Class representing individual number deltas for providing number changes over time at different speeds. **/
+/**
+ * Class representing individual number deltas for providing number changes over time at different speeds.
+ **/
 class NumberDelta {
   /**
    * Creates a number delta from the start number, target number, and duration.
@@ -981,8 +1195,9 @@ class NumberDelta {
    */
   constructor(start, target, duration) {
     if (arguments.length == 0) return;
-    [this.current, this.target, this.duration, this.lazyEquals, this.delta] =
-    [start,        target,      duration,      false,           (target - start) / duration];
+    let delta = target == start ? 0 : (target - start) / duration;
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta] = [start, target, duration, false, delta];
+    this.finished(); // check for duration = 0
   }
 
   /**
@@ -1003,17 +1218,17 @@ class NumberDelta {
    * @param {Number} duration
    * @returns {NumberDelta}
    */
-  static create(start, target, duration) { return new NumberDelta(start, target, duration, duration); }
+  static create(start, target, duration) { return new NumberDelta(start, target, duration); }
 
   /**
    * Computes the next delta number in between the current number and target number.
    * @returns {this}
    */
   next() {
-    if (this.equals()) return this; // lazy-short-circuit
+    if (this.finished()) return this; // lazy-short-circuit
+    if (this.current != this.target) this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
     this.duration -= 1;
-    this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
-    this.equals();
+    this.finished();
     return this;
   }
 
@@ -1027,7 +1242,7 @@ class NumberDelta {
    * Returns true if the current number is equal to the target number; otherwise false.
    * @returns {Boolean}
    */
-  equals() {
+  finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
     if ((this.lazyEquals = this.duration <= 0))
       return (this.current = this.target, true); // set cur to refer to target on match
@@ -1035,53 +1250,56 @@ class NumberDelta {
   }
 }
 
-/** Class representing a color delta for providing color changes over time at different speeds. **/
+/**
+ * Class representing a color delta for providing color changes over time at different speeds.
+ **/
 class ColorDelta {
   /**
-   * Create a color delta from the start color, target color, fade & on durations, and
+   * Create a color delta from the start color, target color, fade duration, and
    * whether to consider the remaining ticks or not for speed purposes.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
    * @param {Number} fadeDuration
-   * @param {Number} onDuration
    * @param {Number} useTicksRemaining
    * @returns {ColorDelta}
    */
-  constructor(start, target = start, fadeDuration = 0, onDuration = 0, useTicksRemaining = false) {
+  constructor(start, target = start, fadeDuration = 0, useTicksRemaining = false) {
     if (arguments.length == 0) return;
-    this.current     = start.clone();           // - deep copy
-    this.target      = target.clone();          // - deep copy
-    this.onDuration  = orNaN(onDuration, 0);    // - parse onDuration
-    this.lazyEquals  = false;                   // - true when current value == target value
-    fadeDuration     = orNaN(fadeDuration, 0);  // - use either the remaining time (of the hour) or total fade duration
-    fadeDuration    -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
-    this.delta       = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
-                                (this.target.r - this.current.r) / fadeDuration,
-                                (this.target.g - this.current.g) / fadeDuration,
-                                (this.target.b - this.current.b) / fadeDuration,
-                                (this.target.a - this.current.a) / fadeDuration);
+    this.current       = start.clone();           // - deep copy
+    this.target        = target.clone();          // - deep copy
+    this.fadeDuration  = orNaN(fadeDuration, 0);  // - use the remaining time (of the hour) or total fade duration
+    this.fadeDuration -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.lazyEqual     = false;                   // - true when current value == target value
+    this.delta         = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                  (this.target.r - this.current.r) / this.fadeDuration,
+                                  (this.target.g - this.current.g) / this.fadeDuration,
+                                  (this.target.b - this.current.b) / this.fadeDuration,
+                                  (this.target.a - this.current.a) / this.fadeDuration);
+    this.finished(); // check for duration = 0
   }
   /**
    * Creates a copy of the ColorDelta object.
    * @returns {ColorDelta}
    **/
   clone() {
-    let that = new ColorDelta();
-    [that.current,           that.target,         that.onDuration, that.lazyEquals, that.delta] =
-    [this.current.clone(),   this.target.clone(), this.onDuration, this.lazyEquals, this.delta.clone()];
+    let that = new  ColorDelta();
+    that.current      = this.current.clone();
+    that.target       = this.target.clone();
+    that.fadeDuration = this.fadeDuration;
+    that.lazyEquals   = this.lazyEquals;
+    that.delta        = this.delta.clone();
     return that;
   }
 
   /**
-   * Creates a light delta from the start color, target color, and fade & on durations.
+   * Creates a light delta from the start color, target color, and fade duration.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
    * @param {Number} fadeDuration
-   * @param {Number} onDuration
    * @returns {ColorDelta}
    */
-  static createLight(start, target, fadeDuration, onDuration) {
-    return new ColorDelta(start, target, fadeDuration, onDuration, false /* don't use remaining ticks */);
+  static create(start, target, fadeDuration) {
+    return new ColorDelta(start, target, fadeDuration, false /* don't use remaining ticks */);
   }
 
   /**
@@ -1090,7 +1308,9 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration, 0, false); }
+  static createTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration);
+  }
 
   /**
    * Creates a battle color delta from the current battle tint, target tint, and fade duration.
@@ -1098,7 +1318,9 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createBattleTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration, 0, false); }
+  static createBattleTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration);
+  }
 
   /**
    * Creates a time color delta from the current time and speed. useCurrentTint specifies whether to
@@ -1108,13 +1330,14 @@ class ColorDelta {
    * @returns {ColorDelta}
    */
   static createTimeTint(useCurrentTint = true) {
-    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
+    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed(); // fade duration
     if (useCurrentTint) { // delta should fade from current color to target
-      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, true);
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, true);
     } else {              // start color should be the color it would normally be at the given time
-      let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
-      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a ref speed to compute the start color
-      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, false);
+      let CL = Community.Lighting; // reference CL
+      let ticks    = fadeDuration == 0 ? CL.minutes() * 60 + CL.seconds() : CL.ticks();
+      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // dur = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration);
       delta.next(ticks); // get current color based off of ticks elapsed in hour
       return delta;
     }
@@ -1127,13 +1350,14 @@ class ColorDelta {
    * @returns {this}
    */
   next(scale = 1) {
-    if (this.equals()) return (this.onDuration = Math.max(this.onDuration - 1, 0), this); // subtract onDuration and lazy-short-circuit
-    this.current.v = this.delta.v;  // Compute next color step and clamp to target
-    this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
-    this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
-    this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
-    this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
-    if (this.equals()) this.onDuration = Math.max(this.onDuration - 1, 0); // check if done and if so subtract onDuration
+    if (this.finished()) return this; // lazy-short-circuit
+    let current = this.current, target = this.target, delta = this.delta; // reference
+    if(current.v != target.v) current.v = target.v;  // Compute next step & clamp to target, check to avoid recomputing
+    if(current.r != target.r) current.r = Math.minmax(delta.r > 0, current.r + scale * delta.r, target.r);
+    if(current.g != target.g) current.g = Math.minmax(delta.g > 0, current.g + scale * delta.g, target.g);
+    if(current.b != target.b) current.b = Math.minmax(delta.b > 0, current.b + scale * delta.b, target.b);
+    if(current.a != target.a) current.a = Math.minmax(delta.a > 0, current.a + scale * delta.a, target.a);
+    this.fadeDuration -= 1;
     return this;
   }
 
@@ -1144,101 +1368,17 @@ class ColorDelta {
   get() { return this.current.clone(); } // duplicate color so reference can't be messed with
 
   /**
-   * Returns true if the current color is equal to the target color; otherwise false.
+   * Returns true if the current color is equal to the target; otherwise false.
    * @returns {Boolean}
    */
-  equals() {
+  finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
-    if ((this.lazyEquals = this.current.equals(this.target)))
-      return (this.current = this.target, true); // set cur to refer to target on match
+    if ((this.lazyEquals = this.fadeDuration <= 0)) return (this.current = this.target, true);
     return false;
-  }
-
-  /**
-   * Returns true if the current color is equal to the target and on duration has been reached; otherwise false.
-   * @returns {Boolean}
-   */
-  finished() { return this.equals() && this.onDuration == 0; }
+   }
 }
 
 (function ($$) {
-  let isOn = (x) => x.toLowerCase() === "on";
-  let isOff = (x) => x.toLowerCase() === "off";
-  let isActivate = (x) => x.toLowerCase() === "activate";
-  let isDeactivate = (x) => x.toLowerCase() === "deactivate";
-
-  // Map community light directions to polar angles (360 degrees)
-  const CLDirectionMap = {
-    0: undefined,       // auto
-    1: 3 * Math.PI / 2, // up
-    2: 2 * Math.PI,     // right
-    3: Math.PI / 2,     // down
-    4: Math.PI          // left
-  };
-
-  // Map RM directions to polar angles (360 degrees)
-  const RMDirectionMap = {
-    1: 3 * Math.PI / 4, // down-left
-    2: Math.PI / 2,     // down
-    3: Math.PI / 4,     // down-right
-    4: Math.PI,         // left
-    6: 2 * Math.PI,     // right
-    7: 5 * Math.PI / 4, // up-left
-    8: 3 * Math.PI / 2, // up
-    9: 7 * Math.PI / 4  // up-right
-  };
-
-  const TileType = {
-    Terrain: 1, terrain: 1, 1: 1,
-    Region:  2, region:  2, 2: 2
-  };
-
-  const LightType = {
-    Light     : 1, light     : 1, 1: 1,
-    Fire      : 2, fire      : 2, 2: 2,
-    Flashlight: 3, flashlight: 3, 3: 3,
-    Glow      : 4, glow      : 4, 4: 4
-  };
-
-  const TileLightType = {
-    tilelight:   [TileType.Terrain,   LightType.Light],
-    tilefire:    [TileType.Terrain,   LightType.Fire],
-    tileglow:    [TileType.Terrain,   LightType.Glow],
-    regionlight: [TileType.Region, LightType.Light],
-    regionfire:  [TileType.Region, LightType.Fire],
-    regionglow:  [TileType.Region, LightType.Glow],
-  };
-
-  const TileBlockType = {
-    tileblock:   TileType.Terrain,
-    regionblock: TileType.Region
-  };
-
-  class TileLight {
-    constructor(tileType, lightType, id, onoff, color, radius, brightness) {
-      this.tileType   = TileType[tileType];
-      this.lightType  = LightType[lightType];
-      this.id         = +id || 0;
-      this.enabled    = isOn(onoff);
-      this.color      = new VRGBA(color);
-      this.radius     = +radius || 0;
-      this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) || $$.defaultBrightness || 0;
-    }
-  }
-
-  class TileBlock {
-    constructor(tileType, id, onoff, color, shape, xOffset, yOffset, blockWidth, blockHeight) {
-      this.tileType    = TileType[tileType];
-      this.id          = +id || 0;
-      this.enabled     = isOn(onoff);
-      this.color       = new VRGBA(color);
-      this.shape       = +shape || 0;
-      this.xOffset     = +xOffset || 0;
-      this.yOffset     = +yOffset || 0;
-      this.blockWidth  = +blockWidth || 0;
-      this.blockHeight = +blockHeight || 0;
-    }
-  }
 
   class Mask_Bitmaps {
     constructor(width, height) {
@@ -1256,22 +1396,22 @@ class ColorDelta {
   let light_tiles = [];
   let block_tiles = [];
 
-  let parameters = $$.parameters;
-  let lightMaskPadding = Number(parameters["Lightmask Padding"]) || 0;
-  let useSmootherLights = orBoolean(parameters['Use smoother lights'], false);
-  let light_event_required = orBoolean(parameters["Light event required"], false);
-  let triangular_flashlight = orBoolean(parameters["Triangular flashlight"], false);
-  let shift_lights_with_events = orBoolean(parameters['Shift lights with events'], false);
-  let player_radius = Number(parameters['Player radius']) || 0;
-  let reset_each_map = orBoolean(parameters['Reset Lights'], false);
-  let noteTagKey = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
-  let dayNightSaveSeconds = Number(parameters['Save DaynightSeconds']) || 0;
-  let dayNightSaveNight = Number(parameters["Save Night Switch"]) || 0;
-  let dayNightNoAutoshadow = orBoolean(parameters["No Autoshadow During Night"], false);
-  let hideAutoShadow = false;
-  let daynightCycleEnabled = orBoolean(parameters['Daynight Cycle'], true);
-  let daynightTintEnabled = false;
-  let dayNightList = (function (dayNight, nightHours) {
+  let parameters                = $$.parameters;
+  let lightMaskPadding          = +parameters["Lightmask Padding"] || 0;
+  let useSmootherLights         = orBoolean(parameters['Use smoother lights'], false);
+  let light_event_required      = orBoolean(parameters["Light event required"], false);
+  let triangular_flashlight     = orBoolean(parameters["Triangular flashlight"], false);
+  let shift_lights_with_events  = orBoolean(parameters['Shift lights with events'], false);
+  let player_radius             = +parameters['Player radius'] || 0;
+  let reset_each_map            = orBoolean(parameters['Reset Lights'], false);
+  let noteTagKey                = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
+  let dayNightSaveSeconds       = +parameters['Save DaynightSeconds'] || 0;
+  let dayNightSaveNight         = +parameters["Save Night Switch"] || 0;
+  let dayNightNoAutoshadow      = orBoolean(parameters["No Autoshadow During Night"], false);
+  let hideAutoShadow            = false;
+  let daynightCycleEnabled      = orBoolean(parameters['Daynight Cycle'], true);
+  let daynightTintEnabled       = false;
+  let dayNightList              = (function (dayNight, nightHours) {
     let result = [];
     try {
       dayNight = JSON.parse(dayNight);
@@ -1281,7 +1421,8 @@ class ColorDelta {
         result[i] = { "color": new VRGBA(dayNight[i]), "isNight": nightHours.contains(i) };
     }
     catch (e) {
-      console.log(`${Community.Lighting.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
+      let CL = Community.Lighting;
+      console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
       result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
     }
     return result;
@@ -1369,7 +1510,8 @@ class ColorDelta {
   $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
   $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
   $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
-  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
+  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() *
+                                $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
     if (showSeconds) result = result + ":" + $$.seconds().padZero(2);
@@ -1384,9 +1526,7 @@ class ColorDelta {
   * @returns {Boolean}
   */
   Game_Temp.prototype.testAndSet = function (index, value) {
-    if (this[index] && (this[index] == value ||
-       (this[index].equals && this[index].equals(value))))
-      return false;
+    if (this[index] && this[index] == value) return false;
     return (this[index] = value, true);
   };
 
@@ -1412,78 +1552,91 @@ class ColorDelta {
   Game_Event.prototype.initLightData = function () {
     this._lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
-    let CycleGroups = [];
-    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((CycleGroups.push(group.split(/\s+/)), '')));
+
+    // parse new cycle groups format within {} braces and extract from tag data for separate handling
+    // old cycle groups are parsed in tagData loop below and are converted to the new group format
+    let cycleGroups = [];
+    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((cycleGroups.push(group.split(/\s+/)), '')));
     tagData = tagData.split(/\s+/);
     this._clType = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._clType) {
-      let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
-      let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
-      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
-      let isUndef      = (x)       => x === undefined;
-      let hasCycle = false;
+      let isFL       = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
+      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
+      let isNul      = (e)       => e == null;
+      let isDayNight = (e)       => isEq(e, "night", "day");
+      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength = +(e.slice(1));
-        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth  = +(e.slice(1));
-        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      hasCycle           = true;
-        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor      = new VRGBA(e);
-        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff      = true;
-        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff      = false;
-        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch     = e;
-        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness = Number(+(e.slice(1)) / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = +(e.slice(1));
-        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = CLDirectionMap[+(e.slice(1))];
-        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection  = Math.PI / 180 * +(e.slice(1));
-        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset    = +(e.slice(1));
-        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset    = +(e.slice(1));
-        else if (           e.length > 0                   && isUndef(this._clId))         this._clId         = e;
+        let n = clip(e);
+        if      (!isFL() && !isNaN(+e)          && isNul(this._clRadius))     this._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamLength)) this._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l") && n  && isNul(this._clBeamLength)) this._clBeamLength = n;
+        else if (isFL()  && isPre(e, "w") && n  && isNul(this._clBeamWidth))  this._clBeamWidth  = n;
+        else if (           isEq(e, "cycle")    && isNul(this._clColor))      hasCycle           = true;
+        else if (           isPre(e, "#", "a#") && hasCycle)                  cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])   cycleGroups[cycleIndex].push('p' + e);
+        else if (           isPre(e, "#", "a#") && isNul(this._clColor))      this._clColor      = new VRGBA(e);
+        else if (           isOn(e)             && isNul(this._clOnOff))      this._clOnOff      = true;
+        else if (           isOff(e)            && isNul(this._clOnOff))      this._clOnOff      = false;
+        else if (           isDayNight(e)       && isNul(this._clSwitch))     this._clSwitch     = e;
+        else if (           isPre(e, "b") && n  && isNul(this._clBrightness)) this._clBrightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = n;
+        else if ( isFL() && !isNaN(+e)          && isNul(this._clDirection))  this._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = CLDirectionMap[n];
+        else if ( isFL() && isPre(e, "a") && n  && isNul(this._clDirection))  this._clDirection  = Math.PI / 180 * n;
+        else if (           isPre(e, "x") && n  && isNul(this._clXOffset))    this._clXOffset    = n;
+        else if (           isPre(e, "y") && n  && isNul(this._clYOffset))    this._clYOffset    = n;
+        else if (           e.length > 0        && isNul(this._clId))         this._clId         = e;
+        cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);
 
       // normalize parameters
-      this._clRadius     = this._clRadius || 0;
-      this._clColor      = orNullish(this._clColor, VRGBA.empty());
-      this._clBrightness = this._clBrightness || 0;
-      this._clDirection  = orNaN(this._clDirection, undefined); // must be undefined for later checks
-      this._clId         = this._clId || 0;
-      this._clBeamLength = this._clBeamLength || 0;
-      this._clBeamWidth  = this._clBeamWidth || 0;
-      this._clOnOff      = orBoolean(this._clOnOff, true);
-      this._clXOffset    = this._clXOffset || 0;
-      this._clYOffset    = this._clYOffset || 0;
-      this._clCycle      = this._clCycle || null;
+      this._clRadius        = orNaN(this._clRadius, 0);
+      this._clColor         = orNullish(this._clColor, VRGBA.empty());
+      this._clBrightness    = orNaN(this._clBrightness, 0);
+      this._clDirection     = orNaN(this._clDirection, undefined); // must be undefined for later checks
+      this._clId            = orNullish(this._clId, 0); // Alphanumeric
+      this._clBeamLength    = orNaN(this._clBeamLength, 0);
+      this._clBeamWidth     = orNaN(this._clBeamWidth, 0);
+      this._clOnOff         = orBoolean(this._clOnOff, true);
+      this._clXOffset       = orNaN(this._clXOffset, 0);
+      this._clYOffset       = orNaN(this._clYOffset, 0);
+      this._clCycle         = this._clCycle || null;
 
       // Process cycle parameters
-      if (hasCycle && CycleGroups.length) {             // check if tag included color cycling
-        this._clCycle = [];                             // only define if cycle exists
-        let t = this;                                   // refer to this as t
-        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight = new ConditionalLight(...args);  // create conditional light
-        CycleGroups.forEach((e, i, a) => {              // ------ loop each group
-          condLight = condLight.clone();                // - clone existing conditional light (inherit properties)
-          let n = a[++i < CycleGroups.length ? i : 0];  // - get next element
-          condLight.parseCondLightProps(e);             // - parse for new properties
-          condLight.parseTargetCondLightProps(n);       // - parse for target properties
-          this._clCycle.push(condLight);                // - push to list
-        }, this);                                       // ------
-        condLight = this._clCycle.shift();              // pop front
-        this._clCondLight = condLight.clone();          // clone it to be the current cond light delta
-        this._clCycle.push(condLight);                  // push original on back of list
+      if (cycleGroups.length) {                                       // check if tag included color cycling
+        this._clCycle = [];                                           // only define if cycle exists
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
+        let condLight = new ConditionalLight(this._clType, ...args);  // create cond light with initial properties
+        cycleGroups.forEach((e, i, a) => {                            // ------ loop each group
+          condLight = condLight.clone();                              // - clone existing light (inherit properties)
+          let n = a[++i < cycleGroups.length ? i : 0];                // - get next element
+          condLight.parseDurationProps(n);                            // - parse durations
+          condLight.parseCurrentProps(e);                             // - parse for new properties
+          if (i == cycleGroups.length)                                // - last group targets initial properties
+            condLight.setTargets(...args);                            // -- setup targets based off non-cycle properties
+          condLight.parseTargetProps(n);                              // - parse for cycle target properties
+          condLight.createDeltas();                                   // - compute deltas
+          this._clCycle.push(condLight);                              // - push to list
+        }, this);                                                     // ------
+        condLight = this._clCycle.shift();                            // pop front
+        this._clCondLight = condLight.clone();                        // clone it to be the current cond light delta
+        this._clCycle.push(condLight);                                // push original on back of list
       }
 
       // Process conditional lighting
-      if (this._clId) {                                 // check for a conditional lighting ID
-        let t = this;                                   // refer to this as t
-        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight  = new ConditionalLight(...args); // create conditional light
-        condLight.setupTargets(0, 0, ...args);          // create matching targets
-        condLight.next();                               // compute deltas (zeroes)
+      if (this._clId) {                                               // check for a conditional lighting ID
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
+        let condLight  = new ConditionalLight(this._clType, ...args); // create conditional light
+        condLight.setTargets(...args);                                // create matching targets
+        condLight.createDeltas();                                     // compute deltas (zeroes)
         $gameVariables.GetLightArray()[this._clId] = condLight;
-        t._clCondLight = condLight;
+        this._clCondLight = condLight;
       }
     }
   };
@@ -1505,20 +1658,20 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.radius, this._clRadius);
+    return orNullish(this._clCondLight.currentRadius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
     if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.color, this._clColor.clone());
+    return orNullish(this._clCondLight.currentColor, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.brightness, this._clBrightness);
+    return orNullish(this._clCondLight.currentBrightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.direction, this._clDirection);
+    return orNullish(this._clCondLight.currentDirection, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1526,24 +1679,25 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamLength, this._clBeamLength);
+    return orNullish(this._clCondLight.currentBeamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamWidth, this._clBeamWidth);
+    return orNullish(this._clCondLight.currentBeamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.xOffset, this._clXOffset);
+    return orNullish(this._clCondLight.currentXOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.yOffset, this._clYOffset);
+    return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
-    if (!this._clSwitch) return this._clOnOff;
-    return (this._clSwitch.equalsIC("night") &&  $$.isNight()) ||
-           (this._clSwitch.equalsIC("day")   && !$$.isNight());
+    if (!this._clSwitch) return orNullish(this._clCondLight.enabled, this._clOnOff);
+    return orNullish(this._clCondLight.enabled,
+                    (this._clSwitch.equalsIC("night") && $$.isNight()) ||
+                    (this._clSwitch.equalsIC("day")   && !$$.isNight()));
   };
   Game_Event.prototype.getLightCycle = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1581,8 +1735,9 @@ class ColorDelta {
     command = command.toLowerCase();
 
     const allCommands = {
-      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight', tilefire: 'addTileLight', regionfire: 'addTileLight',
-      tileglow: 'addTileLight', regionglow: 'addTileLight', tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
+      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight',
+      tilefire: 'addTileLight', regionfire: 'addTileLight', tileglow: 'addTileLight', regionglow: 'addTileLight',
+      tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
       script: 'scriptF', reload: 'reload', tintbattle: 'tintbattle'
     };
     const result = allCommands[command];
@@ -1590,36 +1745,36 @@ class ColorDelta {
   };
 
   if (isRMMZ()) { // RMMZ only command interface
-    let mapOnOff = (args) => args.enabled === "true" ? "on" : "off";
-    let tileType = (args) => (args.tileType === "terrain" ? "tile" : "region") + (args.lightType ? args.lightType : "block");
-    let tintType = (    ) => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  (args) => args.instant === "true" ? "instant" : "";
-    let tintMode = (args) => args.color ? "set" : "reset";
-    let mathMode = (args) => args.mode === "set" ? "hour" : args.mode; // set, add, or subtract.
-    let showMode = (args) => args.enabled.equalsIC("true") ? (args.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
-    let radMode  = (args) => +args.fadeSpeed ? "radiusgrow" : "radius";
+    let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
+    let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
+    let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
+    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let tintMode = a  => a.color ? "set" : "reset";
+    let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
+    let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
+    let radMode  = a  => +a.fadeSpeed ? "radiusgrow" : "radius";
 
-    let reg = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
-    let f = (cmd, args) => $gameMap._interpreter.communityLighting_Commands(cmd, args.filter(_ => _ !== "")); //command wrapper.
+    let r = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
+    let f = (c, a) => $gameMap._interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
 
-    reg("masterSwitch",       (a)  => f("script",     [mapOnOff(a)]));
-    reg("tileBlock",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.shape,          a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
-    reg("tileLight",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.radius,         a.brightness]));
-    reg("setTint",            (a)  => f(tintType(),   [tintMode(a),     a.color,         a.fadeSpeed]));
-    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a),     dayMode(a)]));
-    reg("setTimeSpeed",       (a)  => f("dayNight",   ["speed",         a.speed]));
-    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes,      dayMode(a)]));
-    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours,         dayMode(a)]));
-    reg("showTime",           (a)  => f("dayNight",   [showMode(a)]));
-    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color,         dayMode(a)]));
-    reg("flashlight",         (a)  => f("flashLight", [mapOnOff(a),     a.beamLength,    a.beamWidth,    a.color,          a.density]));
-    reg("setFire",            (a)  => f("setFire",    [a.radiusShift,   a.redYellowShift]));
-    reg("playerLightRadius",  (a)  => f("light",      [radMode(a),      a.radius,        a.color,        "B"+a.brightness, a.fadeSpeed]));
-    reg("activateById",       (a)  => f("light",      [mapOnOff(a),     a.id]));
-    reg("lightColor",         (a)  => f("light",      ["color",         a.id,            a.color]));
-    reg("resetLightSwitches", ( )  => f("light",      ["switch",        "reset"]));
-    reg("resetTint",          (a)  => f(tintType(),   ["reset",         a.fadeSpeed]));
-    reg("condLight",          (a)  => f("light",      ["cond",          a.id,            a.properties]));
+    r("masterSwitch",       a  => f("script",     [mapOnOff(a)]));
+    r("tileBlock",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape,  a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
+    r("tileLight",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]));
+    r("setTint",            a  => f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]));
+    r("daynightEnable",     a  => f("daynight",   [mapOnOff(a), dayMode(a)]));
+    r("setTimeSpeed",       a  => f("dayNight",   ["speed", a.speed]));
+    r("setTime",            a  => f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]));
+    r("setHoursInDay",      a  => f("dayNight",   ["hoursinday", a.hours, dayMode(a)]));
+    r("showTime",           a  => f("dayNight",   [showMode(a)]));
+    r("setHourColor",       a  => f("dayNight",   ["color", a.hour, a.color, dayMode(a)]));
+    r("flashlight",         a  => f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]));
+    r("setFire",            a  => f("setFire",    [a.radiusShift, a.redYellowShift]));
+    r("playerLightRadius",  a  => f("light",      [radMode(a), a.radius, a.color, "B"+a.brightness, a.fadeSpeed]));
+    r("activateById",       a  => f("light",      [mapOnOff(a), a.id]));
+    r("lightColor",         a  => f("light",      ["color", a.id, a.color]));
+    r("resetLightSwitches", () => f("light",      ["switch", "reset"]));
+    r("resetTint",          a  => f(tintType(),   ["reset", a.fadeSpeed]));
+    r("condLight",          a  => f("light",      ["cond", a.id, a.properties]));
   }
 
   /**
@@ -1632,7 +1787,8 @@ class ColorDelta {
     let [tileType, lightType] = TileLightType[command] || [undefined, undefined];
     let [id, enabled, color, radius, brightness] = args;
     let tile = new TileLight(tileType, lightType, id, enabled, color, radius, brightness);
-    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType && e.id === tile.id);
+    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType &&
+                                    e.id === tile.id);
     void (index === -1 ? tilearray.push(tile) : tilearray[index] = tile);
     $gameVariables.SetTileLightArray(tilearray);
     $$.ReloadTagArea();
@@ -1764,7 +1920,9 @@ class ColorDelta {
   Lightmask.prototype.update = function () { this._updateMask(); };
 
   //@method _createBitmaps
-  Lightmask.prototype._createBitmaps = function () { this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY); };
+  Lightmask.prototype._createBitmaps = function () {
+    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
+  };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
   Game_Map.prototype.setupEvents = function () {
@@ -1826,7 +1984,7 @@ class ColorDelta {
     let lightgrow_target = $gameVariables.GetRadiusTarget();
     let lightgrow_speed = (player_radius < lightgrow_target ? 1 : -1) * $gameVariables.GetRadiusSpeed();
     if (lightgrow_speed != 0 && player_radius != lightgrow_target) {
-      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
+      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // clamp
       $gameVariables.SetRadius(player_radius);
     }
 
@@ -1868,22 +2026,23 @@ class ColorDelta {
     let iplayer_radius = Math.floor(player_radius);
 
     if (playerflashlight == true) {
-      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength, flashlightwidth);
+      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength,
+                                                 flashlightwidth);
     }
     if (iplayer_radius > 0) {
       x1 = x1 - flashlightXoffset;
       y1 = y1 - flashlightYoffset;
       if (iplayer_radius < 100) {
         // dim the light a bit at lower lightradius for a less focused effect.
-        let c = playercolor;
-        c.r = Math.max(0, c.r - 50);
-        c.g = Math.max(0, c.g - 50);
-        c.b = Math.max(0, c.b - 50);
-        let newcolor = c;
+        playercolor.r = Math.max(0, playercolor.r - 50);
+        playercolor.g = Math.max(0, playercolor.g - 50);
+        playercolor.b = Math.max(0, playercolor.b - 50);
 
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
+                                                 playerbrightness);
       } else {
-        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
+                                                 playerflicker, playerbrightness);
       }
 
     }
@@ -1917,8 +2076,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distanceApart > lightsOnRadius) {
+        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distpart > lightsOnRadius) {
           continue;
         }
       }
@@ -1967,7 +2126,8 @@ class ColorDelta {
             if (!isNaN(direction)) ldir = direction;
             this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker, brightness, direction);
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+                                                     brightness, direction);
           }
         }
       }
@@ -1991,16 +2151,15 @@ class ColorDelta {
       let y1 = (ph / 2) + (y - dy) * ph;
 
       let objectflicker = tile.lightType.is(LightType.Fire);
-      let tile_color = tile.color;
+      let tile_color = tile.color.clone();
       if (tile.lightType.is(LightType.Glow)) {
-        let c = tile.color.clone();
-        c.r = Math.floor(c.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.g = Math.floor(c.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.b = Math.floor(c.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        tile_color = c;
+        tile_color.r = Math.floor(tile_color.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.g = Math.floor(tile_color.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker, tile.brightness);
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+                                               tile.brightness);
     });
 
     // Tile blocks
@@ -2145,14 +2304,14 @@ class ColorDelta {
     //ctxMul.save(); // unnecessary significant performance hit
     ctxMul.fillStyle = hex;
     ctxMul.beginPath();
-    ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
+    ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, M_2PI);
     ctxMul.fill();
     if (isRMMV()) this.multiply._setDirty(); // doesn't exist in RMMZ
     if (c.v) {
       let ctxAdd = this.additive._context; // Additive lighting context
       ctxAdd.fillStyle = hex;
       ctxAdd.beginPath();
-      ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
+      ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, M_2PI);
       ctxAdd.fill();
       if (isRMMV()) this.additive._setDirty(); // doesn't exist in RMMZ
     }
@@ -2302,8 +2461,8 @@ class ColorDelta {
       let distance = 3 * (flashlength * (flashlength - 1));
 
       // Compute spotlight radiuses
-      r1 = (flashlength - 1) * flashlightdensity;
-      r2 = (flashlength - 1) * flashwidth;
+      r1 = Math.max((flashlength - 1) * flashlightdensity, 0);
+      r2 = Math.max((flashlength - 1) * flashwidth, 0);
 
       // Compute beam left start coordinates
       let xLeftBeamStart = x1 - (r2 / 7) * Math.sin(dirAngle);
@@ -2354,7 +2513,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2365,7 +2525,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2377,7 +2538,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2388,7 +2550,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2407,7 +2570,7 @@ class ColorDelta {
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
       } else {
-        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are always guarded
+        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are conditional
         ctxAdd.shadowBlur = 0;
         ctxAdd.fillStyle = grad;
         ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2); // single call as to not blur things so much.
@@ -2524,7 +2687,7 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
     // Prevent the battle scene from being too dark
-    let c = $gameTemp._BattleTintTarget.next().get(); // reference
+    let c = $gameTemp._BattleTintTarget.next().get(); // get next color
     if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66) {
       c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
       $gameTemp._BattleTintTarget.current = c; // reassign if out of bounds. Shouldn't be possible.
@@ -2796,13 +2959,18 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for default (i.e. no passed color)
+      if (condLight) { condLight.currentColor = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.parseTargetCondLightProps(args[2].split(/\s+/)); }
+      if (condLight) {
+        let properties = args[2].split(/\s+/);
+        condLight.parseDurationProps(properties);
+        condLight.parseTargetProps(properties);
+        condLight.createDeltas();
+      }
     }
 
     // **************************** RESET ALL SWITCHES ***********************
@@ -2837,7 +3005,7 @@ class ColorDelta {
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));
       else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0)); // battle initial color
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0));
       }
     }
   };
@@ -2854,8 +3022,8 @@ class ColorDelta {
       seconds = orNaN(seconds, 0);
       seconds += hours * 60 * 60 + minutes * 60;
       let totalSeconds = hoursInDay * 60 * 60;
-      while (seconds >= totalSeconds) seconds -= totalSeconds;
-      while (seconds < 0) seconds += totalSeconds;
+      seconds %= totalSeconds; // clamp to within total seconds
+      if (seconds < 0) seconds += totalSeconds;
       gV.SetDaynightSeconds(seconds);
       gV.SetDaynightHoursinDay(hoursInDay);
       setTimeColorDelta();
@@ -2869,7 +3037,7 @@ class ColorDelta {
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
         let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed()); // whether to change tint instantly
+        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }
@@ -2879,13 +3047,13 @@ class ColorDelta {
     let [gV, a]                    = [$gameVariables, args];
     let [secondsTotal, hoursInDay] = [gV.GetDaynightSeconds(), gV.GetDaynightHoursinDay()];
     let [hours, minutes, seconds]  = [$$.hours(), $$.minutes(), $$.seconds()];
-    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint changes
-    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disabled daynight tint changes
-    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // daynight speed
-    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to current time
-    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // subtract from current time
-    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the current time
-    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day (must be >0, err = 24)
+    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint
+    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disable daynight tint
+    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // set daynight speed
+    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to cur time
+    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // sub from cur time
+    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the cur time
+    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day
     else if (isCmd('show'))        void showTime(true, false);                                          // show clock
     else if (isCmd('showseconds')) void showTime(true, true);                                           // show clock seconds
     else if (isCmd('hide'))        void showTime(false, false);                                         // hide clock

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -458,7 +458,7 @@ Imported[Community.Lighting.name] = true;
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
 * | beam width  |     w     |           wN            |   w, w12, w13, w14   | flashlight beam width                  |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | * Omitting N or RBG value will reset the given property back to its initial state                                 |
+* | * Omitting N or RBG value will transition the given property back to its initial state                                 |
 * ---------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
@@ -1130,13 +1130,13 @@ class LightDelta {
     let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
     let normalizeClockwiseMovement = () => {
       this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
-      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
-      if (this.current.direction > this.target.direction) this.target.direction += M_2PI; // clockwise normalize
+      target.direction  = normalizeAngle(target.direction);  // convert target to radians before normalization
+      if (this.current.direction > target.direction) target.direction += M_2PI; // clockwise normalize
     };
     let normalizeCounterClockwiseMovement = () => {
       this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
-      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
-      if (this.current.direction < this.target.direction) this.target.direction -= M_2PI; // c-clockwise normalize
+      target.direction  = normalizeAngle(target.direction);  // convert target to radians before normalization
+      if (this.current.direction < target.direction) target.direction -= M_2PI; // c-clockwise normalize
     };
     let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
     let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
@@ -1144,37 +1144,50 @@ class LightDelta {
     // set delta creation at current frame time
     this.current.updateFrame = Graphics.frameCount;
 
+    // Duplicate target so that any target normalization is local to this LightDelta instance
+    let target = this.target.clone();
+
     // Set current durations or 0 if not fading
-    this.current.transitionDuration = fade ? this.target.transitionDuration : 0;
-    this.current.pauseDuration      = fade ? this.target.pauseDuration : 0;
+    this.current.transitionDuration = fade ? target.transitionDuration : 0;
+    this.current.pauseDuration      = fade ? target.pauseDuration : 0;
 
     // Enable or disable the current immediately based off of target value
-    this.current.enable = this.target.enable != null ? this.target.enable : this.defaults.enable;
+    this.current.enable = target.enable != null ? target.enable : this.defaults.enable;
 
     // For currents (flashlights) check the movement direction and normalize the current and target
-    if      (this.current.direction != null && this.target.clockwise)  normalizeClockwiseMovement();
-    else if (this.current.direction != null && !this.target.clockwise) normalizeCounterClockwiseMovement();
+    if      (this.current.direction != null && target.clockwise)  normalizeClockwiseMovement();
+    else if (this.current.direction != null && !target.clockwise) normalizeCounterClockwiseMovement();
+
+    // Set any null targets to default (normalization for nulls) (allows defaults to gradually transition)
+    if(target.color == null)      target.color      = this.defaults.color;
+    if(target.direction == null)  target.direction  = this.defaults.direction;
+    if(target.brightness == null) target.brightness = this.defaults.brightness;
+    if(target.xOffset == null)    target.xOffset    = this.defaults.xOffset;
+    if(target.yOffset == null)    target.yOffset    = this.defaults.yOffset;
+    if(target.radius == null)     target.radius     = this.defaults.radius;
+    if(target.beamLength == null) target.beamLength = this.defaults.beamLength;
+    if(target.beamWidth == null)  target.beamWidth  = this.defaults.beamWidth;
 
     // assign deltas if current & targets exist
-    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
-    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
-    this.delta.direction  = createNumber(this.current.direction,  this.target.direction,  this.current.transitionDuration);
-    this.delta.brightness = createNumber(this.current.brightness, this.target.brightness, this.current.transitionDuration);
-    this.delta.xOffset    = createNumber(this.current.xOffset,    this.target.xOffset,    this.current.transitionDuration);
-    this.delta.yOffset    = createNumber(this.current.yOffset,    this.target.yOffset,    this.current.transitionDuration);
-    this.delta.radius     = createNumber(this.current.radius,     this.target.radius,     this.current.transitionDuration);
-    this.delta.beamLength = createNumber(this.current.beamLength, this.target.beamLength, this.current.transitionDuration);
-    this.delta.beamWidth  = createNumber(this.current.beamWidth,  this.target.beamWidth,  this.current.transitionDuration);
+    this.delta.color      = createColor (this.current.color,      target.color,      this.current.transitionDuration);
+    this.delta.color      = createColor (this.current.color,      target.color,      this.current.transitionDuration);
+    this.delta.direction  = createNumber(this.current.direction,  target.direction,  this.current.transitionDuration);
+    this.delta.brightness = createNumber(this.current.brightness, target.brightness, this.current.transitionDuration);
+    this.delta.xOffset    = createNumber(this.current.xOffset,    target.xOffset,    this.current.transitionDuration);
+    this.delta.yOffset    = createNumber(this.current.yOffset,    target.yOffset,    this.current.transitionDuration);
+    this.delta.radius     = createNumber(this.current.radius,     target.radius,     this.current.transitionDuration);
+    this.delta.beamLength = createNumber(this.current.beamLength, target.beamLength, this.current.transitionDuration);
+    this.delta.beamWidth  = createNumber(this.current.beamWidth,  target.beamWidth,  this.current.transitionDuration);
 
-    // assign new currents for existing deltas to propagate currents for duration = 0 or target.<value> = null
-    this.current.color      = this.delta.color      != null  ? this.delta.color     .get() : this.defaults.color;
-    this.current.direction  = this.delta.direction  != null  ? this.delta.direction .get() : this.defaults.direction;
-    this.current.brightness = this.delta.brightness != null  ? this.delta.brightness.get() : this.defaults.brightness;
-    this.current.xOffset    = this.delta.xOffset    != null  ? this.delta.xOffset   .get() : this.defaults.xOffset;
-    this.current.yOffset    = this.delta.yOffset    != null  ? this.delta.yOffset   .get() : this.defaults.yOffset;
-    this.current.radius     = this.delta.radius     != null  ? this.delta.radius    .get() : this.defaults.radius;
-    this.current.beamLength = this.delta.beamLength != null  ? this.delta.beamLength.get() : this.defaults.beamLength;
-    this.current.beamWidth  = this.delta.beamWidth  != null  ? this.delta.beamWidth .get() : this.defaults.beamWidth;
+    // assign new currents for existing deltas to propagate currents for duration = 0
+    if(this.delta.color != null)      this.current.color      = this.delta.color     .get();
+    if(this.delta.direction != null)  this.current.direction  = this.delta.direction .get();
+    if(this.delta.brightness != null) this.current.brightness = this.delta.brightness.get();
+    if(this.delta.xOffset != null)    this.current.xOffset    = this.delta.xOffset   .get();
+    if(this.delta.yOffset != null)    this.current.yOffset    = this.delta.yOffset   .get();
+    if(this.delta.radius != null)     this.current.radius     = this.delta.radius    .get();
+    if(this.delta.beamLength != null) this.current.beamLength = this.delta.beamLength.get();
+    if(this.delta.beamWidth != null)  this.current.beamWidth  = this.delta.beamWidth .get();
   }
 
   /**

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -882,12 +882,22 @@ class VRGBA {
   }
 
   /**
-   * Creates an empty VRGBA object will all properties initialized to false and 0.
+   * Creates an VRGBA object will r,g,b,a = 0 and v = false.
    * @returns {VRGBA}
    */
-  static empty() {
+  static minRGBA() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
+    return that;
+  }
+
+  /**
+   * Creates an VRGBA object will r,g,b,a = 255 and v = false.
+   * @returns {VRGBA}
+   */
+  static maxRGBA() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [false, 255, 255, 255, 255];
     return that;
   }
 
@@ -1440,7 +1450,7 @@ class ColorDelta {
     catch (e) {
       let CL = Community.Lighting;
       console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
-      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
+      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.minRGBA(), "isNight": false }));
     }
     return result;
   })(parameters["DayNight Colors"], parameters["Night Hours"]);
@@ -1592,7 +1602,7 @@ class ColorDelta {
 
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
-      this._cl.color         = orNullish(this._cl.color, VRGBA.empty());
+      this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
       this._cl.enable        = orBoolean(this._cl.enable, true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
@@ -3098,8 +3108,8 @@ Game_Variables.prototype.SetTintAtHour = function (hour, color) {
 Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   let hours = Community.Lighting.hours() + inc; // increment from current hour
   let hoursinDay = this.GetDaynightHoursinDay();
-  while (hours >= hoursinDay) hours -= hoursinDay;
-  while (hours < 0) hours += hoursinDay;
+  hours %= hoursinDay; // clamp to within total hours in day
+  if (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
   return result ? result.color.clone() : VRGBA.minRGBA();
 };

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -436,7 +436,8 @@ Imported[Community.Lighting.name] = true;
 * See the Plugin Commands section for more details.
 *
 * Ranges can be used if random values are desired. Cycle tags are statically generated at map
-* load. If dynamically random property values are desired, use the 'light cond' command instead.
+* load. If dynamic random property values are desired, use the 'light cond' command instead in
+* combination with the 'light wait' command.
 * See the table below for property specific formatting.
 *
 * The following table shows supported properties:

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -435,36 +435,43 @@ Imported[Community.Lighting.name] = true;
 * The 'light cond' command allows for conditional lights to be dynamically changed on demand.
 * See the Plugin Commands section for more details.
 *
-* The following chart shows all supported properties:
+* Ranges can be used if random values are desired. Cycle tags are statically generated at map
+* load. If dynamically random property values are desired, use the 'light cond' command instead.
+* See the table below for property specific formatting.
+*
+* The following table shows supported properties:
 * ---------------------------------------------------------------------------------------------------------------------
-* | Property    |  Prefix   |         Format*         |       Examples       |              Description               |
+* | Property    |  Prefix   |         Format*†        |       Examples       |              Description               |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   pause     |     p     |           pN            |     p0, p1, p20      | time period in cycles to pause after   |
-* |  duration   |           |                         |                      | transitioning for cycling lights       |
+* |   pause     |     p     |         p<N|N:N>        |     p0, p1, p20,     | time period in cycles to pause after   |
+* |  duration   |           |                         |    p0:20, p1:20      | transitioning for cycling lights       |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | transition  |     t     |           tN            |     t0, t1, t30      | time period to transition the          |
-* |  duration   |           |                         |                      | specified properties over              |
+* | transition  |     t     |         t<N|N:N>        |     t0, t1, t30      | time period to transition the          |
+* |  duration   |           |                         |    t0:30, t1:30      | specified properties over              |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   color     |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | #, a#FFEEDD, #ffeedd | color or additive color                |
+* |   color     |   #, #a   |   <#|#a><hex|hex:hex>   | #, #FFEEDD, #ffeedd, | color or additive color                |
+* |             |           |                         |  a#000000:a#ffffff   |                                        |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |  enable     |     e     |         e<1|0>          |        e1, e0        | turns light on or off instantly        |
+* |  enable     |     e     |        e<1|0|0:1>       |     e1, e0, e0:1     | turns light on or off instantly        |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   angle     | a, +a, -a |       <a|+a|-a>N        |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
-* |             |           |                         |                      | clockwise, '-' moves counterclockwise  |
+* |   angle     | a, +a, -a |     <a|+a|-a><N|N:N>    |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |             |           |                         |    +a0:30, -a0:30    | clockwise, '-' moves counterclockwise  |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | brightness  |     b     |           bN            |    b, b0, b1, b5     | brightness                             |
+* | brightness  |     b     |         b<N|N:N>        | b, b0, b1, b5, b1:5  | brightness                             |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |  x offset   |     x     |           xN            |      x, x2, x-2      | x offset                               |
+* |  x offset   |     x     |         x<N|N:N>        |  x, x2, x-2, x-2:2   | x offset                               |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |  y offset   |     y     |           yN            |      y, y2, y-2      | y offset                               |
+* |  y offset   |     y     |         y<N|N:N>        |  y, y2, y-2, y-2:2   | y offset                               |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   radius    |     r     |           rN            |     r, r50, r150     | light radius                           |
+* |   radius    |     r     |         r<N|N:N>        | r, r50, r150, r50:75 | light radius                           |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | beam length |     l     |           lN            |    l, l8, l9, l10    | flashlight beam length                 |
+* | beam length |     l     |         l<N|N:N>        | l, l8, l9, l10, l7:9 | flashlight beam length                 |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | beam width  |     w     |           wN            |   w, w12, w13, w14   | flashlight beam width                  |
+* | beam width  |     w     |         w<N|N:N>        |   w, w8, w14, w7:9   | flashlight beam width                  |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | * Omitting N or RBG value will transition the given property back to its initial state                                 |
+* | * Omitting N or hex value will transition the given property back to its initial state                            |
+* |-------------------------------------------------------------------------------------------------------------------|
+* | † using the N:N or hex:hex format allows for a randomly generated value within the given range (inclusive)        |
 * ---------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
@@ -1036,34 +1043,54 @@ class LightProperties {
       // clear checks (back to initial value for the given property)
       if      (        e.equalsIC('t'))        this.transitionDuration = 0;
       else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
-      else if (        e.equalsIC('#'))        this.color      = void(0);
-      else if (        e.equalsIC('a#'))       this.color      = void(0);
-      else if (        e.equalsIC('e'))        this.enable     = void(0);
-      else if (        e.equalsIC('b'))        this.brightness = void(0);
-      else if (        e.equalsIC('x'))        this.xOffset    = void(0);
-      else if (        e.equalsIC('y'))        this.yOffset    = void(0);
-      else if (isOL && e.equalsIC('r'))        this.radius     = void(0);
-      else if (isFL && e.equalsIC('l'))        this.beamLength = void(0);
-      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void(0);
-      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void(0);
-      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void(0);
-      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void(0);
-      // on or off checks
+      else if (        e.equalsIC('#'))        this.color      = void (0);
+      else if (        e.equalsIC('a#'))       this.color      = void (0);
+      else if (        e.equalsIC('e'))        this.enable     = void (0);
+      else if (        e.equalsIC('b'))        this.brightness = void (0);
+      else if (        e.equalsIC('x'))        this.xOffset    = void (0);
+      else if (        e.equalsIC('y'))        this.yOffset    = void (0);
+      else if (isOL && e.equalsIC('r'))        this.radius     = void (0);
+      else if (isFL && e.equalsIC('l'))        this.beamLength = void (0);
+      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void (0);
+      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void (0);
+      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void (0);
+      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void (0);
+
+      // parse suffix (individual & random ranges)
+      let suffix, rand = (min, max) => Math.random() * (max - min) + min;
+      if (!e.contains(':') && !e.contains('#')) {                               // single number
+        suffix = orNaN(+e.slice(1), +e.slice(2), 0);                            // - get number
+      } else if (!e.contains(':') && e.contains('#')) {                         // single color
+        suffix = new VRGBA(e);                                                  // - get color
+      } else if (!e.contains('#')) {                                            // number range
+        let eSplit = e.split(':');                                              // - explode range
+        let min = orNaN(+eSplit[0].slice(1), +eSplit[0].slice(2), 0);           // - get suffix (prefix size 1 or 2)
+        let max = orNaN(+eSplit[1], 0);                                         // - get suffix (no prefix)
+        suffix = e[0] != 'e' ? rand(min, max) : Math.floor(rand(min, max + 1)); // - for 'e' we need int ranges
+      } else {                                                                  // color range
+        let eSplit = e.split(':');                                              // - explode range
+        let min = new VRGBA(eSplit[0]);                                         // - get the whole hex value
+        let max = new VRGBA(eSplit[1]);                                         // - get the whole hex value
+        suffix = new VRGBA(Boolean(Math.floor(rand(min.v, max.v + 1))), Math.floor(rand(min.r, max.r + 1)),
+                                   Math.floor(rand(min.g, max.g + 1)),  Math.floor(rand(min.b, max.b + 1)),
+                                   Math.floor(rand(min.a, max.a + 1)));
+      }
+
       // prefix checks
-      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); }
-      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); }
-      else if (        e.startsWithIC('#'))    this.color      = new VRGBA(e);
-      else if (        e.startsWithIC('a#'))   this.color      = new VRGBA(e);
-      else if (        e.startsWithIC('e'))    this.enable     = Boolean(orNaN(+e.slice(1), 0));
-      else if (        e.startsWithIC('b'))    this.brightness = orNaN(+e.slice(1), 0);
-      else if (        e.startsWithIC('x'))    this.xOffset    = orNaN(+e.slice(1), 0);
-      else if (        e.startsWithIC('y'))    this.yOffset    = orNaN(+e.slice(1), 0);
-      else if (isOL && e.startsWithIC('r'))    this.radius     = orNaN(+e.slice(1), 0);
-      else if (isFL && e.startsWithIC('l'))    this.beamLength = orNaN(+e.slice(1), 0);
-      else if (isFL && e.startsWithIC('w'))    this.beamWidth  = orNaN(+e.slice(1), 0);
-      else if (isFL && e.startsWithIC('a'))  { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(1), 0); }
-      else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
-      else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
+      if (             e.startsWithIC('t'))    this.transitionDuration = suffix;
+      else if (        e.startsWithIC('p'))    this.pauseDuration      = suffix;
+      else if (        e.startsWithIC('#'))    this.color      = suffix;
+      else if (        e.startsWithIC('a#'))   this.color      = suffix;
+      else if (        e.startsWithIC('e'))    this.enable     = Boolean(suffix);
+      else if (        e.startsWithIC('b'))    this.brightness = suffix;
+      else if (        e.startsWithIC('x'))    this.xOffset    = suffix;
+      else if (        e.startsWithIC('y'))    this.yOffset    = suffix;
+      else if (isOL && e.startsWithIC('r'))    this.radius     = suffix;
+      else if (isFL && e.startsWithIC('l'))    this.beamLength = suffix;
+      else if (isFL && e.startsWithIC('w'))    this.beamWidth  = suffix;
+      else if (isFL && e.startsWithIC('a'))  { this.clockwise  = true;  this.direction = M_PI_180 * suffix; }
+      else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * suffix; }
+      else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * suffix; }
     }, this);
   }
 
@@ -1607,7 +1634,6 @@ class ColorDelta {
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
         let n = clipNum(e);
-        console.log()
         if      (!isFL() && isPreNum(e, 'r', n) && isNul(this._cl.radius))     this._cl.radius     = n;
         else if (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -1637,7 +1637,6 @@ class ColorDelta {
           lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
         let targetProps = lightArray[this._cl.id];                          // get target prop reference
         this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
-        console.log(this._cl.delta);
       }
       // Non-conditional light
       else {
@@ -2928,8 +2927,7 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      console.log(args[2]);
-      if (targetProps) targetProps.parseProps([args[2] != null ? args[2] : "#"]);
+      if (targetProps) targetProps.parseProps([(args[2] != null && !args[2].equalsIC("defaultcolor")) ? args[2] : "#"]);
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -562,6 +562,10 @@ Imported[Community.Lighting.name] = true;
 * - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
 * - ignored. See the Conditional Light section for more detail on each property.
 *
+* Light wait id
+* - wait for the conditional light to finish both transitioning and pausing before continuing
+* - the event script.
+*
 * Light color id c
 * - Change the color (c) of lightsource with id (id)
 * - Work even if the associated light is currently off.
@@ -1247,7 +1251,7 @@ class LightDelta {
   }
 
   /**
-   * Returns whether all deltas are finished or not.
+   * Returns whether the light has finished transitioning and pausing.
    * @returns {Boolean}
    */
   finished() { return this.current.transitionDuration <= 0 && this.current.pauseDuration <= 0; }
@@ -1767,6 +1771,7 @@ class ColorDelta {
    * @param {String[]} args
    */
   Game_Interpreter.prototype.communityLighting_Commands = function (command, args) {
+    $$.interpreter = this; //assign 'local' interpreter (for parallel processes)
     command = command.toLowerCase();
 
     const allCommands = {
@@ -1790,26 +1795,27 @@ class ColorDelta {
     let radMode  = a  => +a.fadeSpeed ? "radiusgrow" : "radius";
 
     let r = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
-    let f = (c, a) => $gameMap._interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
+    let f = (c, a) => $$.interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
 
-    r("masterSwitch",       a  => f("script",     [mapOnOff(a)]));
-    r("tileBlock",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape,  a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
-    r("tileLight",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]));
-    r("setTint",            a  => f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]));
-    r("daynightEnable",     a  => f("daynight",   [mapOnOff(a), dayMode(a)]));
-    r("setTimeSpeed",       a  => f("dayNight",   ["speed", a.speed]));
-    r("setTime",            a  => f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]));
-    r("setHoursInDay",      a  => f("dayNight",   ["hoursinday", a.hours, dayMode(a)]));
-    r("showTime",           a  => f("dayNight",   [showMode(a)]));
-    r("setHourColor",       a  => f("dayNight",   ["color", a.hour, a.color, dayMode(a)]));
-    r("flashlight",         a  => f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]));
-    r("setFire",            a  => f("setFire",    [a.radiusShift, a.redYellowShift]));
-    r("playerLightRadius",  a  => f("light",      [radMode(a), a.radius, a.color, "B"+a.brightness, a.fadeSpeed]));
-    r("activateById",       a  => f("light",      [mapOnOff(a), a.id]));
-    r("lightColor",         a  => f("light",      ["color", a.id, a.color]));
-    r("resetLightSwitches", () => f("light",      ["switch", "reset"]));
-    r("resetTint",          a  => f(tintType(),   ["reset", a.fadeSpeed]));
-    r("condLight",          a  => f("light",      ["cond", a.id, a.properties]));
+    r("masterSwitch",       function (a) { $$.interpreter = this; f("script",     [mapOnOff(a)]); });
+    r("tileBlock",          function (a) { $$.interpreter = this; f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape, a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]); });
+    r("tileLight",          function (a) { $$.interpreter = this; f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]); });
+    r("setTint",            function (a) { $$.interpreter = this; f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]); });
+    r("daynightEnable",     function (a) { $$.interpreter = this; f("daynight",   [mapOnOff(a), dayMode(a)]); });
+    r("setTimeSpeed",       function (a) { $$.interpreter = this; f("dayNight",   ["speed", a.speed]); });
+    r("setTime",            function (a) { $$.interpreter = this; f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]); });
+    r("setHoursInDay",      function (a) { $$.interpreter = this; f("dayNight",   ["hoursinday", a.hours, dayMode(a)]); });
+    r("showTime",           function (a) { $$.interpreter = this; f("dayNight",   [showMode(a)]); });
+    r("setHourColor",       function (a) { $$.interpreter = this; f("dayNight",   ["color", a.hour, a.color, dayMode(a)]); });
+    r("flashlight",         function (a) { $$.interpreter = this; f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]); });
+    r("setFire",            function (a) { $$.interpreter = this; f("setFire",    [a.radiusShift, a.redYellowShift]); });
+    r("playerLightRadius",  function (a) { $$.interpreter = this; f("light",      [radMode(a), a.radius, a.color, "B" + a.brightness, a.fadeSpeed]); });
+    r("activateById",       function (a) { $$.interpreter = this; f("light",      [mapOnOff(a), a.id]); });
+    r("lightColor",         function (a) { $$.interpreter = this; f("light",      ["color", a.id, a.color]); });
+    r("resetLightSwitches", function ()  { $$.interpreter = this; f("light",      ["switch", "reset"]); });
+    r("resetTint",          function (a) { $$.interpreter = this; f(tintType(),   ["reset", a.fadeSpeed]); });
+    r("condLight",          function (a) { $$.interpreter = this; f("light",      ["cond", a.id].concat(a.properties.split(/\s+/))); });
+    r("condLightWait",      function (a) { $$.interpreter = this; f("light",      ["wait", a.id]); });
   }
 
   /**
@@ -3002,7 +3008,26 @@ class ColorDelta {
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
       let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (targetProps) targetProps.parseProps(args[2] != null ? args[2].split(/\s+/) : ['']);
+      if (targetProps) targetProps.parseProps(args[2] != null ? args.slice(2) : ['']);
+    }
+
+    // *********************** WAIT on CONDITIONAL LIGHT *********************
+    else if (args[0].equalsIC('wait')) { // wait for conditional light to finish processing
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) {
+        if (targetProps.updateFrame == Graphics.frameCount) {
+          // light was scheduled to transition this frame and the deltas haven't been updated to use targets duration
+          $$.interpreter.wait(targetProps.transitionDuration + targetProps.pauseDuration);
+        } else { // light was scheduled to transition in a prior frame so lookup how much time is left
+          for (let i = 0, len = eventObjId.length; i < len; i++) {
+            let cur = events[eventObjId[i]];
+            if (cur._cl.delta.target == targetProps) {
+              $$.interpreter.wait(cur._cl.delta.current.transitionDuration + cur._cl.delta.current.pauseDuration);
+              break;
+            }
+          }
+        }
+      }
     }
 
     // **************************** RESET ALL SWITCHES ***********************

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -2624,13 +2624,10 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // if we came from a map, script is active, configuration authorizes using lighting effects,
-    // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
+    // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
             $gameVariables.GetTint() : new VRGBA("#ffffff");
-
-    // Set initial tint for battle
-    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -1461,9 +1461,6 @@ class ColorDelta {
   let options_lighting_on = true;
   let maxX = (Number(parameters['Screensize X']) || 816) + 2 * lightMaskPadding;
   let maxY = Number(parameters['Screensize Y']) || 624;
-  let battleMaxX = maxX;
-  let battleMaxY = maxY;
-  if (isRMMZ()) battleMaxY += 24; // Plus 24 for RMMZ Spriteset_Battle.prototype.battleFieldOffsetY
   let event_reload_counter = 0;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = new VRGBA(useSmootherLights ? "#00000000" : "#000000");
@@ -1890,7 +1887,7 @@ class ColorDelta {
 
   //@method _createBitmaps
   Lightmask.prototype._createBitmaps = function () {
-    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
+    this._maskBitmaps = new Mask_Bitmaps(maxX, maxY);
   };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
@@ -1960,8 +1957,8 @@ class ColorDelta {
     // ****** PLAYER LIGHTGLOBE ********
     let ctxMul = this._maskBitmaps.multiply.context;
     let ctxAdd = this._maskBitmaps.additive.context;
-    this._maskBitmaps.multiply.fillRect(0, 0, maxX + lightMaskPadding, maxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, maxX + lightMaskPadding, maxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, maxX, maxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     ctxMul.globalCompositeOperation = 'lighter';
     ctxAdd.globalCompositeOperation = 'lighter';
@@ -2006,14 +2003,9 @@ class ColorDelta {
         playercolor.r = Math.max(0, playercolor.r - 50);
         playercolor.g = Math.max(0, playercolor.g - 50);
         playercolor.b = Math.max(0, playercolor.b - 50);
-
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
-                                                 playerbrightness);
-      } else {
-        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
-                                                 playerflicker, playerbrightness);
       }
-
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
+                                               playerbrightness);
     }
 
     // *********************************** DAY NIGHT CYCLE TIMER **************************
@@ -2169,7 +2161,7 @@ class ColorDelta {
     // Compute tint for next frame
     let tintValue = $gameVariables.GetTintTarget().next().get();
     $gameVariables.SetTint(tintValue);
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX + lightMaskPadding, maxY, tintValue);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX, maxY, tintValue); // offset to fill entire mask
 
     // reset drawmode to normal
     ctxMul.globalCompositeOperation = 'source-over';
@@ -2611,12 +2603,16 @@ class ColorDelta {
     this._sprites = [];
     this._createBitmaps();
 
-    //Initialize the bitmap
-    this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.multiply, PIXI.BLEND_MODES.MULTIPLY);
-    this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.additive, PIXI.BLEND_MODES.ADD);
+    // Initialize the bitmap
+    // +24 on Y to inverse RMMZ Spriteset_Battle.prototype.battleFieldOffsetY() math
+    // Graphics width/height adjustments to inverse Spriteset_Battle.prototype.createBattleField() offsets
+    let spriteXOffset = -lightMaskPadding - (Graphics.width - Graphics.boxWidth) / 2;
+    let spriteYOffset = (isRMMZ() ? 24 : 0) - (Graphics.height - Graphics.boxHeight) / 2;
+    this._addSprite(spriteXOffset, spriteYOffset, this._maskBitmaps.multiply, PIXI.BLEND_MODES.MULTIPLY);
+    this._addSprite(spriteXOffset, spriteYOffset, this._maskBitmaps.additive, PIXI.BLEND_MODES.ADD);
 
-    this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, maxX, maxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // if we came from a map, script is active, configuration authorizes using lighting effects,
     // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
@@ -2641,19 +2637,19 @@ class ColorDelta {
 
     $gameTemp._BattleTintInitial = c;
     $gameTemp._BattleTintTarget = ColorDelta.createTint(c);
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX, maxY, c); // offset to fill entire mask
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };
 
   //@method _createBitmaps
   BattleLightmask.prototype._createBitmaps = function () {
-    this._maskBitmaps = new Mask_Bitmaps(battleMaxX + lightMaskPadding, battleMaxY);
+    this._maskBitmaps = new Mask_Bitmaps(maxX, maxY);
   };
 
   BattleLightmask.prototype.update = function () {
-    this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, maxX, maxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // Prevent the battle scene from being too dark
     let c = $gameTemp._BattleTintTarget.next().get(); // get next color
@@ -2663,7 +2659,7 @@ class ColorDelta {
     }
 
     // Compute tint for next frame
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX, maxY, c);
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -974,7 +974,7 @@ class LightProperties {
    * @param {Number}    beamLength
    * @param {Number}    beamWidth
    */
-  constructor(type, enable, color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, color, enable, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
     // Always define in case durations aren't passed to targets
     this.transitionDuration = 0;
     this.pauseDuration      = 0;
@@ -1572,8 +1572,8 @@ class ColorDelta {
         else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
         else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
         else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))      this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))      this._cl.enable    = false;
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
         else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
         else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -576,31 +576,27 @@ Imported[Community.Lighting.name] = true;
 * Flashlight off
 * - Turn off the flashlight.  yup.
 *
-* DayNight on|off [instant]
-* - Activates or deactivates the day/night cycle. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* DayNight on|off [fade]
+* - Activates or deactivates the day/night cycle. Specifying 'fade' will gradually
+*   transition the tint to that of the next hour.
 *
 * Daynight speed n
 * - Changes the speed by which hours pass in game in relation to real life seconds
 *
-* Daynight hour h m [instant]
-* - Sets the in game time to hh:mm. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hour h m [fade]
+* - Sets the in game time to hh:mm. Specifying 'fade' will gradually transition the
+*   tint to that of the next hour.
 *
 * Daynight color h c
 * - Sets the hour (h) to use color (c)
 *
-* Daynight add h m [instant]
-* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight add h m [fade]
+* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying
+*   'fade' will gradually transition the tint to that of the next hour.
 *
-* Daynight subtract h m [instant]
-* - Subtracts the specified hours (h) and minutes (m) from the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight subtract h m [fade]
+* - Subtracts the specified hours (h) and minutes (m) from the in game clock.
+*   Specifying  'fade' will gradually transition the tint to that of the next hour.
 *
 * Daynight show
 * - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -611,10 +607,9 @@ Imported[Community.Lighting.name] = true;
 * Daynight hide
 * - Hides the current time of day mini-window
 *
-* Daynight hoursinday h [instant]
-* - Sets the number of hours in a day to [h] (set hour colors if doing this), Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hoursinday h [fade]
+* - Sets the number of hours in a day to [h] (set hour colors if doing this).
+*   Specifying 'fade' will gradually transition the tint to that of the next hour.
 *
 * Tint set c [s]
 * Tint fade c [s]
@@ -1716,7 +1711,7 @@ class ColorDelta {
     let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
     let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
     let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let dayMode =  a  => a.fade === "true" ? "fade" : "";
     let tintMode = a  => a.color ? "set" : "reset";
     let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
     let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
@@ -3000,8 +2995,8 @@ class ColorDelta {
     };
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
-        let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
+        let hasFade = 'fade'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
+        let delta = ColorDelta.createTimeTint(hasFade, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -376,13 +376,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
-* <cl: light 300 {#ff0000 p15} {#ffff00 p15} {#00ff00 p15} {#00ffff p15} {#0000ff p15}>
+* <cl: light 300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 {#ff0000 t30 p60} {#ffff00 t30 p60} {#00ff00 t30 p60} {#00ffff t30 p60}>
+* <cl: light 300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
-* <cl: light {#ff0000 t30 p60 r250} {#ffff00 t30 p60 r300} {#00ff00 t30 p60 r250} {#00ffff t30 p60 r300}>
+* <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
 * Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
 * and transitions to the next color and size over 60 frames.
 *
@@ -398,7 +398,7 @@ Imported[Community.Lighting.name] = true;
 * plugin commands.
 *
 * <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15>
-* <cl: Flashlight l8 w12 {#f00 p15} {#ff0 p15} {#0f0 p15}>
+* <cl: Flashlight l8 w12 {#f00 p15} {#ff0} {#0f0}>
 * Creates a flashlight beam that rotates every 15 frames.
 *
 * --------------------------------------------------------------------------
@@ -408,7 +408,7 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 {a#990000 t15} {a#999900 t15} {a#009900 t15} {a#009999 t15} {a#000099 t15}>
+* <cl: light 300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
@@ -421,6 +421,8 @@ Imported[Community.Lighting.name] = true;
 * Conditional Lighting allows light properties to be changed either cyclically or
 * dynamically over time via properties that consist of a prefix followed by a property
 * value. This is useful for creating any number of transitional lighting effects.
+* Properties will hold their given value until a change or reset (including pause and
+* transition durations).
 *
 * The properties are supported in light tags or via the 'light cond' command. Light tags
 * support any number of light properties wrapped in {} brackets See the example note tags
@@ -1025,12 +1027,12 @@ class LightProperties {
     this.updateFrame = Graphics.frameCount; // set current frame as update frame
     let isOL = this.isOtherLight();
     let isFL = this.isFlashlight();
-    let hasTransitionDuration = false;
-    let haspauseDuration      = false;
     // properties with no suffix 'clear' the target
     properties.forEach((e) => {
       // clear checks (back to initial value for the given property)
-      if      (        e.equalsIC('#'))        this.color      = void(0);
+      if      (        e.equalsIC('t'))        this.transitionDuration = 0;
+      else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
+      else if (        e.equalsIC('#'))        this.color      = void(0);
       else if (        e.equalsIC('a#'))       this.color      = void(0);
       else if (        e.equalsIC('e'))        this.enable     = void(0);
       else if (        e.equalsIC('b'))        this.brightness = void(0);
@@ -1044,8 +1046,8 @@ class LightProperties {
       else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void(0);
       // on or off checks
       // prefix checks
-      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); hasTransitionDuration = true; }
-      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); haspauseDuration = true; }
+      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); }
+      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); }
       else if (        e.startsWithIC('#'))    this.color      = new VRGBA(e);
       else if (        e.startsWithIC('a#'))   this.color      = new VRGBA(e);
       else if (        e.startsWithIC('e'))    this.enable     = Boolean(orNaN(+e.slice(1), 0));
@@ -1059,8 +1061,6 @@ class LightProperties {
       else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
       else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
     }, this);
-    if (!hasTransitionDuration) this.transitionDuration = 0;
-    if (!haspauseDuration)      this.pauseDuration = 0;
   }
 
   /**
@@ -2974,7 +2974,7 @@ class ColorDelta {
     // **************************** RESET ALL SWITCHES ***********************
     else if (args[0].equalsIC('switch') && args[1].equalsIC('reset')) {
       let lightArray = $gameVariables.GetLightArray();
-      for (let i in lightArray) lightArray[i].parseProps(['#', 'e', 'b', 'x', 'y', 'r', 'l', 'w', 'a']); // clear
+      for (let i in lightArray) lightArray[i].parseProps(['t', 'p', '#', 'e', 'b', 'x', 'y', 'r', 'l', 'w', 'a']); // clear
     }
   };
 

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -2965,7 +2965,7 @@ class ColorDelta {
    * @param {String[]} args
    */
   $$.tintbattle = function (args, overrideInBattleCheck = false) {
-    if ($gameParty.inBattle() || overrideInBattleCheck) {
+    if ($gameVariables.GetScriptActive() && lightInBattle && ($gameParty.inBattle() || overrideInBattleCheck)) {
       let cmd = args[0].trim();
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -1087,13 +1087,13 @@ class LightDelta {
    * @param {LightProperties} current
    * @param {LightProperties} target
    */
-  constructor(current, target, defaults) {
+  constructor(current, target, defaults, fade = true) {
     if (arguments.length == 0) return;
     this.current = current;
     this.target  = target;
     this.defaults = defaults;
     this.delta   = new LightProperties();
-    this.createDeltas();
+    this.createDeltas(fade);
   }
 
   /**
@@ -1110,9 +1110,12 @@ class LightDelta {
   }
 
   /**
-   * Create deltas from currents, targets, and transition duration.
+   * Create deltas from currents, targets, and transition duration. If fade is false, then the current will transition
+   * to the target values instantly.
+   *
+   * @param {Boolean} fade
    */
-  createDeltas() {
+  createDeltas(fade = true) {
     // Helper functions
     let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
     let normalizeClockwiseMovement = () => {
@@ -1130,6 +1133,10 @@ class LightDelta {
 
     // set delta creation at current frame time
     this.current.updateFrame = Graphics.frameCount;
+
+    // Set current durations or 0 if not fading
+    this.current.transitionDuration = fade ? this.target.transitionDuration : 0;
+    this.current.pauseDuration      = fade ? this.target.pauseDuration : 0;
 
     // Enable or disable the current immediately based off of target value
     this.current.enable = this.target.enable != null ? this.target.enable : this.defaults.enable;
@@ -1607,31 +1614,30 @@ class ColorDelta {
       let startProps = new LightProperties(this._cl.type, ...props);
 
       // Process cycle parameters - for each cycle group create currentProps and targetProps and cooresponding light
-      // delta. Then put the deltas into a list to loop/cycle through repeatedly
+      // delta. Then put the deltas into a list to loop/cycle through repeatedly. Note: Last cycle targets first.
       if (cycleGroups.length) { // check if tag included color cycling
         this._cl.cycle = [];     // only define if cycle exists
-        let currentProps = startProps, targetProps, delta;
-        cycleGroups.forEach((e, i, a) => {                                  // ------ loop each group ------
-          let n = a[++i < a.length ? i : 0];                                // - get next element: OOB goes to first
-          currentProps = currentProps.clone();                              // - inherit existing props
-          currentProps.parseProps(e);                                       // - parse for new props
-          targetProps = i == a.length ? startProps : currentProps.clone();  // - create target props: last targets start
-          targetProps.parseProps(n);                                        // - parse for new props: last targets start
-          let delta = new LightDelta(currentProps, targetProps, this._cl);  // - create light delta object
-          this._cl.cycle.push(delta);                                       // - push conditional light delta to list
-        }, this);                                                           // -----------------------------
-        delta = this._cl.cycle.shift(); // pop front
-        this._cl.delta = delta.clone(); // clone front as the initial lightDelta state for this cond light
-        this._cl.cycle.push(delta);     // push original on back of list
+        let currentProps = startProps, targetProps;
+        cycleGroups.forEach((e, i, a) => {                                          // ------ loop each group ------
+          let n = a[++i < a.length ? i : 0];                                        // - get next element
+          currentProps = currentProps.clone();                                      // - inherit existing props
+          currentProps.parseProps(e);                                               // - parse for new props
+          targetProps = i == a.length ? startProps : currentProps.clone();          // - create target props
+          targetProps.parseProps(n);                                                // - parse for new props
+          this._cl.cycle.push(new LightDelta(currentProps, targetProps, this._cl)); // - create light delta object
+        }, this);                                                                   // -----------------------------
+        let delta = this._cl.cycle.shift(); // pop front
+        this._cl.delta = delta.clone();     // clone front as the initial lightDelta state for this cond light
+        this._cl.cycle.push(delta);         // push original on back of list
       }
       // Process conditional lighting - for a cond light, currentProps are light specific and targets are shared by ID
       // a target can be updated on the fly using commands and all lights with matching IDs will use the properties
       else if (this._cl.id) { // check for a conditional lighting ID
-        let lightArray = $gameVariables.GetLightArray();                    // get target light Object
-        if (lightArray[this._cl.id] == null)                                // check if target exists since it's shared
-          lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
-        let targetProps = lightArray[this._cl.id];                          // get target prop reference
-        this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
+        let lightArray = $gameVariables.GetLightArray();                            // get target light Object
+        if (lightArray[this._cl.id] == null)                                        // check if shared target exists
+          lightArray[this._cl.id] = new LightProperties();                          // - if not, create empty reference
+        let targetProps = lightArray[this._cl.id];                                  // get target prop reference
+        this._cl.delta  = new LightDelta(startProps, targetProps, this._cl, false); // create light delta object
       }
       // Non-conditional light
       else {

--- a/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
+++ b/CommunityLightingMVDemo/js/plugins/Community_Lighting.js
@@ -306,11 +306,11 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [enable] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
-* - radius      100, 250, etc
+* - radius      Any number, optionally preceded by "R" or "r", so 100, R100, r100, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -321,7 +321,8 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
 * - night       Causes the light to only come on during the night [optional]
 * - brightness  B50, B25, etc [optional]
@@ -332,20 +333,21 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [enable] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - bl:         Beam length:  Any number, optionally preceded by "L" or "l", so 8, L8, l8, etc.
+* - bw:         Beam width:  Any number, optionally preceded by "W", or 'w', so 12, W12, w12, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -356,19 +358,21 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Sets the event's light to only show during the day [optional]
 * - night       Sets the event's light to only show during night time [optional]
 * - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*               Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               Can be preceded by "D" or "d", so D4, d4, etc. If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A" or "a". If
 *               omitted, sdir is used. [optional]
 * - x           x[offset] Work the same as regular light [optional]
 * - y           y[offset] [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Example note tags:
 *
@@ -376,10 +380,10 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
-* <cl: light 300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
+* <cl: light r300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
+* <cl: light r300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
 * <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
@@ -408,7 +412,7 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
+* <cl: light r300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
@@ -1593,34 +1597,38 @@ class ColorDelta {
     this._cl.type = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._cl.type) {
-      let isFL       = ()        => this._cl.type.is(LightType.Flashlight); // is flashlight
-      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
-      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
-      let isNul      = (e)       => e == null;
-      let isDayNight = (e)       => isEq(e, "night", "day");
-      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let isFL       = ()          => this._cl.type.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, s0, s1) => s0 && e.equalsIC(s0)     || s1 && e.equalsIC(s1);
+      let isPre      = (e, p0, p1) => p0 && e.startsWithIC(p0) || p1 && e.startsWithIC(p1);
+      let isPreNum   = (e, p, n)   => p  && e.startsWithIC(p)  && !isNaN(n);
+      let isNul      = (e)         => e == null;
+      let isDayNight = (e)         => isEq(e, "night", "day");
+      let clipNum    = (e)         => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        let n = clip(e);
-        if      (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
+        let n = clipNum(e);
+        console.log()
+        if      (!isFL() && isPreNum(e, 'r', n) && isNul(this._cl.radius))     this._cl.radius     = n;
+        else if (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamWidth))  this._cl.beamWidth  = +e;
-        else if (isFL()  && isPre(e, "l") && n  && isNul(this._cl.beamLength)) this._cl.beamLength = n;
-        else if (isFL()  && isPre(e, "w") && n  && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
-        else if (           isEq(e, "cycle")    && isNul(this._cl.color))      hasCycle            = true;
-        else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
-        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
-        else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
+        else if (isFL()  && isPreNum(e, 'l', n) && isNul(this._cl.beamLength)) this._cl.beamLength = n;
+        else if (isFL()  && isPreNum(e, 'w', n) && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
+        else if (           isEq(e, 'cycle')    && isNul(this._cl.color))      hasCycle            = true;
+        else if (           isPre(e, '#', 'a#') && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex] .push('p' + e);
+        else if (           isPre(e, '#', 'a#') && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
+        else if (           isPreNum(e, 'e', n) && isNul(this._cl.enable))     this._cl.enable     = Boolean(n);
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable     = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable     = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
-        else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;
+        else if (           isPreNum(e, 'b', n) && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = n;
         else if ( isFL() && !isNaN(+e)          && isNul(this._cl.direction))  this._cl.direction  = +e;
-        else if ( isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
-        else if ( isFL() && isPre(e, "a") && n  && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
-        else if (           isPre(e, "x") && n  && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
-        else if (           isPre(e, "y") && n  && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
+        else if ( isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
+        else if ( isFL() && isPreNum(e, 'a', n) && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
+        else if (           isPreNum(e, 'x', n) && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
+        else if (           isPreNum(e, 'y', n) && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
         else if (           e.length > 0        && isNul(this._cl.id))         this._cl.id         = e;
         cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);

--- a/CommunityLightingMZDemo/data/Map001.json
+++ b/CommunityLightingMZDemo/data/Map001.json
@@ -12211,7 +12211,7 @@
     {
       "id": 3,
       "name": "EV003",
-      "note": "<cl: light 75 {a#00ff0066 t120} {a#ffffff66 t120}>",
+      "note": "<cl: light 75 {a#00ff0066 t120} {a#ffffff66}>",
       "pages": [
         {
           "conditions": {
@@ -12660,7 +12660,7 @@
     {
       "id": 7,
       "name": "Dark cultist",
-      "note": "<CL: Light 100 {a#ff6666bb t120 X-0.5 Y0.2} {a#66ff66bb t120 x0 y0.5} {a#ff00ffbb t120 X0.5 Y0.2} {a#ff6666bb t120 X0.5 Y-0.2} {a#66ff66bb t120 x0 y-0.5} {a#ff00ffbb t120 X-0.5 Y-0.2}>",
+      "note": "<CL: Light 100 {a#ff6666bb t120 X-0.5 Y0.2} {a#66ff66bb x0 y0.5} {a#ff00ffbb X0.5 Y0.2} {a#ff6666bb X0.5 Y-0.2} {a#66ff66bb x0 y-0.5} {a#ff00ffbb X-0.5 Y-0.2}>",
       "pages": [
         {
           "conditions": {
@@ -13903,7 +13903,7 @@
     {
       "id": 13,
       "name": "EV013",
-      "note": "<cl: light {a#ff009966 r75 t120 p60} {a#ff009999 r85 t120 p60}>",
+      "note": "<cl: light {a#ff009966 r75 t120 p60} {a#ff009999 r85}>",
       "pages": [
         {
           "conditions": {
@@ -14063,6 +14063,66 @@
       ],
       "x": 15,
       "y": 27
+    },
+    {
+      "id": 15,
+      "name": "Fairy",
+      "note": "<cl: light 10 a#aaaaaa {x1 y-0.2 t120} {x0.2 y0.2 t120} {x1.5 y-0.1 t60} {x1.2 y0.3 t120} {x0.1 y-0.2 t60} {x1.8 y0.2 t60}>",
+      "pages": [
+        {
+          "conditions": {
+            "actorId": 1,
+            "actorValid": false,
+            "itemId": 1,
+            "itemValid": false,
+            "selfSwitchCh": "A",
+            "selfSwitchValid": false,
+            "switch1Id": 1,
+            "switch1Valid": false,
+            "switch2Id": 1,
+            "switch2Valid": false,
+            "variableId": 1,
+            "variableValid": false,
+            "variableValue": 0
+          },
+          "directionFix": false,
+          "image": {
+            "characterIndex": 0,
+            "characterName": "",
+            "direction": 2,
+            "pattern": 0,
+            "tileId": 0
+          },
+          "list": [
+            {
+              "code": 0,
+              "indent": 0,
+              "parameters": []
+            }
+          ],
+          "moveFrequency": 3,
+          "moveRoute": {
+            "list": [
+              {
+                "code": 0,
+                "parameters": []
+              }
+            ],
+            "repeat": true,
+            "skippable": false,
+            "wait": false
+          },
+          "moveSpeed": 3,
+          "moveType": 0,
+          "priorityType": 0,
+          "stepAnime": false,
+          "through": false,
+          "trigger": 0,
+          "walkAnime": true
+        }
+      ],
+      "x": 10,
+      "y": 21
     }
   ]
 }

--- a/CommunityLightingMZDemo/data/Map001.json
+++ b/CommunityLightingMZDemo/data/Map001.json
@@ -12211,7 +12211,7 @@
     {
       "id": 3,
       "name": "EV003",
-      "note": "<cl: light 75 #00ff00>",
+      "note": "<cl: light 75 {a#00ff0066 t120} {a#ffffff66 t120}>",
       "pages": [
         {
           "conditions": {
@@ -12660,7 +12660,7 @@
     {
       "id": 7,
       "name": "Dark cultist",
-      "note": "<CL: Light 100 cycle #ff6666 10 #66ff66 10 #ff00ff 10 Y-0.5>",
+      "note": "<CL: Light 100 {a#ff6666bb t120 X-0.5 Y0.2} {a#66ff66bb t120 x0 y0.5} {a#ff00ffbb t120 X0.5 Y0.2} {a#ff6666bb t120 X0.5 Y-0.2} {a#66ff66bb t120 x0 y-0.5} {a#ff00ffbb t120 X-0.5 Y-0.2}>",
       "pages": [
         {
           "conditions": {
@@ -13903,7 +13903,7 @@
     {
       "id": 13,
       "name": "EV013",
-      "note": "<cl: light 75 #ff00ff>",
+      "note": "<cl: light {a#ff009966 r75 t120 p60} {a#ff009999 r85 t120 p60}>",
       "pages": [
         {
           "conditions": {

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -1533,20 +1533,20 @@ class LightProperties {
     // properties with no suffix 'clear' the target
     properties.forEach((e) => {
       // clear checks (back to initial value for the given property)
-      if      (        e.equalsIC('t'))        this.transitionDuration = 0;
-      else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
-      else if (        e.equalsIC('#'))        this.color      = void (0);
-      else if (        e.equalsIC('a#'))       this.color      = void (0);
-      else if (        e.equalsIC('e'))        this.enable     = void (0);
-      else if (        e.equalsIC('b'))        this.brightness = void (0);
-      else if (        e.equalsIC('x'))        this.xOffset    = void (0);
-      else if (        e.equalsIC('y'))        this.yOffset    = void (0);
-      else if (isOL && e.equalsIC('r'))        this.radius     = void (0);
-      else if (isFL && e.equalsIC('l'))        this.beamLength = void (0);
-      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void (0);
-      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void (0);
+      if      (        e.equalsIC('t'))  { this.transitionDuration = 0; return; }
+      else if (        e.equalsIC('p'))  { this.pauseDuration      = 0; return; }
+      else if (        e.equalsIC('#'))  { this.color      = void (0); return; }
+      else if (        e.equalsIC('a#')) { this.color      = void (0); return; }
+      else if (        e.equalsIC('e'))  { this.enable     = void (0); return; }
+      else if (        e.equalsIC('b'))  { this.brightness = void (0); return; }
+      else if (        e.equalsIC('x'))  { this.xOffset    = void (0); return; }
+      else if (        e.equalsIC('y'))  { this.yOffset    = void (0); return; }
+      else if (isOL && e.equalsIC('r'))  { this.radius     = void (0); return; }
+      else if (isFL && e.equalsIC('l'))  { this.beamLength = void (0); return; }
+      else if (isFL && e.equalsIC('w'))  { this.beamWidth  = void (0); return; }
+      else if (isFL && e.equalsIC('a'))  { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('+a')) { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('-a')) { this.clockwise  = this.direction = void (0); return; }
 
       // parse suffix (individual & random ranges)
       let suffix, rand = (min, max) => Math.random() * (max - min) + min;
@@ -2154,7 +2154,7 @@ class ColorDelta {
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
       this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
-      this._cl.enable        = orBoolean(this._cl.enable, true);
+      this._cl.enable        = orBoolean(this._cl.enable, this._cl.id ? false : true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
       this._cl.id            = orNullish(this._cl.id, 0); // Alphanumeric

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -923,7 +923,8 @@ Imported[Community.Lighting.name] = true;
 * See the Plugin Commands section for more details.
 *
 * Ranges can be used if random values are desired. Cycle tags are statically generated at map
-* load. If dynamically random property values are desired, use the 'light cond' command instead.
+* load. If dynamic random property values are desired, use the 'light cond' command instead in
+* combination with the 'light wait' command.
 * See the table below for property specific formatting.
 *
 * The following table shows supported properties:

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -782,11 +782,11 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [enable] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
-* - radius      100, 250, etc
+* - radius      Any number, optionally preceded by "R" or "r", so 100, R100, r100, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -797,7 +797,8 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
 * - night       Causes the light to only come on during the night [optional]
 * - brightness  B50, B25, etc [optional]
@@ -808,20 +809,21 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [enable] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - bl:         Beam length:  Any number, optionally preceded by "L" or "l", so 8, L8, l8, etc.
+* - bw:         Beam width:  Any number, optionally preceded by "W", or 'w', so 12, W12, w12, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -832,19 +834,21 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Sets the event's light to only show during the day [optional]
 * - night       Sets the event's light to only show during night time [optional]
 * - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*               Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               Can be preceded by "D" or "d", so D4, d4, etc. If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A" or "a". If
 *               omitted, sdir is used. [optional]
 * - x           x[offset] Work the same as regular light [optional]
 * - y           y[offset] [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Example note tags:
 *
@@ -852,10 +856,10 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
-* <cl: light 300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
+* <cl: light r300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
+* <cl: light r300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
 * <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
@@ -884,7 +888,7 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
+* <cl: light r300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
@@ -2069,34 +2073,38 @@ class ColorDelta {
     this._cl.type = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._cl.type) {
-      let isFL       = ()        => this._cl.type.is(LightType.Flashlight); // is flashlight
-      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
-      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
-      let isNul      = (e)       => e == null;
-      let isDayNight = (e)       => isEq(e, "night", "day");
-      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let isFL       = ()          => this._cl.type.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, s0, s1) => s0 && e.equalsIC(s0)     || s1 && e.equalsIC(s1);
+      let isPre      = (e, p0, p1) => p0 && e.startsWithIC(p0) || p1 && e.startsWithIC(p1);
+      let isPreNum   = (e, p, n)   => p  && e.startsWithIC(p)  && !isNaN(n);
+      let isNul      = (e)         => e == null;
+      let isDayNight = (e)         => isEq(e, "night", "day");
+      let clipNum    = (e)         => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        let n = clip(e);
-        if      (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
+        let n = clipNum(e);
+        console.log()
+        if      (!isFL() && isPreNum(e, 'r', n) && isNul(this._cl.radius))     this._cl.radius     = n;
+        else if (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamWidth))  this._cl.beamWidth  = +e;
-        else if (isFL()  && isPre(e, "l") && n  && isNul(this._cl.beamLength)) this._cl.beamLength = n;
-        else if (isFL()  && isPre(e, "w") && n  && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
-        else if (           isEq(e, "cycle")    && isNul(this._cl.color))      hasCycle            = true;
-        else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
-        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
-        else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
+        else if (isFL()  && isPreNum(e, 'l', n) && isNul(this._cl.beamLength)) this._cl.beamLength = n;
+        else if (isFL()  && isPreNum(e, 'w', n) && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
+        else if (           isEq(e, 'cycle')    && isNul(this._cl.color))      hasCycle            = true;
+        else if (           isPre(e, '#', 'a#') && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex] .push('p' + e);
+        else if (           isPre(e, '#', 'a#') && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
+        else if (           isPreNum(e, 'e', n) && isNul(this._cl.enable))     this._cl.enable     = Boolean(n);
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable     = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable     = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
-        else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;
+        else if (           isPreNum(e, 'b', n) && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = n;
         else if ( isFL() && !isNaN(+e)          && isNul(this._cl.direction))  this._cl.direction  = +e;
-        else if ( isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
-        else if ( isFL() && isPre(e, "a") && n  && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
-        else if (           isPre(e, "x") && n  && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
-        else if (           isPre(e, "y") && n  && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
+        else if ( isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
+        else if ( isFL() && isPreNum(e, 'a', n) && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
+        else if (           isPreNum(e, 'x', n) && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
+        else if (           isPreNum(e, 'y', n) && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
         else if (           e.length > 0        && isNul(this._cl.id))         this._cl.id         = e;
         cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -1197,13 +1197,13 @@ Imported[Community.Lighting.name] = true;
 const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
 const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
 
-Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
-Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
-Number.prototype.clone        = function()        { return this; };
-Boolean.prototype.clone       = function()        { return this; };
-String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
+Number.prototype.is           = function(...a)     { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max) { return this >= min && this <= max; };
+Number.prototype.clone        = function()         { return this; };
+Boolean.prototype.clone       = function()         { return this; };
+String.prototype.equalsIC     = function(...a)     { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)        { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) =>  minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
@@ -1308,7 +1308,7 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
  * @param {Number} a
  * @returns {String}
  */
- function rgba(r, g, b, a) {
+function rgba(r, g, b, a) {
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
@@ -2513,8 +2513,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distpart > lightsOnRadius) {
+        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distanceApart > lightsOnRadius) {
           continue;
         }
       }
@@ -2674,7 +2674,7 @@ class ColorDelta {
   * @param {Number} brightness
   * @param {VRGBA} c1
   * @param {VRGBA} c2
-   */
+  */
   CanvasGradient.prototype.addTransparentColorStops = function (brightness, c1, c2) {
     if (brightness) {
       if (!useSmootherLights) {

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -1358,12 +1358,22 @@ class VRGBA {
   }
 
   /**
-   * Creates an empty VRGBA object will all properties initialized to false and 0.
+   * Creates an VRGBA object will r,g,b,a = 0 and v = false.
    * @returns {VRGBA}
    */
-  static empty() {
+  static minRGBA() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
+    return that;
+  }
+
+  /**
+   * Creates an VRGBA object will r,g,b,a = 255 and v = false.
+   * @returns {VRGBA}
+   */
+  static maxRGBA() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [false, 255, 255, 255, 255];
     return that;
   }
 
@@ -1916,7 +1926,7 @@ class ColorDelta {
     catch (e) {
       let CL = Community.Lighting;
       console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
-      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
+      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.minRGBA(), "isNight": false }));
     }
     return result;
   })(parameters["DayNight Colors"], parameters["Night Hours"]);
@@ -2068,7 +2078,7 @@ class ColorDelta {
 
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
-      this._cl.color         = orNullish(this._cl.color, VRGBA.empty());
+      this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
       this._cl.enable        = orBoolean(this._cl.enable, true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
@@ -2561,9 +2571,9 @@ class ColorDelta {
             let flashlength = cur.getLightFlashlightLength();
             let flashwidth  = cur.getLightFlashlightWidth();
             if (!isNaN(direction)) ldir = direction;
-            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
+            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.minRGBA(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.minRGBA(), objectflicker,
                                                      brightness, direction);
           }
         }
@@ -2595,7 +2605,7 @@ class ColorDelta {
         tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
         tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.minRGBA(), objectflicker,
                                                tile.brightness);
     });
 
@@ -3103,7 +3113,7 @@ class ColorDelta {
     // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
-            $gameVariables.GetTint() : new VRGBA("#ffffff");
+            $gameVariables.GetTint() : VRGBA.maxRGBA();
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {
@@ -3564,7 +3574,7 @@ Game_Variables.prototype.SetTint = function (value) {
   this._Community_Tint_Value = value.clone();
 };
 Game_Variables.prototype.GetTint = function () {
-  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.empty();
+  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.minRGBA();
   return this._Community_Tint_Value.clone();
 };
 Game_Variables.prototype.SetTintAtHour = function (hour, color) {
@@ -3577,7 +3587,7 @@ Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   while (hours >= hoursinDay) hours -= hoursinDay;
   while (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
-  return result ? result.color.clone() : VRGBA.empty();
+  return result ? result.color.clone() : VRGBA.minRGBA();
 };
 Game_Variables.prototype.SetTintTarget = function (delta) {
   this._Community_TintTarget = delta;
@@ -3617,7 +3627,7 @@ Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if emp
   if (value) this._Community_Lighting_PlayerColor = new VRGBA(value);
 };
 Game_Variables.prototype.GetPlayerColor = function () {
-  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = new VRGBA("#ffffff");
+  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = VRGBA.maxRGBA();
   return this._Community_Lighting_PlayerColor.clone();
 };
 Game_Variables.prototype.SetPlayerBrightness = function (value) { // don't set if invalid.
@@ -3672,7 +3682,7 @@ Game_Variables.prototype.GetDaynightColorArray = function () {
   if (hoursInDay > result.length) { // lazy check bounds before returning and add colors if too small
     let origLength = result.length;
     result.length = hoursInDay;     // more efficient than a for loop
-    result.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+    result.fill({ "color": VRGBA.maxRGBA(), "isNight": false }, origLength);
   }
   this._Community_Lighting_DayNightColorArray = result; // assign reference
   return result;

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -302,8 +302,8 @@ Imported[Community.Lighting.name] = true;
 * @----------------------------
 *
 * @command condLight
-* @text Conditional Lighting
-* @desc Set conditional lighting properties. Supports: Fade, color, angle, brightness, x offset, y offset, radius, length, width.
+* @text Set Conditional Lighting
+* @desc Supports transition & pause durations, color, angle, brightness, x offset, y offset, radius, beam length & width.
 *
 * @arg id
 * @text Event ID
@@ -312,9 +312,9 @@ Imported[Community.Lighting.name] = true;
 *
 * @arg properties
 * @text properties
-* @desc Supported prefixes: f, #, #a, a, b, x, y, r, l, w.
+* @desc Format: [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
 * @type text
-* @default f5 #ffffff b0 x0 y0 r150
+* @default t5 #ffffff -a90 b0 x0 y0 r150 l12 w12
 *
 * @----------------------------
 *
@@ -783,16 +783,19 @@ Imported[Community.Lighting.name] = true;
 * Events
 * --------------------------------------------------------------------------
 * Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
-*               that will be cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
-*               fadeDuration and growRadius are optional argument used to transition between colors
-*               and radius sizes over the provided cycle interval. If growRadius is not provided
-*               the default radius is used for the given color. In Terrax Lighting, there was a hard
-*               limit of 4, but now you can use as many as you want. [optional]
+* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+*               through before repeating from the beginning. See the examples below for usage.
+*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+*               To cycle any light property or for fade transitions, use the cycleProps
+*               format instead. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
 * - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
@@ -805,40 +808,43 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not begin with 'd', 'x' or 'y' otherwise
-*               they will be mistaken for one of the previous optional parameters.
+*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
+*               where N is a number otherwise they will be mistaken for one of the previous
+*               optional parameters.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
 * Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
-*             grow_bw tuples to follow that will be cycled through before repeating
-*             from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
-*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
-*             transition between colors and beam lengths & widths over the provided
-*             cycle interval. If grow_bl or grow_bw are not provided, the default
-*             length or width is used for the given color. There's no limit to how
-*             many colors can be cycled. [optional]
-* - color     #ffffff, #ff0000, etc
-* - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
-* - day       Sets the event's light to only show during the day [optional]
-* - night     Sets the event's light to only show during night time [optional]
-* - sdir:     Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*             Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:    Forced direction in degrees (optional): must be preceded by "A". If
-*             omitted, sdir is used. [optional]
-* - x         x[offset] Work the same as regular light [optional]
-* - y         y[offset] [optional]
-* - id        1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*             These should not begin with 'a', 'd', 'x' or 'y' otherwise
-*             they will be mistaken for one of the previous optional parameters.
+* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
+* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+*               through before repeating from the beginning. See the examples below for usage.
+*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+*               To cycle any light property or for fade transitions, use the cycleProps
+*               format instead. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
+* - color       #ffffff, #ff0000, etc
+* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - day         Sets the event's light to only show during the day [optional]
+* - night       Sets the event's light to only show during night time [optional]
+* - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
+*               Can be preceded by "D", so D4.  If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               omitted, sdir is used. [optional]
+* - x           x[offset] Work the same as regular light [optional]
+* - y           y[offset] [optional]
+* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
+*               where N is a number otherwise they will be mistaken for one of the previous
+*               optional parameters.
 *
 * Example note tags:
 *
@@ -846,12 +852,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
+* <cl: light 300 {#ff0000 p15} {#ffff00 p15} {#00ff00 p15} {#00ffff p15} {#0000ff p15}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* <cl: light 300 {#ff0000 t30 p60} {#ffff00 t30 p60} {#00ff00 t30 p60} {#00ffff t30 p60}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
-* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* <cl: light {#ff0000 t30 p60 r250} {#ffff00 t30 p60 r300} {#00ff00 t30 p60 r250} {#00ffff t30 p60 r300}>
 * Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
 * and transitions to the next color and size over 60 frames.
 *
@@ -862,9 +869,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
-* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
+* <cl: Flashlight l8 w12 #ff0000 on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
+*
+* <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15>
+* <cl: Flashlight l8 w12 {#f00 p15} {#ff0 p15} {#0f0 p15}>
+* Creates a flashlight beam that rotates every 15 frames.
 *
 * --------------------------------------------------------------------------
 * Additive Lighting Effects
@@ -873,12 +884,54 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 cycle a#990000 15 a#999900 15 a#009900 15 a#009999 15 a#000099 15>
+* <cl: light 300 {a#990000 t15} {a#999900 t15} {a#009900 t15} {a#009999 t15} {a#000099 t15}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
 * Creates a red volumetric flashlight beam with id asdf which can be turned on or off
 * via plugin commands.
+*
+* --------------------------------------------------------------------------
+* Conditional Lighting
+* --------------------------------------------------------------------------
+* Conditional Lighting allows light properties to be changed either cyclically or
+* dynamically over time via properties that consist of a prefix followed by a property
+* value. This is useful for creating any number of transitional lighting effects.
+*
+* The properties are supported in light tags or via the 'light cond' command. Light tags
+* support any number of light properties wrapped in {} brackets See the example note tags
+* above.
+*
+* The 'light cond' command allows for conditional lights to be dynamically changed on demand.
+* See the Plugin Commands section for more details.
+*
+* The following chart shows all supported properties:
+* --------------------------------------------------------------------------------------------------------------------
+* |   Property     |  Prefix   |        Format           | Examples          | Description                            |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     pause      |     p     |           pN            |    p0, p1, p20    | time period in cycles to pause after   |
+* |    duration    |           |                         |                   | transitioning for cycling lights       |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   transition   |     t     |           tN            |    t0, t1, t30    | time period to transition the          |
+* |    duration    |           |                         |                   | specified properties over              |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     color      |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | a#FFEEDD, #ffeedd | color or additive color                |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     angle      | a, +a, -a |       <a|+a|-a>N        |  a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |                |           |                         |                   | clockwise, '-' moves counterclockwise  |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   brightness   |     b     |           bN            |    b0, b1, b5     | brightness                             |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    x offset    |     x     |           xN            |     x2, x-2       | x offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    y offset    |     y     |           yN            |     y2, y-2       | y offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     radius     |     r     |           rN            |    r50, r150      | light radius                           |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam length  |     l     |           lN            |   l8, l9, l10     | flashlight beam length                 |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam width   |     w     |           wN            |  w12, w13, w14    | flashlight beam width                  |
+* --------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
 * Easy hex color references
@@ -960,6 +1013,13 @@ Imported[Community.Lighting.name] = true;
 *
 * Light off id
 * - Turn off light with matching id number
+*
+* Light cond id [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+* - transitions a conditional light to the specified properties over the the given
+* - time period in cycles. Supported propreties are color, flashlight angle (a),
+* - brightness (b), x offset (x), y offset (y), radius (r), flashlight beam length (l),
+* - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
+* - ignored. See the Conditional Light section for more detail on each property.
 *
 * Light color id c
 * - Change the color (c) of lightsource with id (id)
@@ -1135,16 +1195,17 @@ Imported[Community.Lighting.name] = true;
 * ....where # is the max distance you want in tiles.
 */
 
-Number.prototype.is           = function (...a) { return a.includes(Number(this)); };
-Number.prototype.inRange      = function (min, max) { return this >= min && this <= max; };
-String.prototype.equalsIC     = function (...a) { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function (s) { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Math.min(...a) : Math.max(...a); }; // min if positive
+const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
+const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
+
+Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
+String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
-
-let cmpFloat = (x, y) => Math.abs(x - y) < 1e-3; // custom epsilon
 
 function orBoolean(...a) {
   for (let i = 0; i < a.length; i++) {
@@ -1157,6 +1218,85 @@ function orBoolean(...a) {
 }
 function orNullish(...a) { for (let i = 0; i < a.length; i++) if (a[i] != null) return a[i]; }
 function orNaN(...a)     { for (let i = 0; i < a.length; i++) if (!isNaN(a[i])) return a[i]; }
+
+let isOn         = (x) => x.toLowerCase() === "on";
+let isOff        = (x) => x.toLowerCase() === "off";
+let isActivate   = (x) => x.toLowerCase() === "activate";
+let isDeactivate = (x) => x.toLowerCase() === "deactivate";
+
+// Map community light directions to polar angles (360 degrees)
+const CLDirectionMap = {
+  0: undefined,       // auto
+  1: 3 * Math.PI / 2, // up
+  2: 2 * Math.PI,     // right
+  3: Math.PI / 2,     // down
+  4: Math.PI          // left
+};
+
+// Map RM directions to polar angles (360 degrees)
+const RMDirectionMap = {
+  1: 3 * Math.PI / 4, // down-left
+  2: Math.PI / 2,     // down
+  3: Math.PI / 4,     // down-right
+  4: Math.PI,         // left
+  6: 2 * Math.PI,     // right
+  7: 5 * Math.PI / 4, // up-left
+  8: 3 * Math.PI / 2, // up
+  9: 7 * Math.PI / 4  // up-right
+};
+
+const TileType = {
+  Terrain: 1, terrain: 1, 1: 1,
+  Region:  2, region:  2, 2: 2
+};
+
+const LightType = {
+  Light     : 1, light     : 1, 1: 1,
+  Fire      : 2, fire      : 2, 2: 2,
+  Flashlight: 3, flashlight: 3, 3: 3,
+  Glow      : 4, glow      : 4, 4: 4
+};
+
+const TileLightType = {
+  tilelight:   [TileType.Terrain, LightType.Light],
+  tilefire:    [TileType.Terrain, LightType.Fire],
+  tileglow:    [TileType.Terrain, LightType.Glow],
+  regionlight: [TileType.Region,  LightType.Light],
+  regionfire:  [TileType.Region,  LightType.Fire],
+  regionglow:  [TileType.Region,  LightType.Glow],
+};
+
+const TileBlockType = {
+  tileblock:   TileType.Terrain,
+  regionblock: TileType.Region
+};
+
+class TileLight {
+  constructor(tileType, lightType, id, onoff, color, radius, brightness) {
+    this.tileType   = TileType[tileType];
+    this.lightType  = LightType[lightType];
+    this.id         = +id || 0;
+    this.enabled    = isOn(onoff);
+    this.color      = new VRGBA(color);
+    this.radius     = +radius || 0;
+    this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) ||
+                      Community.Lighting.defaultBrightness || 0;
+  }
+}
+
+class TileBlock {
+  constructor(tileType, id, onoff, color, shape, xOffset, yOffset, blockWidth, blockHeight) {
+    this.tileType    = TileType[tileType];
+    this.id          = +id || 0;
+    this.enabled     = isOn(onoff);
+    this.color       = new VRGBA(color);
+    this.shape       = +shape || 0;
+    this.xOffset     = +xOffset || 0;
+    this.yOffset     = +yOffset || 0;
+    this.blockWidth  = +blockWidth || 0;
+    this.blockHeight = +blockHeight || 0;
+  }
+}
 
 const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive lighting
 
@@ -1171,18 +1311,18 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
-/** Class to handle volumetric/additive coloring with rgba colors uniformly.
- *  Additive coloring prefixes an 'a' on a normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
+/** Class to handle volumetric/additive coloring with rgba colors uniformly. Additive coloring prefixes an 'a' on a
+ *  normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
  */
 class VRGBA {
   /**
-   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a hex String
-   * can be passed with an optional default alternative Hex string, or another VRGBA object can be passed to create a clone.
+   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a
+   * hex String can be passed with an optional default alternative Hex string which is used in case of parsing failure.
    * @param {String|Boolean|VRGBA} vOrHex     - Boolean representing the additive component, or
    *                                            String representing the hex color, or
    *                                            other VRGBA object to clone.
    * @param {String|Number}        rOrDefault - Number representing the red component, or
-   *                                            String representing a default hex string in case the provided one cannot be parsed.
+   *                                            String representing a default hex string.
    * @param {null|Number}          g          - Number representing the green component.
    * @param {null|Number}          b          - Number representing the blue component.
    * @param {null|Number}          a          - Number representing the alpha component.
@@ -1233,26 +1373,15 @@ class VRGBA {
   set(that) { for (let k in that) if (this[k] != null) this[k] = that[k]; }
 
   /**
-   * Compares this Object to that Object and returns true if the v, r, g, b, and a properties are equal; otherwise false.
-   * @param {VRGBA} that
-   * @returns {Boolean}
-   */
-  equals(that) { // fastest non-exactness comparison -- only checks v, r, g, b, a properties
-    let [a, b] = [this, that];
-    if (b && cmpFloat(a.v, b.v) && cmpFloat(a.r, b.r) && cmpFloat(a.g, b.g) && cmpFloat(a.b, b.b) && cmpFloat(a.a, b.a))
-      return true;
-    return false;
-  }
-
-  /**
    * Adds together the r, g, and b properties and returns the result.
    * @returns {Number}
    */
   magnitude() { return this.r + this.g + this.b; }
 
   /**
-   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String. If invalid, a default
-   * value of "#000000ff" is returned. If either provided String is valid, it will be returned as an 'a#rrggbbaa' formatted color hex String.
+   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String.
+   * If invalid, a default value of "#000000ff" is returned. If either provided String is valid, it will be returned
+   * as an 'a#rrggbbaa' formatted color hex String.
    * @param {String} hex
    * @param {String} alt
    * @returns {String}
@@ -1272,9 +1401,10 @@ class VRGBA {
   }
 
   /**
-   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the hex is additive or not.
-   * The setWebSafe parameter is used to to strip the additive property (v) so that the resulting color can be used with Canvas APIs. An
-   * override Object can be provided to override the existing v, r, g, b, or a properties in the output.
+   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the
+   * hex is additive or not. The setWebSafe parameter is used to to strip the additive property (v) so that the
+   * resulting color can be used with Canvas APIs. An override Object can be provided to override the existing v, r, g,
+   * b, or a properties in the output.
    * @param {Boolean} setWebSafe
    * @param {VRGBA} override
    * @returns {String}
@@ -1303,31 +1433,37 @@ class VRGBA {
 }
 
 /**
- * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability to compute deltas
- * between the current parameter values and the target values, and allows for current values to be extracted.
+ * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability
+ * to compute deltas between the current parameter values and the target values, and allows for current values to be
+ * extracted.
  **/
 class ConditionalLight {
   /**
    * Creates a ConditionalLight object with the provided parameters
-   * @param {VRGBA}  color
-   * @param {Number} direction
-   * @param {Number} brightness
-   * @param {Number} xOffset
-   * @param {Number} yOffset
-   * @param {Number} radius
-   * @param {Number} beamLength
-   * @param {Number} beamWidth
+   * @param {LightType} type
+   * @param {VRGBA}     currentColor
+   * @param {Number}    currentDirection
+   * @param {Number}    currentBrightness
+   * @param {Number}    currentXOffset
+   * @param {Number}    currentYOffset
+   * @param {Number}    currentRadius
+   * @param {Number}    currentBeamLength
+   * @param {Number}    currentBeamWidth
    **/
-  constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
+              currentBeamLength, currentBeamWidth) {
     if (arguments.length == 0) return;
-    this.color      = color;
-    this.direction  = direction;
-    this.brightness = brightness;
-    this.xOffset    = xOffset;
-    this.yOffset    = yOffset;
-    this.radius     = radius;
-    this.beamLength = beamLength;
-    this.beamWidth  = beamWidth;
+    this.transitionDuration = 0;
+    this.pauseDuration      = 0;
+    this.type               = type;
+    this.currentColor       = currentColor;
+    this.currentDirection   = this.isFlashlight() ? currentDirection  : void(0);
+    this.currentBrightness  = currentBrightness;
+    this.currentXOffset     = currentXOffset;
+    this.currentYOffset     = currentYOffset;
+    this.currentRadius      = this.isOtherLight() ? currentRadius     : void(0);
+    this.currentBeamLength  = this.isFlashlight() ? currentBeamLength : void(0);
+    this.currentBeamWidth   = this.isFlashlight() ? currentBeamWidth  : void(0);
   }
 
   /**
@@ -1336,89 +1472,162 @@ class ConditionalLight {
    **/
   clone() {
     let that = new ConditionalLight();
-    // clone properties
-    if (this.color      != null) that.color      = this.color.clone();
-    if (this.direction  != null) that.direction  = this.direction;
-    if (this.brightness != null) that.brightness = this.brightness;
-    if (this.xOffset    != null) that.xOffset    = this.xOffset;
-    if (this.yOffset    != null) that.yOffset    = this.yOffset;
-    if (this.radius     != null) that.radius     = this.radius;
-    if (this.beamLength != null) that.beamLength = this.beamLength;
-    if (this.beamWidth  != null) that.beamWidth  = this.beamWidth;
+    // clone durations
+    if (this.transitionDuration != null) that.transitionDuration = this.transitionDuration;
+    if (this.pauseDuration      != null) that.pauseDuration      = this.pauseDuration;
+    // clone type
+    if (this.type               != null) that.type               = this.type;
+    // clone currents
+    if (this.currentColor       != null) that.currentColor       = this.currentColor.clone();
+    if (this.currentDirection   != null) that.currentDirection   = this.currentDirection;
+    if (this.currentBrightness  != null) that.currentBrightness  = this.currentBrightness;
+    if (this.currentXOffset     != null) that.currentXOffset     = this.currentXOffset;
+    if (this.currentYOffset     != null) that.currentYOffset     = this.currentYOffset;
+    if (this.currentRadius      != null) that.currentRadius      = this.currentRadius;
+    if (this.currentBeamLength  != null) that.currentBeamLength  = this.currentBeamLength;
+    if (this.currentBeamWidth   != null) that.currentBeamWidth   = this.currentBeamWidth;
+    // clone targets
+    if (this.targetColor        != null) that.targetColor        = this.targetColor.clone();
+    if (this.targetDirection    != null) that.targetDirection    = this.targetDirection;
+    if (this.targetBrightness   != null) that.targetBrightness   = this.targetBrightness;
+    if (this.targetXOffset      != null) that.targetXOffset      = this.targetXOffset;
+    if (this.targetYOffset      != null) that.targetYOffset      = this.targetYOffset;
+    if (this.targetRadius       != null) that.targetRadius       = this.targetRadius;
+    if (this.targetBeamLength   != null) that.targetBeamLength   = this.targetBeamLength;
+    if (this.targetBeamWidth    != null) that.targetBeamWidth    = this.targetBeamWidth;
     // clone deltas
-    if (this.colorDelta      != null) that.colorDelta      = this.colorDelta     .clone();
-    if (this.directionDelta  != null) that.directionDelta  = this.directionDelta .clone();
-    if (this.brightnessDelta != null) that.brightnessDelta = this.brightnessDelta.clone();
-    if (this.xOffsetDelta    != null) that.xOffsetDelta    = this.xOffsetDelta   .clone();
-    if (this.yOffsetDelta    != null) that.yOffsetDelta    = this.yOffsetDelta   .clone();
-    if (this.radiusDelta     != null) that.radiusDelta     = this.radiusDelta    .clone();
-    if (this.beamLengthDelta != null) that.beamLengthDelta = this.beamLengthDelta.clone();
-    if (this.beamWidthDelta  != null) that.beamWidthDelta  = this.beamWidthDelta .clone();
+    if (this.deltaColor         != null) that.deltaColor         = this.deltaColor     .clone();
+    if (this.deltaDirection     != null) that.deltaDirection     = this.deltaDirection .clone();
+    if (this.deltaBrightness    != null) that.deltaBrightness    = this.deltaBrightness.clone();
+    if (this.deltaXOffset       != null) that.deltaXOffset       = this.deltaXOffset   .clone();
+    if (this.deltaYOffset       != null) that.deltaYOffset       = this.deltaYOffset   .clone();
+    if (this.deltaRadius        != null) that.deltaRadius        = this.deltaRadius    .clone();
+    if (this.deltaBeamLength    != null) that.deltaBeamLength    = this.deltaBeamLength.clone();
+    if (this.deltaBeamWidth     != null) that.deltaBeamWidth     = this.deltaBeamWidth .clone();
     return that;
   }
 
   /**
-   * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
-   * @param {Number} fadeDuration
-   * @param {Number} pauseDuration
-   * @param {VRGBA}  tColor
-   * @param {Number} tDirection
-   * @param {Number} tBrightness
-   * @param {Number} tXOffset
-   * @param {Number} tYOffset
-   * @param {Number} tRadius
-   * @param {Number} tBeamLength
-   * @param {Number} tBeamWidth
+   * Returns true if the light type is a flashlight; otherwise false.
    */
-  setupTargets(fadeDuration, pauseDuration, tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
-    if (this.color      != null) this.colorDelta      = ColorDelta.createLight(this.color,  tColor,      fadeDuration, pauseDuration);
-    if (this.direction  != null) this.directionDelta  = NumberDelta.create(this.direction,  tDirection,  fadeDuration);
-    if (this.brightness != null) this.brightnessDelta = NumberDelta.create(this.brightness, tBrightness, fadeDuration);
-    if (this.xOffset    != null) this.xOffsetDelta    = NumberDelta.create(this.xOffset,    tXOffset,    fadeDuration);
-    if (this.yOffset    != null) this.yOffsetDelta    = NumberDelta.create(this.yOffset,    tYOffset,    fadeDuration);
-    if (this.radius     != null) this.radiusDelta     = NumberDelta.create(this.radius,     tRadius,     fadeDuration);
-    if (this.beamLength != null) this.beamLengthDelta = NumberDelta.create(this.beamLength, tBeamLength, fadeDuration);
-    if (this.beamWidth  != null) this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  tBeamWidth,  fadeDuration);
+  isFlashlight() { return this.type.is(LightType.Flashlight); }
+
+  /**
+   * Returns true if the light type is light, fire, or glow; otherwise false.
+   */
+  isOtherLight() { return this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
+
+  /**
+   * Sets up all supported targets.
+   * @param {VRGBA}  targetColor
+   * @param {Number} targetDirection
+   * @param {Number} targetBrightness
+   * @param {Number} targetXOffset
+   * @param {Number} targetYOffset
+   * @param {Number} targetRadius
+   * @param {Number} targetBeamLength
+   * @param {Number} targetBeamWidth
+   */
+  setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
+             targetBeamLength, targetBeamWidth) {
+    if (targetColor       != null) this.targetColor      = targetColor;
+    if (targetDirection   != null) this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
+    if (targetBrightness  != null) this.targetBrightness = targetBrightness;
+    if (targetXOffset     != null) this.targetXOffset    = targetXOffset;
+    if (targetYOffset     != null) this.targetYOffset    = targetYOffset;
+    if (targetRadius      != null) this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
+    if (targetBeamLength  != null) this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
+    if (targetBeamWidth   != null) this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
   }
 
   /**
-   * Processes and sets current conditional light properties from a string array.
+   * Processes and sets target transition and pause duration properties from a string array.
    * @param {String[]} properties
    **/
-  parseCondLightProps(properties) {
-    properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.direction  = orNaN(Math.PI / 180 * +(e.slice(1)));
-      else if (e.startsWithIC('b'))  this.brightness = orNaN(+e.slice(1));
-      else if (e.startsWithIC('x'))  this.xOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('y'))  this.yOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('r'))  this.radius     = orNaN(+e.slice(1));
-      else if (e.startsWithIC('l'))  this.beamLength = orNaN(+e.slice(1));
-      else if (e.startsWithIC('w'))  this.beamWidth  = orNaN(+e.slice(1));
-    });
+  parseDurationProps(properties) {
+    this.transitionDuration = properties.find((e) => (e.startsWithIC('t')));
+    this.pauseDuration      = properties.find((e) => (e.startsWithIC('p')));
+    this.transitionDuration = this.transitionDuration ? +this.transitionDuration.slice(1) : 0;
+    this.pauseDuration      = this.pauseDuration      ? +this.pauseDuration.slice(1)      : 0;
   }
 
   /**
-   * Processes and sets target conditional light properties from a string array.
+   * Processes and sets current properties from a string array.
    * @param {String[]} properties
    **/
-  parseTargetCondLightProps(properties) {
-    let fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
-    let pauseDuration = properties.find((e) => (e.startsWithIC('p')));
-    fadeDuration      = fadeDuration ?  +fadeDuration.slice(1)  : 0;
-    pauseDuration     = pauseDuration ? +pauseDuration.slice(1) : 0;
+  parseCurrentProps(properties) {
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
-      else if (e.startsWithIC('a#')) this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
-      else if (e.startsWithIC('a'))  this.directionDelta  = NumberDelta.create(this.direction,  Math.PI / 180 * +(e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('b'))  this.brightnessDelta = NumberDelta.create(this.brightness, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('x'))  this.xOffsetDelta    = NumberDelta.create(this.xOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('y'))  this.yOffsetDelta    = NumberDelta.create(this.yOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('r'))  this.radiusDelta     = NumberDelta.create(this.radius,     orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('l'))  this.beamLengthDelta = NumberDelta.create(this.beamLength, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('w'))  this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  orNaN(+e.slice(1)), fadeDuration);
-    });
+      if      (                       e.startsWithIC('#'))  this.currentColor      = new VRGBA(e);
+      else if (                       e.startsWithIC('a#')) this.currentColor      = new VRGBA(e);
+      else if (this.isFlashlight() && e.startsWithIC('a'))  this.currentDirection  = M_PI_180 * orNaN(+e.slice(1), 0);
+      else if (this.isFlashlight() && e.startsWithIC('+a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
+      else if (this.isFlashlight() && e.startsWithIC('-a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
+      else if (                       e.startsWithIC('b'))  this.currentBrightness = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('x'))  this.currentXOffset    = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('y'))  this.currentYOffset    = orNaN(+e.slice(1));
+      else if (this.isOtherLight() && e.startsWithIC('r'))  this.currentRadius     = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('l'))  this.currentBeamLength = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('w'))  this.currentBeamWidth  = orNaN(+e.slice(1));
+    }, this);
+  }
+
+  /**
+   * Processes and sets target properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseTargetProps(properties) {
+    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
+
+    let normalizeClockwiseMovement = (target) => {
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
+      if (this.currentDirection > this.targetDirection) this.targetDirection += M_2PI; // clockwise normalize
+    };
+    let normalizeCounterClockwiseMovement = (target) => {
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
+      if (this.currentDirection < this.targetDirection) this.targetDirection -= M_2PI; // c-clockwise normalize
+    };
+    properties.forEach((e) => {
+      if      (                       e.startsWithIC('#'))  this.targetColor = new VRGBA(e);
+      else if (                       e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
+      else if (this.isFlashlight() && e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
+      else if (this.isFlashlight() && e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (this.isFlashlight() && e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (                       e.startsWithIC('b'))  this.targetBrightness = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('x'))  this.targetXOffset    = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('y'))  this.targetYOffset    = orNaN(+e.slice(1));
+      else if (this.isOtherLight() && e.startsWithIC('r'))  this.targetRadius     = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('l'))  this.targetBeamLength = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('w'))  this.targetBeamWidth  = orNaN(+e.slice(1));
+    }, this);
+  }
+
+  /**
+   * Create deltas from currents, targets, and transition duration.
+   **/
+  createDeltas() {
+    let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
+    let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
+    // assign deltas if current & targets exist
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.transitionDuration);
+    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.transitionDuration);
+    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.transitionDuration);
+    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.transitionDuration);
+    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.transitionDuration);
+    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.transitionDuration);
+    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.transitionDuration);
+    // assign new currents for existing deltas (to propagate currents for duration = 0)
+    if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
+    if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
+    if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.get();
+    if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .get();
+    if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .get();
+    if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .get();
+    if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.get();
+    if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .get();
   }
 
   /**
@@ -1426,14 +1635,19 @@ class ConditionalLight {
    * @returns {this}
    */
   next() {
-    if (this.colorDelta      != null) this.color      = this.colorDelta     .next().get();
-    if (this.directionDelta  != null) this.direction  = this.directionDelta .next().get();
-    if (this.brightnessDelta != null) this.brightness = this.brightnessDelta.next().get();
-    if (this.xOffsetDelta    != null) this.xOffset    = this.xOffsetDelta   .next().get();
-    if (this.yOffsetDelta    != null) this.yOffset    = this.yOffsetDelta   .next().get();
-    if (this.radiusDelta     != null) this.radius     = this.radiusDelta    .next().get();
-    if (this.beamLengthDelta != null) this.beamLength = this.beamLengthDelta.next().get();
-    if (this.beamWidthDelta  != null) this.beamWidth  = this.beamWidthDelta .next().get();
+    if (this.finished()) return this;
+    if (this.transitionDuration > 0) { // only update if transition duration isn't 0 (finished)
+      if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
+      if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
+      if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
+      if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .next().get();
+      if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .next().get();
+      if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
+      if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
+      if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
+      this.transitionDuration--;
+    } else
+      this.pauseDuration--;
     return this;
   }
 
@@ -1441,12 +1655,12 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() {
-    return this.colorDelta.finished();
-  }
+  finished() { return this.transitionDuration <= 0 && this.pauseDuration <= 0; }
 }
 
-/** Class representing individual number deltas for providing number changes over time at different speeds. **/
+/**
+ * Class representing individual number deltas for providing number changes over time at different speeds.
+ **/
 class NumberDelta {
   /**
    * Creates a number delta from the start number, target number, and duration.
@@ -1457,8 +1671,9 @@ class NumberDelta {
    */
   constructor(start, target, duration) {
     if (arguments.length == 0) return;
-    [this.current, this.target, this.duration, this.lazyEquals, this.delta] =
-    [start,        target,      duration,      false,           (target - start) / duration];
+    let delta = target == start ? 0 : (target - start) / duration;
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta] = [start, target, duration, false, delta];
+    this.finished(); // check for duration = 0
   }
 
   /**
@@ -1479,17 +1694,17 @@ class NumberDelta {
    * @param {Number} duration
    * @returns {NumberDelta}
    */
-  static create(start, target, duration) { return new NumberDelta(start, target, duration, duration); }
+  static create(start, target, duration) { return new NumberDelta(start, target, duration); }
 
   /**
    * Computes the next delta number in between the current number and target number.
    * @returns {this}
    */
   next() {
-    if (this.equals()) return this; // lazy-short-circuit
+    if (this.finished()) return this; // lazy-short-circuit
+    if (this.current != this.target) this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
     this.duration -= 1;
-    this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
-    this.equals();
+    this.finished();
     return this;
   }
 
@@ -1503,7 +1718,7 @@ class NumberDelta {
    * Returns true if the current number is equal to the target number; otherwise false.
    * @returns {Boolean}
    */
-  equals() {
+  finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
     if ((this.lazyEquals = this.duration <= 0))
       return (this.current = this.target, true); // set cur to refer to target on match
@@ -1511,53 +1726,56 @@ class NumberDelta {
   }
 }
 
-/** Class representing a color delta for providing color changes over time at different speeds. **/
+/**
+ * Class representing a color delta for providing color changes over time at different speeds.
+ **/
 class ColorDelta {
   /**
-   * Create a color delta from the start color, target color, fade & on durations, and
+   * Create a color delta from the start color, target color, fade duration, and
    * whether to consider the remaining ticks or not for speed purposes.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
    * @param {Number} fadeDuration
-   * @param {Number} onDuration
    * @param {Number} useTicksRemaining
    * @returns {ColorDelta}
    */
-  constructor(start, target = start, fadeDuration = 0, onDuration = 0, useTicksRemaining = false) {
+  constructor(start, target = start, fadeDuration = 0, useTicksRemaining = false) {
     if (arguments.length == 0) return;
-    this.current     = start.clone();           // - deep copy
-    this.target      = target.clone();          // - deep copy
-    this.onDuration  = orNaN(onDuration, 0);    // - parse onDuration
-    this.lazyEquals  = false;                   // - true when current value == target value
-    fadeDuration     = orNaN(fadeDuration, 0);  // - use either the remaining time (of the hour) or total fade duration
-    fadeDuration    -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
-    this.delta       = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
-                                (this.target.r - this.current.r) / fadeDuration,
-                                (this.target.g - this.current.g) / fadeDuration,
-                                (this.target.b - this.current.b) / fadeDuration,
-                                (this.target.a - this.current.a) / fadeDuration);
+    this.current       = start.clone();           // - deep copy
+    this.target        = target.clone();          // - deep copy
+    this.fadeDuration  = orNaN(fadeDuration, 0);  // - use the remaining time (of the hour) or total fade duration
+    this.fadeDuration -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.lazyEqual     = false;                   // - true when current value == target value
+    this.delta         = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                  (this.target.r - this.current.r) / this.fadeDuration,
+                                  (this.target.g - this.current.g) / this.fadeDuration,
+                                  (this.target.b - this.current.b) / this.fadeDuration,
+                                  (this.target.a - this.current.a) / this.fadeDuration);
+    this.finished(); // check for duration = 0
   }
   /**
    * Creates a copy of the ColorDelta object.
    * @returns {ColorDelta}
    **/
   clone() {
-    let that = new ColorDelta();
-    [that.current,           that.target,         that.onDuration, that.lazyEquals, that.delta] =
-    [this.current.clone(),   this.target.clone(), this.onDuration, this.lazyEquals, this.delta.clone()];
+    let that = new  ColorDelta();
+    that.current      = this.current.clone();
+    that.target       = this.target.clone();
+    that.fadeDuration = this.fadeDuration;
+    that.lazyEquals   = this.lazyEquals;
+    that.delta        = this.delta.clone();
     return that;
   }
 
   /**
-   * Creates a light delta from the start color, target color, and fade & on durations.
+   * Creates a light delta from the start color, target color, and fade duration.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
    * @param {Number} fadeDuration
-   * @param {Number} onDuration
    * @returns {ColorDelta}
    */
-  static createLight(start, target, fadeDuration, onDuration) {
-    return new ColorDelta(start, target, fadeDuration, onDuration, false /* don't use remaining ticks */);
+  static create(start, target, fadeDuration) {
+    return new ColorDelta(start, target, fadeDuration, false /* don't use remaining ticks */);
   }
 
   /**
@@ -1566,7 +1784,9 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration, 0, false); }
+  static createTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration);
+  }
 
   /**
    * Creates a battle color delta from the current battle tint, target tint, and fade duration.
@@ -1574,7 +1794,9 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createBattleTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration, 0, false); }
+  static createBattleTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration);
+  }
 
   /**
    * Creates a time color delta from the current time and speed. useCurrentTint specifies whether to
@@ -1584,13 +1806,14 @@ class ColorDelta {
    * @returns {ColorDelta}
    */
   static createTimeTint(useCurrentTint = true) {
-    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
+    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed(); // fade duration
     if (useCurrentTint) { // delta should fade from current color to target
-      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, true);
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, true);
     } else {              // start color should be the color it would normally be at the given time
-      let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
-      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a ref speed to compute the start color
-      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, false);
+      let CL = Community.Lighting; // reference CL
+      let ticks    = fadeDuration == 0 ? CL.minutes() * 60 + CL.seconds() : CL.ticks();
+      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // dur = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration);
       delta.next(ticks); // get current color based off of ticks elapsed in hour
       return delta;
     }
@@ -1603,13 +1826,14 @@ class ColorDelta {
    * @returns {this}
    */
   next(scale = 1) {
-    if (this.equals()) return (this.onDuration = Math.max(this.onDuration - 1, 0), this); // subtract onDuration and lazy-short-circuit
-    this.current.v = this.delta.v;  // Compute next color step and clamp to target
-    this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
-    this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
-    this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
-    this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
-    if (this.equals()) this.onDuration = Math.max(this.onDuration - 1, 0); // check if done and if so subtract onDuration
+    if (this.finished()) return this; // lazy-short-circuit
+    let current = this.current, target = this.target, delta = this.delta; // reference
+    if(current.v != target.v) current.v = target.v;  // Compute next step & clamp to target, check to avoid recomputing
+    if(current.r != target.r) current.r = Math.minmax(delta.r > 0, current.r + scale * delta.r, target.r);
+    if(current.g != target.g) current.g = Math.minmax(delta.g > 0, current.g + scale * delta.g, target.g);
+    if(current.b != target.b) current.b = Math.minmax(delta.b > 0, current.b + scale * delta.b, target.b);
+    if(current.a != target.a) current.a = Math.minmax(delta.a > 0, current.a + scale * delta.a, target.a);
+    this.fadeDuration -= 1;
     return this;
   }
 
@@ -1620,101 +1844,17 @@ class ColorDelta {
   get() { return this.current.clone(); } // duplicate color so reference can't be messed with
 
   /**
-   * Returns true if the current color is equal to the target color; otherwise false.
+   * Returns true if the current color is equal to the target; otherwise false.
    * @returns {Boolean}
    */
-  equals() {
+  finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
-    if ((this.lazyEquals = this.current.equals(this.target)))
-      return (this.current = this.target, true); // set cur to refer to target on match
+    if ((this.lazyEquals = this.fadeDuration <= 0)) return (this.current = this.target, true);
     return false;
-  }
-
-  /**
-   * Returns true if the current color is equal to the target and on duration has been reached; otherwise false.
-   * @returns {Boolean}
-   */
-  finished() { return this.equals() && this.onDuration == 0; }
+   }
 }
 
 (function ($$) {
-  let isOn = (x) => x.toLowerCase() === "on";
-  let isOff = (x) => x.toLowerCase() === "off";
-  let isActivate = (x) => x.toLowerCase() === "activate";
-  let isDeactivate = (x) => x.toLowerCase() === "deactivate";
-
-  // Map community light directions to polar angles (360 degrees)
-  const CLDirectionMap = {
-    0: undefined,       // auto
-    1: 3 * Math.PI / 2, // up
-    2: 2 * Math.PI,     // right
-    3: Math.PI / 2,     // down
-    4: Math.PI          // left
-  };
-
-  // Map RM directions to polar angles (360 degrees)
-  const RMDirectionMap = {
-    1: 3 * Math.PI / 4, // down-left
-    2: Math.PI / 2,     // down
-    3: Math.PI / 4,     // down-right
-    4: Math.PI,         // left
-    6: 2 * Math.PI,     // right
-    7: 5 * Math.PI / 4, // up-left
-    8: 3 * Math.PI / 2, // up
-    9: 7 * Math.PI / 4  // up-right
-  };
-
-  const TileType = {
-    Terrain: 1, terrain: 1, 1: 1,
-    Region:  2, region:  2, 2: 2
-  };
-
-  const LightType = {
-    Light     : 1, light     : 1, 1: 1,
-    Fire      : 2, fire      : 2, 2: 2,
-    Flashlight: 3, flashlight: 3, 3: 3,
-    Glow      : 4, glow      : 4, 4: 4
-  };
-
-  const TileLightType = {
-    tilelight:   [TileType.Terrain,   LightType.Light],
-    tilefire:    [TileType.Terrain,   LightType.Fire],
-    tileglow:    [TileType.Terrain,   LightType.Glow],
-    regionlight: [TileType.Region, LightType.Light],
-    regionfire:  [TileType.Region, LightType.Fire],
-    regionglow:  [TileType.Region, LightType.Glow],
-  };
-
-  const TileBlockType = {
-    tileblock:   TileType.Terrain,
-    regionblock: TileType.Region
-  };
-
-  class TileLight {
-    constructor(tileType, lightType, id, onoff, color, radius, brightness) {
-      this.tileType   = TileType[tileType];
-      this.lightType  = LightType[lightType];
-      this.id         = +id || 0;
-      this.enabled    = isOn(onoff);
-      this.color      = new VRGBA(color);
-      this.radius     = +radius || 0;
-      this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) || $$.defaultBrightness || 0;
-    }
-  }
-
-  class TileBlock {
-    constructor(tileType, id, onoff, color, shape, xOffset, yOffset, blockWidth, blockHeight) {
-      this.tileType    = TileType[tileType];
-      this.id          = +id || 0;
-      this.enabled     = isOn(onoff);
-      this.color       = new VRGBA(color);
-      this.shape       = +shape || 0;
-      this.xOffset     = +xOffset || 0;
-      this.yOffset     = +yOffset || 0;
-      this.blockWidth  = +blockWidth || 0;
-      this.blockHeight = +blockHeight || 0;
-    }
-  }
 
   class Mask_Bitmaps {
     constructor(width, height) {
@@ -1732,22 +1872,22 @@ class ColorDelta {
   let light_tiles = [];
   let block_tiles = [];
 
-  let parameters = $$.parameters;
-  let lightMaskPadding = Number(parameters["Lightmask Padding"]) || 0;
-  let useSmootherLights = orBoolean(parameters['Use smoother lights'], false);
-  let light_event_required = orBoolean(parameters["Light event required"], false);
-  let triangular_flashlight = orBoolean(parameters["Triangular flashlight"], false);
-  let shift_lights_with_events = orBoolean(parameters['Shift lights with events'], false);
-  let player_radius = Number(parameters['Player radius']) || 0;
-  let reset_each_map = orBoolean(parameters['Reset Lights'], false);
-  let noteTagKey = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
-  let dayNightSaveSeconds = Number(parameters['Save DaynightSeconds']) || 0;
-  let dayNightSaveNight = Number(parameters["Save Night Switch"]) || 0;
-  let dayNightNoAutoshadow = orBoolean(parameters["No Autoshadow During Night"], false);
-  let hideAutoShadow = false;
-  let daynightCycleEnabled = orBoolean(parameters['Daynight Cycle'], true);
-  let daynightTintEnabled = false;
-  let dayNightList = (function (dayNight, nightHours) {
+  let parameters                = $$.parameters;
+  let lightMaskPadding          = +parameters["Lightmask Padding"] || 0;
+  let useSmootherLights         = orBoolean(parameters['Use smoother lights'], false);
+  let light_event_required      = orBoolean(parameters["Light event required"], false);
+  let triangular_flashlight     = orBoolean(parameters["Triangular flashlight"], false);
+  let shift_lights_with_events  = orBoolean(parameters['Shift lights with events'], false);
+  let player_radius             = +parameters['Player radius'] || 0;
+  let reset_each_map            = orBoolean(parameters['Reset Lights'], false);
+  let noteTagKey                = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
+  let dayNightSaveSeconds       = +parameters['Save DaynightSeconds'] || 0;
+  let dayNightSaveNight         = +parameters["Save Night Switch"] || 0;
+  let dayNightNoAutoshadow      = orBoolean(parameters["No Autoshadow During Night"], false);
+  let hideAutoShadow            = false;
+  let daynightCycleEnabled      = orBoolean(parameters['Daynight Cycle'], true);
+  let daynightTintEnabled       = false;
+  let dayNightList              = (function (dayNight, nightHours) {
     let result = [];
     try {
       dayNight = JSON.parse(dayNight);
@@ -1757,7 +1897,8 @@ class ColorDelta {
         result[i] = { "color": new VRGBA(dayNight[i]), "isNight": nightHours.contains(i) };
     }
     catch (e) {
-      console.log(`${Community.Lighting.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
+      let CL = Community.Lighting;
+      console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
       result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
     }
     return result;
@@ -1845,7 +1986,8 @@ class ColorDelta {
   $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
   $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
   $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
-  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
+  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() *
+                                $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
     if (showSeconds) result = result + ":" + $$.seconds().padZero(2);
@@ -1860,9 +2002,7 @@ class ColorDelta {
   * @returns {Boolean}
   */
   Game_Temp.prototype.testAndSet = function (index, value) {
-    if (this[index] && (this[index] == value ||
-       (this[index].equals && this[index].equals(value))))
-      return false;
+    if (this[index] && this[index] == value) return false;
     return (this[index] = value, true);
   };
 
@@ -1888,78 +2028,91 @@ class ColorDelta {
   Game_Event.prototype.initLightData = function () {
     this._lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
-    let CycleGroups = [];
-    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((CycleGroups.push(group.split(/\s+/)), '')));
+
+    // parse new cycle groups format within {} braces and extract from tag data for separate handling
+    // old cycle groups are parsed in tagData loop below and are converted to the new group format
+    let cycleGroups = [];
+    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((cycleGroups.push(group.split(/\s+/)), '')));
     tagData = tagData.split(/\s+/);
     this._clType = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._clType) {
-      let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
-      let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
-      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
-      let isUndef      = (x)       => x === undefined;
-      let hasCycle = false;
+      let isFL       = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
+      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
+      let isNul      = (e)       => e == null;
+      let isDayNight = (e)       => isEq(e, "night", "day");
+      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength = +(e.slice(1));
-        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth  = +(e.slice(1));
-        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      hasCycle           = true;
-        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor      = new VRGBA(e);
-        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff      = true;
-        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff      = false;
-        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch     = e;
-        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness = Number(+(e.slice(1)) / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = +(e.slice(1));
-        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = CLDirectionMap[+(e.slice(1))];
-        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection  = Math.PI / 180 * +(e.slice(1));
-        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset    = +(e.slice(1));
-        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset    = +(e.slice(1));
-        else if (           e.length > 0                   && isUndef(this._clId))         this._clId         = e;
+        let n = clip(e);
+        if      (!isFL() && !isNaN(+e)          && isNul(this._clRadius))     this._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamLength)) this._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l") && n  && isNul(this._clBeamLength)) this._clBeamLength = n;
+        else if (isFL()  && isPre(e, "w") && n  && isNul(this._clBeamWidth))  this._clBeamWidth  = n;
+        else if (           isEq(e, "cycle")    && isNul(this._clColor))      hasCycle           = true;
+        else if (           isPre(e, "#", "a#") && hasCycle)                  cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])   cycleGroups[cycleIndex].push('p' + e);
+        else if (           isPre(e, "#", "a#") && isNul(this._clColor))      this._clColor      = new VRGBA(e);
+        else if (           isOn(e)             && isNul(this._clOnOff))      this._clOnOff      = true;
+        else if (           isOff(e)            && isNul(this._clOnOff))      this._clOnOff      = false;
+        else if (           isDayNight(e)       && isNul(this._clSwitch))     this._clSwitch     = e;
+        else if (           isPre(e, "b") && n  && isNul(this._clBrightness)) this._clBrightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = n;
+        else if ( isFL() && !isNaN(+e)          && isNul(this._clDirection))  this._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = CLDirectionMap[n];
+        else if ( isFL() && isPre(e, "a") && n  && isNul(this._clDirection))  this._clDirection  = Math.PI / 180 * n;
+        else if (           isPre(e, "x") && n  && isNul(this._clXOffset))    this._clXOffset    = n;
+        else if (           isPre(e, "y") && n  && isNul(this._clYOffset))    this._clYOffset    = n;
+        else if (           e.length > 0        && isNul(this._clId))         this._clId         = e;
+        cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);
 
       // normalize parameters
-      this._clRadius     = this._clRadius || 0;
-      this._clColor      = orNullish(this._clColor, VRGBA.empty());
-      this._clBrightness = this._clBrightness || 0;
-      this._clDirection  = orNaN(this._clDirection, undefined); // must be undefined for later checks
-      this._clId         = this._clId || 0;
-      this._clBeamLength = this._clBeamLength || 0;
-      this._clBeamWidth  = this._clBeamWidth || 0;
-      this._clOnOff      = orBoolean(this._clOnOff, true);
-      this._clXOffset    = this._clXOffset || 0;
-      this._clYOffset    = this._clYOffset || 0;
-      this._clCycle      = this._clCycle || null;
+      this._clRadius        = orNaN(this._clRadius, 0);
+      this._clColor         = orNullish(this._clColor, VRGBA.empty());
+      this._clBrightness    = orNaN(this._clBrightness, 0);
+      this._clDirection     = orNaN(this._clDirection, undefined); // must be undefined for later checks
+      this._clId            = orNullish(this._clId, 0); // Alphanumeric
+      this._clBeamLength    = orNaN(this._clBeamLength, 0);
+      this._clBeamWidth     = orNaN(this._clBeamWidth, 0);
+      this._clOnOff         = orBoolean(this._clOnOff, true);
+      this._clXOffset       = orNaN(this._clXOffset, 0);
+      this._clYOffset       = orNaN(this._clYOffset, 0);
+      this._clCycle         = this._clCycle || null;
 
       // Process cycle parameters
-      if (hasCycle && CycleGroups.length) {             // check if tag included color cycling
-        this._clCycle = [];                             // only define if cycle exists
-        let t = this;                                   // refer to this as t
-        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight = new ConditionalLight(...args);  // create conditional light
-        CycleGroups.forEach((e, i, a) => {              // ------ loop each group
-          condLight = condLight.clone();                // - clone existing conditional light (inherit properties)
-          let n = a[++i < CycleGroups.length ? i : 0];  // - get next element
-          condLight.parseCondLightProps(e);             // - parse for new properties
-          condLight.parseTargetCondLightProps(n);       // - parse for target properties
-          this._clCycle.push(condLight);                // - push to list
-        }, this);                                       // ------
-        condLight = this._clCycle.shift();              // pop front
-        this._clCondLight = condLight.clone();          // clone it to be the current cond light delta
-        this._clCycle.push(condLight);                  // push original on back of list
+      if (cycleGroups.length) {                                       // check if tag included color cycling
+        this._clCycle = [];                                           // only define if cycle exists
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
+        let condLight = new ConditionalLight(this._clType, ...args);  // create cond light with initial properties
+        cycleGroups.forEach((e, i, a) => {                            // ------ loop each group
+          condLight = condLight.clone();                              // - clone existing light (inherit properties)
+          let n = a[++i < cycleGroups.length ? i : 0];                // - get next element
+          condLight.parseDurationProps(n);                            // - parse durations
+          condLight.parseCurrentProps(e);                             // - parse for new properties
+          if (i == cycleGroups.length)                                // - last group targets initial properties
+            condLight.setTargets(...args);                            // -- setup targets based off non-cycle properties
+          condLight.parseTargetProps(n);                              // - parse for cycle target properties
+          condLight.createDeltas();                                   // - compute deltas
+          this._clCycle.push(condLight);                              // - push to list
+        }, this);                                                     // ------
+        condLight = this._clCycle.shift();                            // pop front
+        this._clCondLight = condLight.clone();                        // clone it to be the current cond light delta
+        this._clCycle.push(condLight);                                // push original on back of list
       }
 
       // Process conditional lighting
-      if (this._clId) {                                 // check for a conditional lighting ID
-        let t = this;                                   // refer to this as t
-        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight  = new ConditionalLight(...args); // create conditional light
-        condLight.setupTargets(0, 0, ...args);          // create matching targets
-        condLight.next();                               // compute deltas (zeroes)
+      if (this._clId) {                                               // check for a conditional lighting ID
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
+        let condLight  = new ConditionalLight(this._clType, ...args); // create conditional light
+        condLight.setTargets(...args);                                // create matching targets
+        condLight.createDeltas();                                     // compute deltas (zeroes)
         $gameVariables.GetLightArray()[this._clId] = condLight;
-        t._clCondLight = condLight;
+        this._clCondLight = condLight;
       }
     }
   };
@@ -1981,20 +2134,20 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.radius, this._clRadius);
+    return orNullish(this._clCondLight.currentRadius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
     if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.color, this._clColor.clone());
+    return orNullish(this._clCondLight.currentColor, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.brightness, this._clBrightness);
+    return orNullish(this._clCondLight.currentBrightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.direction, this._clDirection);
+    return orNullish(this._clCondLight.currentDirection, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -2002,24 +2155,25 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamLength, this._clBeamLength);
+    return orNullish(this._clCondLight.currentBeamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamWidth, this._clBeamWidth);
+    return orNullish(this._clCondLight.currentBeamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.xOffset, this._clXOffset);
+    return orNullish(this._clCondLight.currentXOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.yOffset, this._clYOffset);
+    return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
-    if (!this._clSwitch) return this._clOnOff;
-    return (this._clSwitch.equalsIC("night") &&  $$.isNight()) ||
-           (this._clSwitch.equalsIC("day")   && !$$.isNight());
+    if (!this._clSwitch) return orNullish(this._clCondLight.enabled, this._clOnOff);
+    return orNullish(this._clCondLight.enabled,
+                    (this._clSwitch.equalsIC("night") && $$.isNight()) ||
+                    (this._clSwitch.equalsIC("day")   && !$$.isNight()));
   };
   Game_Event.prototype.getLightCycle = function () {
     if (this._clType === undefined) this.initLightData();
@@ -2057,8 +2211,9 @@ class ColorDelta {
     command = command.toLowerCase();
 
     const allCommands = {
-      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight', tilefire: 'addTileLight', regionfire: 'addTileLight',
-      tileglow: 'addTileLight', regionglow: 'addTileLight', tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
+      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight',
+      tilefire: 'addTileLight', regionfire: 'addTileLight', tileglow: 'addTileLight', regionglow: 'addTileLight',
+      tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
       script: 'scriptF', reload: 'reload', tintbattle: 'tintbattle'
     };
     const result = allCommands[command];
@@ -2066,36 +2221,36 @@ class ColorDelta {
   };
 
   if (isRMMZ()) { // RMMZ only command interface
-    let mapOnOff = (args) => args.enabled === "true" ? "on" : "off";
-    let tileType = (args) => (args.tileType === "terrain" ? "tile" : "region") + (args.lightType ? args.lightType : "block");
-    let tintType = (    ) => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  (args) => args.instant === "true" ? "instant" : "";
-    let tintMode = (args) => args.color ? "set" : "reset";
-    let mathMode = (args) => args.mode === "set" ? "hour" : args.mode; // set, add, or subtract.
-    let showMode = (args) => args.enabled.equalsIC("true") ? (args.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
-    let radMode  = (args) => +args.fadeSpeed ? "radiusgrow" : "radius";
+    let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
+    let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
+    let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
+    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let tintMode = a  => a.color ? "set" : "reset";
+    let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
+    let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
+    let radMode  = a  => +a.fadeSpeed ? "radiusgrow" : "radius";
 
-    let reg = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
-    let f = (cmd, args) => $gameMap._interpreter.communityLighting_Commands(cmd, args.filter(_ => _ !== "")); //command wrapper.
+    let r = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
+    let f = (c, a) => $gameMap._interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
 
-    reg("masterSwitch",       (a)  => f("script",     [mapOnOff(a)]));
-    reg("tileBlock",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.shape,          a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
-    reg("tileLight",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.radius,         a.brightness]));
-    reg("setTint",            (a)  => f(tintType(),   [tintMode(a),     a.color,         a.fadeSpeed]));
-    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a),     dayMode(a)]));
-    reg("setTimeSpeed",       (a)  => f("dayNight",   ["speed",         a.speed]));
-    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes,      dayMode(a)]));
-    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours,         dayMode(a)]));
-    reg("showTime",           (a)  => f("dayNight",   [showMode(a)]));
-    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color,         dayMode(a)]));
-    reg("flashlight",         (a)  => f("flashLight", [mapOnOff(a),     a.beamLength,    a.beamWidth,    a.color,          a.density]));
-    reg("setFire",            (a)  => f("setFire",    [a.radiusShift,   a.redYellowShift]));
-    reg("playerLightRadius",  (a)  => f("light",      [radMode(a),      a.radius,        a.color,        "B"+a.brightness, a.fadeSpeed]));
-    reg("activateById",       (a)  => f("light",      [mapOnOff(a),     a.id]));
-    reg("lightColor",         (a)  => f("light",      ["color",         a.id,            a.color]));
-    reg("resetLightSwitches", ( )  => f("light",      ["switch",        "reset"]));
-    reg("resetTint",          (a)  => f(tintType(),   ["reset",         a.fadeSpeed]));
-    reg("condLight",          (a)  => f("light",      ["cond",          a.id,            a.properties]));
+    r("masterSwitch",       a  => f("script",     [mapOnOff(a)]));
+    r("tileBlock",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape,  a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
+    r("tileLight",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]));
+    r("setTint",            a  => f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]));
+    r("daynightEnable",     a  => f("daynight",   [mapOnOff(a), dayMode(a)]));
+    r("setTimeSpeed",       a  => f("dayNight",   ["speed", a.speed]));
+    r("setTime",            a  => f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]));
+    r("setHoursInDay",      a  => f("dayNight",   ["hoursinday", a.hours, dayMode(a)]));
+    r("showTime",           a  => f("dayNight",   [showMode(a)]));
+    r("setHourColor",       a  => f("dayNight",   ["color", a.hour, a.color, dayMode(a)]));
+    r("flashlight",         a  => f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]));
+    r("setFire",            a  => f("setFire",    [a.radiusShift, a.redYellowShift]));
+    r("playerLightRadius",  a  => f("light",      [radMode(a), a.radius, a.color, "B"+a.brightness, a.fadeSpeed]));
+    r("activateById",       a  => f("light",      [mapOnOff(a), a.id]));
+    r("lightColor",         a  => f("light",      ["color", a.id, a.color]));
+    r("resetLightSwitches", () => f("light",      ["switch", "reset"]));
+    r("resetTint",          a  => f(tintType(),   ["reset", a.fadeSpeed]));
+    r("condLight",          a  => f("light",      ["cond", a.id, a.properties]));
   }
 
   /**
@@ -2108,7 +2263,8 @@ class ColorDelta {
     let [tileType, lightType] = TileLightType[command] || [undefined, undefined];
     let [id, enabled, color, radius, brightness] = args;
     let tile = new TileLight(tileType, lightType, id, enabled, color, radius, brightness);
-    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType && e.id === tile.id);
+    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType &&
+                                    e.id === tile.id);
     void (index === -1 ? tilearray.push(tile) : tilearray[index] = tile);
     $gameVariables.SetTileLightArray(tilearray);
     $$.ReloadTagArea();
@@ -2240,7 +2396,9 @@ class ColorDelta {
   Lightmask.prototype.update = function () { this._updateMask(); };
 
   //@method _createBitmaps
-  Lightmask.prototype._createBitmaps = function () { this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY); };
+  Lightmask.prototype._createBitmaps = function () {
+    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
+  };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
   Game_Map.prototype.setupEvents = function () {
@@ -2302,7 +2460,7 @@ class ColorDelta {
     let lightgrow_target = $gameVariables.GetRadiusTarget();
     let lightgrow_speed = (player_radius < lightgrow_target ? 1 : -1) * $gameVariables.GetRadiusSpeed();
     if (lightgrow_speed != 0 && player_radius != lightgrow_target) {
-      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
+      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // clamp
       $gameVariables.SetRadius(player_radius);
     }
 
@@ -2344,22 +2502,23 @@ class ColorDelta {
     let iplayer_radius = Math.floor(player_radius);
 
     if (playerflashlight == true) {
-      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength, flashlightwidth);
+      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength,
+                                                 flashlightwidth);
     }
     if (iplayer_radius > 0) {
       x1 = x1 - flashlightXoffset;
       y1 = y1 - flashlightYoffset;
       if (iplayer_radius < 100) {
         // dim the light a bit at lower lightradius for a less focused effect.
-        let c = playercolor;
-        c.r = Math.max(0, c.r - 50);
-        c.g = Math.max(0, c.g - 50);
-        c.b = Math.max(0, c.b - 50);
-        let newcolor = c;
+        playercolor.r = Math.max(0, playercolor.r - 50);
+        playercolor.g = Math.max(0, playercolor.g - 50);
+        playercolor.b = Math.max(0, playercolor.b - 50);
 
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
+                                                 playerbrightness);
       } else {
-        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
+                                                 playerflicker, playerbrightness);
       }
 
     }
@@ -2393,8 +2552,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distanceApart > lightsOnRadius) {
+        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distpart > lightsOnRadius) {
           continue;
         }
       }
@@ -2443,7 +2602,8 @@ class ColorDelta {
             if (!isNaN(direction)) ldir = direction;
             this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker, brightness, direction);
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+                                                     brightness, direction);
           }
         }
       }
@@ -2467,16 +2627,15 @@ class ColorDelta {
       let y1 = (ph / 2) + (y - dy) * ph;
 
       let objectflicker = tile.lightType.is(LightType.Fire);
-      let tile_color = tile.color;
+      let tile_color = tile.color.clone();
       if (tile.lightType.is(LightType.Glow)) {
-        let c = tile.color.clone();
-        c.r = Math.floor(c.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.g = Math.floor(c.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.b = Math.floor(c.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        tile_color = c;
+        tile_color.r = Math.floor(tile_color.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.g = Math.floor(tile_color.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker, tile.brightness);
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+                                               tile.brightness);
     });
 
     // Tile blocks
@@ -2621,14 +2780,14 @@ class ColorDelta {
     //ctxMul.save(); // unnecessary significant performance hit
     ctxMul.fillStyle = hex;
     ctxMul.beginPath();
-    ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
+    ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, M_2PI);
     ctxMul.fill();
     if (isRMMV()) this.multiply._setDirty(); // doesn't exist in RMMZ
     if (c.v) {
       let ctxAdd = this.additive._context; // Additive lighting context
       ctxAdd.fillStyle = hex;
       ctxAdd.beginPath();
-      ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
+      ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, M_2PI);
       ctxAdd.fill();
       if (isRMMV()) this.additive._setDirty(); // doesn't exist in RMMZ
     }
@@ -2778,8 +2937,8 @@ class ColorDelta {
       let distance = 3 * (flashlength * (flashlength - 1));
 
       // Compute spotlight radiuses
-      r1 = (flashlength - 1) * flashlightdensity;
-      r2 = (flashlength - 1) * flashwidth;
+      r1 = Math.max((flashlength - 1) * flashlightdensity, 0);
+      r2 = Math.max((flashlength - 1) * flashwidth, 0);
 
       // Compute beam left start coordinates
       let xLeftBeamStart = x1 - (r2 / 7) * Math.sin(dirAngle);
@@ -2830,7 +2989,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2841,7 +3001,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2853,7 +3014,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2864,7 +3026,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2883,7 +3046,7 @@ class ColorDelta {
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
       } else {
-        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are always guarded
+        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are conditional
         ctxAdd.shadowBlur = 0;
         ctxAdd.fillStyle = grad;
         ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2); // single call as to not blur things so much.
@@ -3000,7 +3163,7 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
     // Prevent the battle scene from being too dark
-    let c = $gameTemp._BattleTintTarget.next().get(); // reference
+    let c = $gameTemp._BattleTintTarget.next().get(); // get next color
     if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66) {
       c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
       $gameTemp._BattleTintTarget.current = c; // reassign if out of bounds. Shouldn't be possible.
@@ -3272,13 +3435,18 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for default (i.e. no passed color)
+      if (condLight) { condLight.currentColor = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.parseTargetCondLightProps(args[2].split(/\s+/)); }
+      if (condLight) {
+        let properties = args[2].split(/\s+/);
+        condLight.parseDurationProps(properties);
+        condLight.parseTargetProps(properties);
+        condLight.createDeltas();
+      }
     }
 
     // **************************** RESET ALL SWITCHES ***********************
@@ -3313,7 +3481,7 @@ class ColorDelta {
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));
       else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0)); // battle initial color
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0));
       }
     }
   };
@@ -3330,8 +3498,8 @@ class ColorDelta {
       seconds = orNaN(seconds, 0);
       seconds += hours * 60 * 60 + minutes * 60;
       let totalSeconds = hoursInDay * 60 * 60;
-      while (seconds >= totalSeconds) seconds -= totalSeconds;
-      while (seconds < 0) seconds += totalSeconds;
+      seconds %= totalSeconds; // clamp to within total seconds
+      if (seconds < 0) seconds += totalSeconds;
       gV.SetDaynightSeconds(seconds);
       gV.SetDaynightHoursinDay(hoursInDay);
       setTimeColorDelta();
@@ -3345,7 +3513,7 @@ class ColorDelta {
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
         let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed()); // whether to change tint instantly
+        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }
@@ -3355,13 +3523,13 @@ class ColorDelta {
     let [gV, a]                    = [$gameVariables, args];
     let [secondsTotal, hoursInDay] = [gV.GetDaynightSeconds(), gV.GetDaynightHoursinDay()];
     let [hours, minutes, seconds]  = [$$.hours(), $$.minutes(), $$.seconds()];
-    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint changes
-    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disabled daynight tint changes
-    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // daynight speed
-    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to current time
-    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // subtract from current time
-    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the current time
-    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day (must be >0, err = 24)
+    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint
+    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disable daynight tint
+    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // set daynight speed
+    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to cur time
+    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // sub from cur time
+    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the cur time
+    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day
     else if (isCmd('show'))        void showTime(true, false);                                          // show clock
     else if (isCmd('showseconds')) void showTime(true, true);                                           // show clock seconds
     else if (isCmd('hide'))        void showTime(false, false);                                         // hide clock

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -3584,8 +3584,8 @@ Game_Variables.prototype.SetTintAtHour = function (hour, color) {
 Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   let hours = Community.Lighting.hours() + inc; // increment from current hour
   let hoursinDay = this.GetDaynightHoursinDay();
-  while (hours >= hoursinDay) hours -= hoursinDay;
-  while (hours < 0) hours += hoursinDay;
+  hours %= hoursinDay; // clamp to within total hours in day
+  if (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
   return result ? result.color.clone() : VRGBA.minRGBA();
 };

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -267,9 +267,9 @@ Imported[Community.Lighting.name] = true;
 * @off Off
 * @default true
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -462,9 +462,9 @@ Imported[Community.Lighting.name] = true;
 * @value subtract
 * @default set
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -487,9 +487,9 @@ Imported[Community.Lighting.name] = true;
 * @type text
 * @default #ffffff
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -507,9 +507,9 @@ Imported[Community.Lighting.name] = true;
 * @min 0
 * @default 24
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -1052,31 +1052,27 @@ Imported[Community.Lighting.name] = true;
 * Flashlight off
 * - Turn off the flashlight.  yup.
 *
-* DayNight on|off [instant]
-* - Activates or deactivates the day/night cycle. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* DayNight on|off [fade]
+* - Activates or deactivates the day/night cycle. Specifying 'fade' will gradually
+*   transition the tint to that of the next hour.
 *
 * Daynight speed n
 * - Changes the speed by which hours pass in game in relation to real life seconds
 *
-* Daynight hour h m [instant]
-* - Sets the in game time to hh:mm. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hour h m [fade]
+* - Sets the in game time to hh:mm. Specifying 'fade' will gradually transition the
+*   tint to that of the next hour.
 *
 * Daynight color h c
 * - Sets the hour (h) to use color (c)
 *
-* Daynight add h m [instant]
-* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight add h m [fade]
+* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying
+*   'fade' will gradually transition the tint to that of the next hour.
 *
-* Daynight subtract h m [instant]
-* - Subtracts the specified hours (h) and minutes (m) from the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight subtract h m [fade]
+* - Subtracts the specified hours (h) and minutes (m) from the in game clock.
+*   Specifying  'fade' will gradually transition the tint to that of the next hour.
 *
 * Daynight show
 * - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -1087,10 +1083,9 @@ Imported[Community.Lighting.name] = true;
 * Daynight hide
 * - Hides the current time of day mini-window
 *
-* Daynight hoursinday h [instant]
-* - Sets the number of hours in a day to [h] (set hour colors if doing this), Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hoursinday h [fade]
+* - Sets the number of hours in a day to [h] (set hour colors if doing this).
+*   Specifying 'fade' will gradually transition the tint to that of the next hour.
 *
 * Tint set c [s]
 * Tint fade c [s]
@@ -2192,7 +2187,7 @@ class ColorDelta {
     let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
     let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
     let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let dayMode =  a  => a.fade === "true" ? "fade" : "";
     let tintMode = a  => a.color ? "set" : "reset";
     let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
     let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
@@ -3476,8 +3471,8 @@ class ColorDelta {
     };
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
-        let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
+        let hasFade = 'fade'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
+        let delta = ColorDelta.createTimeTint(hasFade, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -2113,7 +2113,6 @@ class ColorDelta {
           lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
         let targetProps = lightArray[this._cl.id];                          // get target prop reference
         this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
-        console.log(this._cl.delta);
       }
       // Non-conditional light
       else {
@@ -3404,8 +3403,7 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      console.log(args[2]);
-      if (targetProps) targetProps.parseProps([args[2] != null ? args[2] : "#"]);
+      if (targetProps) targetProps.parseProps([(args[2] != null && !args[2].equalsIC("defaultcolor")) ? args[2] : "#"]);
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -1450,7 +1450,7 @@ class LightProperties {
    * @param {Number}    beamLength
    * @param {Number}    beamWidth
    */
-  constructor(type, enable, color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, color, enable, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
     // Always define in case durations aren't passed to targets
     this.transitionDuration = 0;
     this.pauseDuration      = 0;
@@ -2048,8 +2048,8 @@ class ColorDelta {
         else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
         else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
         else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))      this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))      this._cl.enable    = false;
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
         else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
         else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -1903,10 +1903,12 @@ class ColorDelta {
     }
   }
 
+  let ReloadMapEventsRequired = false;
   let colorcycle_count = [1000];
   let colorcycle_timer = [1000];
   let eventObjId = [];
   let event_id = [];
+  let events;
   let event_stacknumber = [];
   let event_eventcount = 0;
   let light_tiles = [];
@@ -1960,7 +1962,6 @@ class ColorDelta {
   let options_lighting_on = true;
   let maxX = (Number(parameters['Screensize X']) || 816) + 2 * lightMaskPadding;
   let maxY = Number(parameters['Screensize Y']) || 624;
-  let event_reload_counter = 0;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = new VRGBA(useSmootherLights ? "#00000000" : "#000000");
   $$.getFirstComment = function (page) {
@@ -1992,14 +1993,6 @@ class ColorDelta {
     }
     else result = note.trim();
     return result;
-  };
-  Game_Event.prototype.getCLTag = function () {
-    let result;
-    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
-    let note = this.event().note;
-    if (pageNote) result = $$.getCLTag(pageNote);
-    if (!result) result = $$.getCLTag(note);
-    return result || "";
   };
   $$.getDayNightList = function () {
     return dayNightList;
@@ -2043,8 +2036,27 @@ class ColorDelta {
     return (this[index] = value, true);
   };
 
-  // Event note tag caching
-  Game_Event.prototype.initLightData = function () {
+  let _Game_Event_setupPage = Game_Event.prototype.setupPage;
+  Game_Event.prototype.setupPage = function () { // Hook Game_Event.setupPage() to detect page changes
+    _Game_Event_setupPage.call(this);
+    ReloadMapEventsRequired = true; // force refresh
+  };
+  let _Game_Map_setupEvents = Game_Map.prototype.setupEvents;
+  Game_Map.prototype.setupEvents = function () { // hook $GameMap.setupEvents() and _events to detect event changes.
+    _Game_Map_setupEvents.call(this);
+    this._events = new Proxy(this._events, { // called on events pop, push, splice, assign
+      set: function (...a) { ReloadMapEventsRequired = true; return Reflect.set(...a); }
+    }); // force refresh
+  };
+  Game_Event.prototype.getCLTag = function () {
+    let result;
+    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
+    let note = this.event().note;
+    if (pageNote) result = $$.getCLTag(pageNote);
+    if (!result) result = $$.getCLTag(note);
+    return result || "";
+  };
+  Game_Event.prototype.initLightData = function () {   // Event note tag caching
     this._cl = {};
     this._cl.lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
@@ -2413,19 +2425,15 @@ class ColorDelta {
       $$.ReloadMapEvents();  // reload map events on map change
     }
 
-    // reload mapevents if event_data has changed (deleted or spawned events/saves)
-    if (event_eventcount != $gameMap.events().length) $$.ReloadMapEvents();
-
     // remove all old sprites
     for (let i = 0, len = this._sprites.length; i < len; i++) this._removeSprite();
 
     // No lighting on maps less than 1 || Plugin deactivated in options || Plugin deactivated by plugin command
     if (map_id <= 0 || !options_lighting_on || !$gameVariables.GetScriptActive()) return;
 
-    // reload map events every 200 cycles just in case or when a refresh is requested
-    event_reload_counter++;
-    if (event_reload_counter > 200) {
-      event_reload_counter = 0;
+    // reload map when a refresh is requested (event erase, page change, or _events object change)
+    if (ReloadMapEventsRequired) {
+      ReloadMapEventsRequired = false;
       $$.ReloadMapEvents();
     }
 
@@ -2531,8 +2539,8 @@ class ColorDelta {
     // ********** OTHER LIGHTSOURCES **************
     for (let i = 0, len = eventObjId.length; i < len; i++) {
       let evid = event_id[i];
-      let cur = $gameMap.events()[eventObjId[i]];
-      if (cur._cl == null || cur._cl.lastLightPage !== cur._pageIndex) cur.initLightData();
+      let cur  = events[eventObjId[i]];
+      if (cur._cl == null) cur.initLightData();
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
@@ -2569,10 +2577,10 @@ class ColorDelta {
         }
         // show light
         if (state === true) {
-          let lx1 = $gameMap.events()[event_stacknumber[i]].screenX();
-          let ly1 = $gameMap.events()[event_stacknumber[i]].screenY() - 24;
+          let lx1 = events[event_stacknumber[i]].screenX();
+          let ly1 = events[event_stacknumber[i]].screenY() - 24;
           if (!shift_lights_with_events) {
-            ly1 += $gameMap.events()[event_stacknumber[i]].shiftY();
+            ly1 += events[event_stacknumber[i]].shiftY();
           }
 
           // apply offsets
@@ -2580,7 +2588,7 @@ class ColorDelta {
           ly1 += +yOffset;
 
           if (lightType.is(LightType.Flashlight)) {
-            let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
+            let ldir = RMDirectionMap[events[event_stacknumber[i]]._direction] || 0;
             let flashlength = cur.getLightFlashlightLength();
             let flashwidth  = cur.getLightFlashlightWidth();
             if (!isNaN(direction)) ldir = direction;
@@ -3249,19 +3257,20 @@ class ColorDelta {
     //**********************fill up new map-array *************************
     eventObjId = [];
     event_id = [];
+    events = $gameMap.events(); // cache because events() API calls filter for each call
     event_stacknumber = [];
-    event_eventcount = $gameMap.events().length;
+    event_eventcount = events.length;
 
     for (let i = 0; i < event_eventcount; i++) {
-      if ($gameMap.events()[i]) {
-        if ($gameMap.events()[i].event() && !$gameMap.events()[i]._erased) {
-          let note = $gameMap.events()[i].getCLTag();
+      if (events[i]) {
+        if (events[i].event() && !events[i]._erased) {
+          let note = events[i].getCLTag();
 
           let note_args = note.split(" ");
           let note_command = LightType[note_args.shift().toLowerCase()];
           if (note_command) {
             eventObjId.push(i);
-            event_id.push($gameMap.events()[i]._eventId);
+            event_id.push(events[i]._eventId);
             event_stacknumber.push(i);
 
           }

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -3100,13 +3100,10 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // if we came from a map, script is active, configuration authorizes using lighting effects,
-    // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
+    // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
             $gameVariables.GetTint() : new VRGBA("#ffffff");
-
-    // Set initial tint for battle
-    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -303,7 +303,7 @@ Imported[Community.Lighting.name] = true;
 *
 * @command condLight
 * @text Set Conditional Lighting
-* @desc Supports transition & pause durations, color, angle, brightness, x offset, y offset, radius, beam length & width.
+* @desc Supports transition & pause durations, on & off, color, angle, brightness, x offset, y offset, radius, beam length & width.
 *
 * @arg id
 * @text Event ID
@@ -312,9 +312,9 @@ Imported[Community.Lighting.name] = true;
 *
 * @arg properties
 * @text properties
-* @desc Format: [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+* @desc Format: [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [on|off] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
 * @type text
-* @default t5 #ffffff -a90 b0 x0 y0 r150 l12 w12
+* @default t5 #ffffff on -a90 b0 x0 y0 r150 l12 w12
 *
 * @----------------------------
 *
@@ -906,32 +906,36 @@ Imported[Community.Lighting.name] = true;
 * See the Plugin Commands section for more details.
 *
 * The following chart shows all supported properties:
-* --------------------------------------------------------------------------------------------------------------------
-* |   Property     |  Prefix   |        Format           | Examples          | Description                            |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     pause      |     p     |           pN            |    p0, p1, p20    | time period in cycles to pause after   |
-* |    duration    |           |                         |                   | transitioning for cycling lights       |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   transition   |     t     |           tN            |    t0, t1, t30    | time period to transition the          |
-* |    duration    |           |                         |                   | specified properties over              |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     color      |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | a#FFEEDD, #ffeedd | color or additive color                |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     angle      | a, +a, -a |       <a|+a|-a>N        |  a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
-* |                |           |                         |                   | clockwise, '-' moves counterclockwise  |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   brightness   |     b     |           bN            |    b0, b1, b5     | brightness                             |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |    x offset    |     x     |           xN            |     x2, x-2       | x offset                               |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |    y offset    |     y     |           yN            |     y2, y-2       | y offset                               |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     radius     |     r     |           rN            |    r50, r150      | light radius                           |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   beam length  |     l     |           lN            |   l8, l9, l10     | flashlight beam length                 |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   beam width   |     w     |           wN            |  w12, w13, w14    | flashlight beam width                  |
-* --------------------------------------------------------------------------------------------------------------------
+* ---------------------------------------------------------------------------------------------------------------------
+* | Property    |  Prefix   |         Format*         |       Examples       |              Description               |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   pause     |     p     |           pN            |     p0, p1, p20      | time period in cycles to pause after   |
+* |  duration   |           |                         |                      | transitioning for cycling lights       |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | transition  |     t     |           tN            |     t0, t1, t30      | time period to transition the          |
+* |  duration   |           |                         |                      | specified properties over              |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   color     |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | #, a#FFEEDD, #ffeedd | color or additive color                |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |  enable     |     e     |         e<1|0>          |        e1, e0        | turns light on or off instantly        |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   angle     | a, +a, -a |       <a|+a|-a>N        |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |             |           |                         |                      | clockwise, '-' moves counterclockwise  |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | brightness  |     b     |           bN            |    b, b0, b1, b5     | brightness                             |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |  x offset   |     x     |           xN            |      x, x2, x-2      | x offset                               |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |  y offset   |     y     |           yN            |      y, y2, y-2      | y offset                               |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   radius    |     r     |           rN            |     r, r50, r150     | light radius                           |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | beam length |     l     |           lN            |    l, l8, l9, l10    | flashlight beam length                 |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | beam width  |     w     |           wN            |   w, w12, w13, w14   | flashlight beam width                  |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | * Omitting N or RBG value will reset the given property back to its initial state                                 |
+* ---------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
 * Easy hex color references
@@ -1200,6 +1204,8 @@ const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
 
 Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
 Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
+Number.prototype.clone        = function()        { return this; };
+Boolean.prototype.clone       = function()        { return this; };
 String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
 String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
 Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
@@ -1349,7 +1355,7 @@ class VRGBA {
   /**
    * Creates a copy of the VRGBA object.
    * @returns {VRGBA}
-   **/
+   */
   clone() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [this.v, this.r, this.g, this.b, this.a];
@@ -1359,7 +1365,7 @@ class VRGBA {
   /**
    * Creates an empty VRGBA object will all properties initialized to false and 0.
    * @returns {VRGBA}
-   **/
+   */
   static empty() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
@@ -1433,201 +1439,206 @@ class VRGBA {
 }
 
 /**
- * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability
- * to compute deltas between the current parameter values and the target values, and allows for current values to be
- * extracted.
- **/
-class ConditionalLight {
+ * Class representing conditional light properties that can be changed.
+ */
+class LightProperties {
   /**
-   * Creates a ConditionalLight object with the provided parameters
+   * Creates a LightProperties object with the provided parameters
    * @param {LightType} type
-   * @param {VRGBA}     currentColor
-   * @param {Number}    currentDirection
-   * @param {Number}    currentBrightness
-   * @param {Number}    currentXOffset
-   * @param {Number}    currentYOffset
-   * @param {Number}    currentRadius
-   * @param {Number}    currentBeamLength
-   * @param {Number}    currentBeamWidth
-   **/
-  constructor(type, currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
-              currentBeamLength, currentBeamWidth) {
-    if (arguments.length == 0) return;
+   * @param {VRGBA}     color
+   * @param {Boolean}   enable
+   * @param {Number}    direction
+   * @param {Number}    brightness
+   * @param {Number}    xOffset
+   * @param {Number}    yOffset
+   * @param {Number}    radius
+   * @param {Number}    beamLength
+   * @param {Number}    beamWidth
+   */
+  constructor(type, enable, color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+    // Always define in case durations aren't passed to targets
     this.transitionDuration = 0;
     this.pauseDuration      = 0;
-    this.type               = type;
-    this.currentColor       = currentColor;
-    this.currentDirection   = this.isFlashlight() ? currentDirection  : void(0);
-    this.currentBrightness  = currentBrightness;
-    this.currentXOffset     = currentXOffset;
-    this.currentYOffset     = currentYOffset;
-    this.currentRadius      = this.isOtherLight() ? currentRadius     : void(0);
-    this.currentBeamLength  = this.isFlashlight() ? currentBeamLength : void(0);
-    this.currentBeamWidth   = this.isFlashlight() ? currentBeamWidth  : void(0);
+    this.updateFrame        = 0;
+    if (arguments.length == 0) return;
+    // shared properties
+    this.type       = type;
+    this.color      = color;
+    this.enable     = enable;
+    this.brightness = brightness;
+    this.xOffset    = xOffset;
+    this.yOffset    = yOffset;
+    // light type dependent properties
+    let isOL = this.isOtherLight();
+    let isFL = this.isFlashlight();
+    if (isOL) this.radius     = radius;
+    if (isFL) this.clockwise  = true;
+    if (isFL) this.direction  = direction;
+    if (isFL) this.beamLength = beamLength;
+    if (isFL) this.beamWidth  = beamWidth;
   }
 
   /**
-   * Creates a copy of the ConditionalLight object.
-   * @returns {ConditionalLight}
-   **/
+   * Returns true if the light type is a flashlight or null; otherwise false.
+   */
+  isFlashlight() { return this.type == null || this.type.is(LightType.Flashlight); }
+
+  /**
+   * Returns true if the light type is light, fire, glow, or null; otherwise false.
+   */
+  isOtherLight() { return this.type == null || this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
+
+  /**
+   * Processes and sets properties from a string array.
+   * @param {String[]} properties
+   */
+  parseProps(properties) {
+    this.updateFrame = Graphics.frameCount; // set current frame as update frame
+    let isOL = this.isOtherLight();
+    let isFL = this.isFlashlight();
+    let hasTransitionDuration = false;
+    let haspauseDuration      = false;
+    // properties with no suffix 'clear' the target
+    properties.forEach((e) => {
+      // clear checks (back to initial value for the given property)
+      if      (        e.equalsIC('#'))        this.color      = void(0);
+      else if (        e.equalsIC('a#'))       this.color      = void(0);
+      else if (        e.equalsIC('e'))        this.enable     = void(0);
+      else if (        e.equalsIC('b'))        this.brightness = void(0);
+      else if (        e.equalsIC('x'))        this.xOffset    = void(0);
+      else if (        e.equalsIC('y'))        this.yOffset    = void(0);
+      else if (isOL && e.equalsIC('r'))        this.radius     = void(0);
+      else if (isFL && e.equalsIC('l'))        this.beamLength = void(0);
+      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void(0);
+      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void(0);
+      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void(0);
+      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void(0);
+      // on or off checks
+      // prefix checks
+      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); hasTransitionDuration = true; }
+      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); haspauseDuration = true; }
+      else if (        e.startsWithIC('#'))    this.color      = new VRGBA(e);
+      else if (        e.startsWithIC('a#'))   this.color      = new VRGBA(e);
+      else if (        e.startsWithIC('e'))    this.enable     = Boolean(orNaN(+e.slice(1), 0));
+      else if (        e.startsWithIC('b'))    this.brightness = orNaN(+e.slice(1), 0);
+      else if (        e.startsWithIC('x'))    this.xOffset    = orNaN(+e.slice(1), 0);
+      else if (        e.startsWithIC('y'))    this.yOffset    = orNaN(+e.slice(1), 0);
+      else if (isOL && e.startsWithIC('r'))    this.radius     = orNaN(+e.slice(1), 0);
+      else if (isFL && e.startsWithIC('l'))    this.beamLength = orNaN(+e.slice(1), 0);
+      else if (isFL && e.startsWithIC('w'))    this.beamWidth  = orNaN(+e.slice(1), 0);
+      else if (isFL && e.startsWithIC('a'))  { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(1), 0); }
+      else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
+      else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
+    }, this);
+    if (!hasTransitionDuration) this.transitionDuration = 0;
+    if (!haspauseDuration)      this.pauseDuration = 0;
+  }
+
+  /**
+   * Creates a copy of the LightProperties object.
+   * @returns {LightDelta}
+   */
   clone() {
-    let that = new ConditionalLight();
-    // clone durations
+    let that = new LightProperties();
     if (this.transitionDuration != null) that.transitionDuration = this.transitionDuration;
     if (this.pauseDuration      != null) that.pauseDuration      = this.pauseDuration;
-    // clone type
+    if (this.updateFrame        != null) that.updateFrame        = this.updateFrame;
     if (this.type               != null) that.type               = this.type;
-    // clone currents
-    if (this.currentColor       != null) that.currentColor       = this.currentColor.clone();
-    if (this.currentDirection   != null) that.currentDirection   = this.currentDirection;
-    if (this.currentBrightness  != null) that.currentBrightness  = this.currentBrightness;
-    if (this.currentXOffset     != null) that.currentXOffset     = this.currentXOffset;
-    if (this.currentYOffset     != null) that.currentYOffset     = this.currentYOffset;
-    if (this.currentRadius      != null) that.currentRadius      = this.currentRadius;
-    if (this.currentBeamLength  != null) that.currentBeamLength  = this.currentBeamLength;
-    if (this.currentBeamWidth   != null) that.currentBeamWidth   = this.currentBeamWidth;
-    // clone targets
-    if (this.targetColor        != null) that.targetColor        = this.targetColor.clone();
-    if (this.targetDirection    != null) that.targetDirection    = this.targetDirection;
-    if (this.targetBrightness   != null) that.targetBrightness   = this.targetBrightness;
-    if (this.targetXOffset      != null) that.targetXOffset      = this.targetXOffset;
-    if (this.targetYOffset      != null) that.targetYOffset      = this.targetYOffset;
-    if (this.targetRadius       != null) that.targetRadius       = this.targetRadius;
-    if (this.targetBeamLength   != null) that.targetBeamLength   = this.targetBeamLength;
-    if (this.targetBeamWidth    != null) that.targetBeamWidth    = this.targetBeamWidth;
-    // clone deltas
-    if (this.deltaColor         != null) that.deltaColor         = this.deltaColor     .clone();
-    if (this.deltaDirection     != null) that.deltaDirection     = this.deltaDirection .clone();
-    if (this.deltaBrightness    != null) that.deltaBrightness    = this.deltaBrightness.clone();
-    if (this.deltaXOffset       != null) that.deltaXOffset       = this.deltaXOffset   .clone();
-    if (this.deltaYOffset       != null) that.deltaYOffset       = this.deltaYOffset   .clone();
-    if (this.deltaRadius        != null) that.deltaRadius        = this.deltaRadius    .clone();
-    if (this.deltaBeamLength    != null) that.deltaBeamLength    = this.deltaBeamLength.clone();
-    if (this.deltaBeamWidth     != null) that.deltaBeamWidth     = this.deltaBeamWidth .clone();
+    if (this.enable             != null) that.enable             = this.enable;
+    if (this.color              != null) that.color              = this.color     .clone();
+    if (this.brightness         != null) that.brightness         = this.brightness.clone();
+    if (this.xOffset            != null) that.xOffset            = this.xOffset   .clone();
+    if (this.yOffset            != null) that.yOffset            = this.yOffset   .clone();
+    if (this.radius             != null) that.radius             = this.radius    .clone();
+    if (this.clockwise          != null) that.clockwise          = this.clockwise .clone();
+    if (this.direction          != null) that.direction          = this.direction .clone();
+    if (this.beamLength         != null) that.beamLength         = this.beamLength.clone();
+    if (this.beamWidth          != null) that.beamWidth          = this.beamWidth .clone();
+    return that;
+  }
+}
+
+/**
+ * Class representing conditional light deltas that provides the ability to compute deltas between the
+ * current parameter values and the target values.
+ */
+class LightDelta {
+  /**
+   * Creates a LightDelta object with the provided LightProperties.
+   * @param {LightProperties} current
+   * @param {LightProperties} target
+   */
+  constructor(current, target, defaults) {
+    if (arguments.length == 0) return;
+    this.current = current;
+    this.target  = target;
+    this.defaults = defaults;
+    this.delta   = new LightProperties();
+    this.createDeltas();
+  }
+
+  /**
+   * Creates a copy of the LightDelta object.
+   * @returns {LightDelta}
+   */
+  clone() {
+    let that = new LightDelta();
+    // clone durations
+    if (this.current != null) that.current = this.current.clone();
+    if (this.target  != null) that.target  = this.target.clone();
+    if (this.delta   != null) that.delta   = this.delta.clone();
     return that;
   }
 
   /**
-   * Returns true if the light type is a flashlight; otherwise false.
-   */
-  isFlashlight() { return this.type.is(LightType.Flashlight); }
-
-  /**
-   * Returns true if the light type is light, fire, or glow; otherwise false.
-   */
-  isOtherLight() { return this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
-
-  /**
-   * Sets up all supported targets.
-   * @param {VRGBA}  targetColor
-   * @param {Number} targetDirection
-   * @param {Number} targetBrightness
-   * @param {Number} targetXOffset
-   * @param {Number} targetYOffset
-   * @param {Number} targetRadius
-   * @param {Number} targetBeamLength
-   * @param {Number} targetBeamWidth
-   */
-  setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
-             targetBeamLength, targetBeamWidth) {
-    if (targetColor       != null) this.targetColor      = targetColor;
-    if (targetDirection   != null) this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
-    if (targetBrightness  != null) this.targetBrightness = targetBrightness;
-    if (targetXOffset     != null) this.targetXOffset    = targetXOffset;
-    if (targetYOffset     != null) this.targetYOffset    = targetYOffset;
-    if (targetRadius      != null) this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
-    if (targetBeamLength  != null) this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
-    if (targetBeamWidth   != null) this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
-  }
-
-  /**
-   * Processes and sets target transition and pause duration properties from a string array.
-   * @param {String[]} properties
-   **/
-  parseDurationProps(properties) {
-    this.transitionDuration = properties.find((e) => (e.startsWithIC('t')));
-    this.pauseDuration      = properties.find((e) => (e.startsWithIC('p')));
-    this.transitionDuration = this.transitionDuration ? +this.transitionDuration.slice(1) : 0;
-    this.pauseDuration      = this.pauseDuration      ? +this.pauseDuration.slice(1)      : 0;
-  }
-
-  /**
-   * Processes and sets current properties from a string array.
-   * @param {String[]} properties
-   **/
-  parseCurrentProps(properties) {
-    properties.forEach((e) => {
-      if      (                       e.startsWithIC('#'))  this.currentColor      = new VRGBA(e);
-      else if (                       e.startsWithIC('a#')) this.currentColor      = new VRGBA(e);
-      else if (this.isFlashlight() && e.startsWithIC('a'))  this.currentDirection  = M_PI_180 * orNaN(+e.slice(1), 0);
-      else if (this.isFlashlight() && e.startsWithIC('+a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
-      else if (this.isFlashlight() && e.startsWithIC('-a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
-      else if (                       e.startsWithIC('b'))  this.currentBrightness = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('x'))  this.currentXOffset    = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('y'))  this.currentYOffset    = orNaN(+e.slice(1));
-      else if (this.isOtherLight() && e.startsWithIC('r'))  this.currentRadius     = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('l'))  this.currentBeamLength = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('w'))  this.currentBeamWidth  = orNaN(+e.slice(1));
-    }, this);
-  }
-
-  /**
-   * Processes and sets target properties from a string array.
-   * @param {String[]} properties
-   **/
-  parseTargetProps(properties) {
-    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
-
-    let normalizeClockwiseMovement = (target) => {
-      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
-      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
-      if (this.currentDirection > this.targetDirection) this.targetDirection += M_2PI; // clockwise normalize
-    };
-    let normalizeCounterClockwiseMovement = (target) => {
-      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
-      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
-      if (this.currentDirection < this.targetDirection) this.targetDirection -= M_2PI; // c-clockwise normalize
-    };
-    properties.forEach((e) => {
-      if      (                       e.startsWithIC('#'))  this.targetColor = new VRGBA(e);
-      else if (                       e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
-      else if (this.isFlashlight() && e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
-      else if (this.isFlashlight() && e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
-      else if (this.isFlashlight() && e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
-      else if (                       e.startsWithIC('b'))  this.targetBrightness = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('x'))  this.targetXOffset    = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('y'))  this.targetYOffset    = orNaN(+e.slice(1));
-      else if (this.isOtherLight() && e.startsWithIC('r'))  this.targetRadius     = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('l'))  this.targetBeamLength = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('w'))  this.targetBeamWidth  = orNaN(+e.slice(1));
-    }, this);
-  }
-
-  /**
    * Create deltas from currents, targets, and transition duration.
-   **/
+   */
   createDeltas() {
+    // Helper functions
+    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
+    let normalizeClockwiseMovement = () => {
+      this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
+      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
+      if (this.current.direction > this.target.direction) this.target.direction += M_2PI; // clockwise normalize
+    };
+    let normalizeCounterClockwiseMovement = () => {
+      this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
+      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
+      if (this.current.direction < this.target.direction) this.target.direction -= M_2PI; // c-clockwise normalize
+    };
     let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
     let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
+
+    // set delta creation at current frame time
+    this.current.updateFrame = Graphics.frameCount;
+
+    // Enable or disable the current immediately based off of target value
+    this.current.enable = this.target.enable != null ? this.target.enable : this.defaults.enable;
+
+    // For currents (flashlights) check the movement direction and normalize the current and target
+    if      (this.current.direction != null && this.target.clockwise)  normalizeClockwiseMovement();
+    else if (this.current.direction != null && !this.target.clockwise) normalizeCounterClockwiseMovement();
+
     // assign deltas if current & targets exist
-    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
-    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
-    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.transitionDuration);
-    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.transitionDuration);
-    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.transitionDuration);
-    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.transitionDuration);
-    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.transitionDuration);
-    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.transitionDuration);
-    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.transitionDuration);
-    // assign new currents for existing deltas (to propagate currents for duration = 0)
-    if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
-    if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
-    if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.get();
-    if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .get();
-    if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .get();
-    if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .get();
-    if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.get();
-    if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .get();
+    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
+    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
+    this.delta.direction  = createNumber(this.current.direction,  this.target.direction,  this.current.transitionDuration);
+    this.delta.brightness = createNumber(this.current.brightness, this.target.brightness, this.current.transitionDuration);
+    this.delta.xOffset    = createNumber(this.current.xOffset,    this.target.xOffset,    this.current.transitionDuration);
+    this.delta.yOffset    = createNumber(this.current.yOffset,    this.target.yOffset,    this.current.transitionDuration);
+    this.delta.radius     = createNumber(this.current.radius,     this.target.radius,     this.current.transitionDuration);
+    this.delta.beamLength = createNumber(this.current.beamLength, this.target.beamLength, this.current.transitionDuration);
+    this.delta.beamWidth  = createNumber(this.current.beamWidth,  this.target.beamWidth,  this.current.transitionDuration);
+
+    // assign new currents for existing deltas to propagate currents for duration = 0 or target.<value> = null
+    this.current.color      = this.delta.color      != null  ? this.delta.color     .get() : this.defaults.color;
+    this.current.direction  = this.delta.direction  != null  ? this.delta.direction .get() : this.defaults.direction;
+    this.current.brightness = this.delta.brightness != null  ? this.delta.brightness.get() : this.defaults.brightness;
+    this.current.xOffset    = this.delta.xOffset    != null  ? this.delta.xOffset   .get() : this.defaults.xOffset;
+    this.current.yOffset    = this.delta.yOffset    != null  ? this.delta.yOffset   .get() : this.defaults.yOffset;
+    this.current.radius     = this.delta.radius     != null  ? this.delta.radius    .get() : this.defaults.radius;
+    this.current.beamLength = this.delta.beamLength != null  ? this.delta.beamLength.get() : this.defaults.beamLength;
+    this.current.beamWidth  = this.delta.beamWidth  != null  ? this.delta.beamWidth .get() : this.defaults.beamWidth;
   }
 
   /**
@@ -1635,19 +1646,23 @@ class ConditionalLight {
    * @returns {this}
    */
   next() {
+    // Compared the last time a delta has been generated to the last time the target has been updated
+    if (this.current.updateFrame < this.target.updateFrame) this.createDeltas();
+    // Check if transition and pause durations have reached zero
     if (this.finished()) return this;
-    if (this.transitionDuration > 0) { // only update if transition duration isn't 0 (finished)
-      if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
-      if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
-      if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
-      if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .next().get();
-      if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .next().get();
-      if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
-      if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
-      if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
-      this.transitionDuration--;
+    // only update if transition duration isn't 0 (finished)
+    if (this.current.transitionDuration > 0) {
+      if (this.delta.color      != null) this.current.color      = this.delta.color     .next().get();
+      if (this.delta.direction  != null) this.current.direction  = this.delta.direction .next().get();
+      if (this.delta.brightness != null) this.current.brightness = this.delta.brightness.next().get();
+      if (this.delta.xOffset    != null) this.current.xOffset    = this.delta.xOffset   .next().get();
+      if (this.delta.yOffset    != null) this.current.yOffset    = this.delta.yOffset   .next().get();
+      if (this.delta.radius     != null) this.current.radius     = this.delta.radius    .next().get();
+      if (this.delta.beamLength != null) this.current.beamLength = this.delta.beamLength.next().get();
+      if (this.delta.beamWidth  != null) this.current.beamWidth  = this.delta.beamWidth .next().get();
+      this.current.transitionDuration--;
     } else
-      this.pauseDuration--;
+      this.current.pauseDuration--;
     return this;
   }
 
@@ -1655,12 +1670,12 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() { return this.transitionDuration <= 0 && this.pauseDuration <= 0; }
+  finished() { return this.current.transitionDuration <= 0 && this.current.pauseDuration <= 0; }
 }
 
 /**
  * Class representing individual number deltas for providing number changes over time at different speeds.
- **/
+ */
 class NumberDelta {
   /**
    * Creates a number delta from the start number, target number, and duration.
@@ -1679,7 +1694,7 @@ class NumberDelta {
   /**
    * Creates a copy of the NumberDelta object.
    * @returns {NumberDelta}
-   **/
+   */
   clone() {
     let that = new NumberDelta();
     [that.current, that.target, that.duration, that.lazyEquals, that.delta] =
@@ -1711,7 +1726,7 @@ class NumberDelta {
   /**
    * Returns the current delta number.
    * @returns {Number}
-   **/
+   */
   get() { return this.current; }
 
   /**
@@ -1728,7 +1743,7 @@ class NumberDelta {
 
 /**
  * Class representing a color delta for providing color changes over time at different speeds.
- **/
+ */
 class ColorDelta {
   /**
    * Create a color delta from the start color, target color, fade duration, and
@@ -1756,7 +1771,7 @@ class ColorDelta {
   /**
    * Creates a copy of the ColorDelta object.
    * @returns {ColorDelta}
-   **/
+   */
   clone() {
     let that = new  ColorDelta();
     that.current      = this.current.clone();
@@ -1840,7 +1855,7 @@ class ColorDelta {
   /**
    * Returns the current delta color.
    * @returns {Number}
-   **/
+   */
   get() { return this.current.clone(); } // duplicate color so reference can't be messed with
 
   /**
@@ -2007,26 +2022,9 @@ class ColorDelta {
   };
 
   // Event note tag caching
-  Game_Event.prototype.resetLightData = function () {
-    this._clType        = undefined;
-    this._lastLightPage = undefined;
-    this._clRadius      = undefined;
-    this._clColor       = undefined;
-    this._clCycle       = undefined;
-    this._clBrightness  = undefined;
-    this._clSwitch      = undefined;
-    this._clDirection   = undefined;
-    this._clXOffset     = undefined;
-    this._clYOffset     = undefined;
-    this._clId          = undefined;
-    this._clBeamLength  = undefined;
-    this._clBeamWidth   = undefined;
-    this._clOnOff       = undefined;
-    this._clCondLight   = {};
-    this.initLightData();
-  };
   Game_Event.prototype.initLightData = function () {
-    this._lastLightPage = this._pageIndex;
+    this._cl = {};
+    this._cl.lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
 
     // parse new cycle groups format within {} braces and extract from tag data for separate handling
@@ -2034,10 +2032,10 @@ class ColorDelta {
     let cycleGroups = [];
     tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((cycleGroups.push(group.split(/\s+/)), '')));
     tagData = tagData.split(/\s+/);
-    this._clType = LightType[tagData.shift()];
+    this._cl.type = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
-    if (this._clType) {
-      let isFL       = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+    if (this._cl.type) {
+      let isFL       = ()        => this._cl.type.is(LightType.Flashlight); // is flashlight
       let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
       let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
       let isNul      = (e)       => e == null;
@@ -2046,139 +2044,110 @@ class ColorDelta {
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
         let n = clip(e);
-        if      (!isFL() && !isNaN(+e)          && isNul(this._clRadius))     this._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamLength)) this._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l") && n  && isNul(this._clBeamLength)) this._clBeamLength = n;
-        else if (isFL()  && isPre(e, "w") && n  && isNul(this._clBeamWidth))  this._clBeamWidth  = n;
-        else if (           isEq(e, "cycle")    && isNul(this._clColor))      hasCycle           = true;
-        else if (           isPre(e, "#", "a#") && hasCycle)                  cycleIndex = cycleGroups.push([e]) - 2;
-        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])   cycleGroups[cycleIndex].push('p' + e);
-        else if (           isPre(e, "#", "a#") && isNul(this._clColor))      this._clColor      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._clOnOff))      this._clOnOff      = true;
-        else if (           isOff(e)            && isNul(this._clOnOff))      this._clOnOff      = false;
-        else if (           isDayNight(e)       && isNul(this._clSwitch))     this._clSwitch     = e;
-        else if (           isPre(e, "b") && n  && isNul(this._clBrightness)) this._clBrightness = (n / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = n;
-        else if ( isFL() && !isNaN(+e)          && isNul(this._clDirection))  this._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = CLDirectionMap[n];
-        else if ( isFL() && isPre(e, "a") && n  && isNul(this._clDirection))  this._clDirection  = Math.PI / 180 * n;
-        else if (           isPre(e, "x") && n  && isNul(this._clXOffset))    this._clXOffset    = n;
-        else if (           isPre(e, "y") && n  && isNul(this._clYOffset))    this._clYOffset    = n;
-        else if (           e.length > 0        && isNul(this._clId))         this._clId         = e;
+        if      (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamWidth))  this._cl.beamWidth  = +e;
+        else if (isFL()  && isPre(e, "l") && n  && isNul(this._cl.beamLength)) this._cl.beamLength = n;
+        else if (isFL()  && isPre(e, "w") && n  && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
+        else if (           isEq(e, "cycle")    && isNul(this._cl.color))      hasCycle            = true;
+        else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
+        else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
+        else if (           isOn(e)             && isNul(this._cl.enable))      this._cl.enable    = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))      this._cl.enable    = false;
+        else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
+        else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;
+        else if ( isFL() && !isNaN(+e)          && isNul(this._cl.direction))  this._cl.direction  = +e;
+        else if ( isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
+        else if ( isFL() && isPre(e, "a") && n  && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
+        else if (           isPre(e, "x") && n  && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
+        else if (           isPre(e, "y") && n  && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
+        else if (           e.length > 0        && isNul(this._cl.id))         this._cl.id         = e;
         cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);
 
       // normalize parameters
-      this._clRadius        = orNaN(this._clRadius, 0);
-      this._clColor         = orNullish(this._clColor, VRGBA.empty());
-      this._clBrightness    = orNaN(this._clBrightness, 0);
-      this._clDirection     = orNaN(this._clDirection, undefined); // must be undefined for later checks
-      this._clId            = orNullish(this._clId, 0); // Alphanumeric
-      this._clBeamLength    = orNaN(this._clBeamLength, 0);
-      this._clBeamWidth     = orNaN(this._clBeamWidth, 0);
-      this._clOnOff         = orBoolean(this._clOnOff, true);
-      this._clXOffset       = orNaN(this._clXOffset, 0);
-      this._clYOffset       = orNaN(this._clYOffset, 0);
-      this._clCycle         = this._clCycle || null;
+      this._cl.radius        = orNaN(this._cl.radius, 0);
+      this._cl.color         = orNullish(this._cl.color, VRGBA.empty());
+      this._cl.enable        = orBoolean(this._cl.enable, true);
+      this._cl.brightness    = orNaN(this._cl.brightness, 0);
+      this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
+      this._cl.id            = orNullish(this._cl.id, 0); // Alphanumeric
+      this._cl.beamLength    = orNaN(this._cl.beamLength, 0);
+      this._cl.beamWidth     = orNaN(this._cl.beamWidth, 0);
+      this._cl.xOffset       = orNaN(this._cl.xOffset, 0);
+      this._cl.yOffset       = orNaN(this._cl.yOffset, 0);
+      this._cl.cycle         = this._cl.cycle || null;
 
-      // Process cycle parameters
-      if (cycleGroups.length) {                                       // check if tag included color cycling
-        this._clCycle = [];                                           // only define if cycle exists
-        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
-                    this._clRadius, this._clBeamLength, this._clBeamWidth];
-        let condLight = new ConditionalLight(this._clType, ...args);  // create cond light with initial properties
-        cycleGroups.forEach((e, i, a) => {                            // ------ loop each group
-          condLight = condLight.clone();                              // - clone existing light (inherit properties)
-          let n = a[++i < cycleGroups.length ? i : 0];                // - get next element
-          condLight.parseDurationProps(n);                            // - parse durations
-          condLight.parseCurrentProps(e);                             // - parse for new properties
-          if (i == cycleGroups.length)                                // - last group targets initial properties
-            condLight.setTargets(...args);                            // -- setup targets based off non-cycle properties
-          condLight.parseTargetProps(n);                              // - parse for cycle target properties
-          condLight.createDeltas();                                   // - compute deltas
-          this._clCycle.push(condLight);                              // - push to list
-        }, this);                                                     // ------
-        condLight = this._clCycle.shift();                            // pop front
-        this._clCondLight = condLight.clone();                        // clone it to be the current cond light delta
-        this._clCycle.push(condLight);                                // push original on back of list
+      // Store initial light properties
+      let props = [this._cl.color, this._cl.enable, this._cl.direction, this._cl.brightness, this._cl.xOffset,
+                   this._cl.yOffset, this._cl.radius, this._cl.beamLength, this._cl.beamWidth];
+
+      // create initial properties
+      let startProps = new LightProperties(this._cl.type, ...props);
+
+      // Process cycle parameters - for each cycle group create currentProps and targetProps and cooresponding light
+      // delta. Then put the deltas into a list to loop/cycle through repeatedly
+      if (cycleGroups.length) { // check if tag included color cycling
+        this._cl.cycle = [];     // only define if cycle exists
+        let currentProps = startProps, targetProps, delta;
+        cycleGroups.forEach((e, i, a) => {                                  // ------ loop each group ------
+          let n = a[++i < a.length ? i : 0];                                // - get next element: OOB goes to first
+          currentProps = currentProps.clone();                              // - inherit existing props
+          currentProps.parseProps(e);                                       // - parse for new props
+          targetProps = i == a.length ? startProps : currentProps.clone();  // - create target props: last targets start
+          targetProps.parseProps(n);                                        // - parse for new props: last targets start
+          let delta = new LightDelta(currentProps, targetProps, this._cl);  // - create light delta object
+          this._cl.cycle.push(delta);                                       // - push conditional light delta to list
+        }, this);                                                           // -----------------------------
+        delta = this._cl.cycle.shift(); // pop front
+        this._cl.delta = delta.clone(); // clone front as the initial lightDelta state for this cond light
+        this._cl.cycle.push(delta);     // push original on back of list
       }
-
-      // Process conditional lighting
-      if (this._clId) {                                               // check for a conditional lighting ID
-        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
-                    this._clRadius, this._clBeamLength, this._clBeamWidth];
-        let condLight  = new ConditionalLight(this._clType, ...args); // create conditional light
-        condLight.setTargets(...args);                                // create matching targets
-        condLight.createDeltas();                                     // compute deltas (zeroes)
-        $gameVariables.GetLightArray()[this._clId] = condLight;
-        this._clCondLight = condLight;
+      // Process conditional lighting - for a cond light, currentProps are light specific and targets are shared by ID
+      // a target can be updated on the fly using commands and all lights with matching IDs will use the properties
+      else if (this._cl.id) { // check for a conditional lighting ID
+        let lightArray = $gameVariables.GetLightArray();                    // get target light Object
+        if (lightArray[this._cl.id] == null)                                // check if target exists since it's shared
+          lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
+        let targetProps = lightArray[this._cl.id];                          // get target prop reference
+        this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
+        console.log(this._cl.delta);
+      }
+      // Non-conditional light
+      else {
+        this._cl.delta = { current: this._cl };// really just a self reference
       }
     }
   };
   Game_Event.prototype.cycleLightingNext = function () {
     let cycleList = this.getLightCycle();
-    if (cycleList && this._clCondLight.finished()) {
-      let condLight = cycleList.shift();     // pop delta from front
-      this._clCondLight = condLight.clone(); // duplicate delta
-      cycleList.push(condLight);             // push delta on back
+    if (cycleList && this._cl.delta.finished()) {
+      let delta = cycleList.shift();  // pop delta from front
+      this._cl.delta = delta.clone(); // duplicate delta
+      cycleList.push(delta);          // push delta on back
     }
   };
   Game_Event.prototype.conditionalLightingNext = function () {
-    if (this._clType === undefined) this.initLightData();
-    if (this.getLightCycle() || this.getLightId()) this._clCondLight.next();
+    if (this.getLightCycle() || this.getLightId()) this._cl.delta.next();
   };
-  Game_Event.prototype.getLightType = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clType;
+  Game_Event.prototype.getLightEnabled          = function () {
+    if (!this._cl.switch) return this._cl.delta.current.enable;
+    return (this._cl.switch.equalsIC("night") && $$.isNight()) ||
+           (this._cl.switch.equalsIC("day")   && !$$.isNight());
   };
-  Game_Event.prototype.getLightRadius = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentRadius, this._clRadius);
-  };
-  Game_Event.prototype.getLightColor = function () {
-    if (this._clType === undefined) this.initLightData();
-    if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.currentColor, this._clColor.clone());
-  };
-  Game_Event.prototype.getLightBrightness = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentBrightness, this._clBrightness);
-  };
-  Game_Event.prototype.getLightDirection = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentDirection, this._clDirection);
-  };
-  Game_Event.prototype.getLightId = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clId;
-  };
-  Game_Event.prototype.getLightFlashlightLength = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentBeamLength, this._clBeamLength);
-  };
-  Game_Event.prototype.getLightFlashlightWidth = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentBeamWidth, this._clBeamWidth);
-  };
-  Game_Event.prototype.getLightXOffset = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentXOffset, this._clXOffset);
-  };
-  Game_Event.prototype.getLightYOffset = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
-  };
-  Game_Event.prototype.getLightEnabled = function () {
-    if (!this._clSwitch) return orNullish(this._clCondLight.enabled, this._clOnOff);
-    return orNullish(this._clCondLight.enabled,
-                    (this._clSwitch.equalsIC("night") && $$.isNight()) ||
-                    (this._clSwitch.equalsIC("day")   && !$$.isNight()));
-  };
-  Game_Event.prototype.getLightCycle = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clCycle;
-  };
+  Game_Event.prototype.getLightType             = function () { return this._cl.type; };
+  Game_Event.prototype.getLightRadius           = function () { return this._cl.delta.current.radius; };
+  Game_Event.prototype.getLightColor            = function () { return this._cl.delta.current.color.clone(); };
+  Game_Event.prototype.getLightBrightness       = function () { return this._cl.delta.current.brightness; };
+  Game_Event.prototype.getLightDirection        = function () { return this._cl.delta.current.direction; };
+  Game_Event.prototype.getLightId               = function () { return this._cl.id; };
+  Game_Event.prototype.getLightFlashlightLength = function () { return this._cl.delta.current.beamLength; };
+  Game_Event.prototype.getLightFlashlightWidth  = function () { return this._cl.delta.current.beamWidth; };
+  Game_Event.prototype.getLightXOffset          = function () { return this._cl.delta.current.xOffset; };
+  Game_Event.prototype.getLightYOffset          = function () { return this._cl.delta.current.yOffset; };
+  Game_Event.prototype.getLightCycle            = function () { return this._cl.cycle; };
 
   let _Game_Interpreter_pluginCommand = Game_Interpreter.prototype.pluginCommand;
   /**
@@ -2548,7 +2517,7 @@ class ColorDelta {
     for (let i = 0, len = eventObjId.length; i < len; i++) {
       let evid = event_id[i];
       let cur = $gameMap.events()[eventObjId[i]];
-      if (cur._lastLightPage !== cur._pageIndex) cur.resetLightData();
+      if (cur._cl == null || cur._cl.lastLightPage !== cur._pageIndex) cur.initLightData();
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
@@ -2568,8 +2537,8 @@ class ColorDelta {
         let color          = cur.getLightColor();      // light color
         let direction      = cur.getLightDirection();  // direction
         let brightness     = cur.getLightBrightness(); // brightness
-        let xoffset        = cur.getLightXOffset() * $gameMap.tileWidth();
-        let yoffset        = cur.getLightYOffset() * $gameMap.tileHeight();
+        let xOffset        = cur.getLightXOffset() * $gameMap.tileWidth();
+        let yOffset        = cur.getLightYOffset() * $gameMap.tileHeight();
         let state          = cur.getLightEnabled();    // checks for on, off, day, and night
 
         // Set kill switch to ON if the conditional light is deactivated,
@@ -2592,8 +2561,8 @@ class ColorDelta {
           }
 
           // apply offsets
-          lx1 += +xoffset;
-          ly1 += +yoffset;
+          lx1 += +xOffset;
+          ly1 += +yOffset;
 
           if (lightType.is(LightType.Flashlight)) {
             let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
@@ -3422,36 +3391,33 @@ class ColorDelta {
 
     // *********************** TURN SPECIFIC LIGHT ON *********************
     else if (isOn(args[0])) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.enabled = true; }
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) { targetProps.parseProps(["e1"]); }
     }
 
     // *********************** TURN SPECIFIC LIGHT OFF *********************
     else if (isOff(args[0])) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.enabled = false; }
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) { targetProps.parseProps(["e0"]); }
     }
 
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.currentColor = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      console.log(args[2]);
+      if (targetProps) targetProps.parseProps([args[2] != null ? args[2] : "#"]);
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) {
-        let properties = args[2].split(/\s+/);
-        condLight.parseDurationProps(properties);
-        condLight.parseTargetProps(properties);
-        condLight.createDeltas();
-      }
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) targetProps.parseProps(args[2] != null ? args[2].split(/\s+/) : ['']);
     }
 
     // **************************** RESET ALL SWITCHES ***********************
     else if (args[0].equalsIC('switch') && args[1].equalsIC('reset')) {
-      $gameVariables.SetLightArray({});
+      let lightArray = $gameVariables.GetLightArray();
+      for (let i in lightArray) lightArray[i].parseProps(['#', 'e', 'b', 'x', 'y', 'r', 'l', 'w', 'a']); // clear
     }
   };
 
@@ -3755,7 +3721,7 @@ Game_Variables.prototype.SetLightArray = function (value) {
 };
 Game_Variables.prototype.GetLightArray = function () {
   if (this._Community_Lighting_LightArray == null)
-    this._Community_Lighting_LightArray = { 0: {} };
+    this._Community_Lighting_LightArray = {};
   return this._Community_Lighting_LightArray;
 };
 Game_Variables.prototype.SetTileLightArray = function (value) {

--- a/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
+++ b/CommunityLightingMZDemo/js/plugins/Community_Lighting_MZ.js
@@ -3441,7 +3441,7 @@ class ColorDelta {
    * @param {String[]} args
    */
   $$.tintbattle = function (args, overrideInBattleCheck = false) {
-    if ($gameParty.inBattle() || overrideInBattleCheck) {
+    if ($gameVariables.GetScriptActive() && lightInBattle && ($gameParty.inBattle() || overrideInBattleCheck)) {
       let cmd = args[0].trim();
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -721,13 +721,13 @@ Imported[Community.Lighting.name] = true;
 const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
 const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
 
-Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
-Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
-Number.prototype.clone        = function()        { return this; };
-Boolean.prototype.clone       = function()        { return this; };
-String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
+Number.prototype.is           = function(...a)     { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max) { return this >= min && this <= max; };
+Number.prototype.clone        = function()         { return this; };
+Boolean.prototype.clone       = function()         { return this; };
+String.prototype.equalsIC     = function(...a)     { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)        { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) =>  minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
@@ -832,7 +832,7 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
  * @param {Number} a
  * @returns {String}
  */
- function rgba(r, g, b, a) {
+function rgba(r, g, b, a) {
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
@@ -2037,8 +2037,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distpart > lightsOnRadius) {
+        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distanceApart > lightsOnRadius) {
           continue;
         }
       }
@@ -2198,7 +2198,7 @@ class ColorDelta {
   * @param {Number} brightness
   * @param {VRGBA} c1
   * @param {VRGBA} c2
-   */
+  */
   CanvasGradient.prototype.addTransparentColorStops = function (brightness, c1, c2) {
     if (brightness) {
       if (!useSmootherLights) {

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -2085,9 +2085,9 @@ class ColorDelta {
             let flashlength = cur.getLightFlashlightLength();
             let flashwidth  = cur.getLightFlashlightWidth();
             if (!isNaN(direction)) ldir = direction;
-            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
+            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.minRGBA(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.minRGBA(), objectflicker,
                                                      brightness, direction);
           }
         }
@@ -2119,7 +2119,7 @@ class ColorDelta {
         tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
         tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.minRGBA(), objectflicker,
                                                tile.brightness);
     });
 
@@ -2627,7 +2627,7 @@ class ColorDelta {
     // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
-            $gameVariables.GetTint() : new VRGBA("#ffffff");
+            $gameVariables.GetTint() : VRGBA.maxRGBA();
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {
@@ -3088,7 +3088,7 @@ Game_Variables.prototype.SetTint = function (value) {
   this._Community_Tint_Value = value.clone();
 };
 Game_Variables.prototype.GetTint = function () {
-  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.empty();
+  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.minRGBA();
   return this._Community_Tint_Value.clone();
 };
 Game_Variables.prototype.SetTintAtHour = function (hour, color) {
@@ -3101,7 +3101,7 @@ Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   while (hours >= hoursinDay) hours -= hoursinDay;
   while (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
-  return result ? result.color.clone() : VRGBA.empty();
+  return result ? result.color.clone() : VRGBA.minRGBA();
 };
 Game_Variables.prototype.SetTintTarget = function (delta) {
   this._Community_TintTarget = delta;
@@ -3141,7 +3141,7 @@ Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if emp
   if (value) this._Community_Lighting_PlayerColor = new VRGBA(value);
 };
 Game_Variables.prototype.GetPlayerColor = function () {
-  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = new VRGBA("#ffffff");
+  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = VRGBA.maxRGBA();
   return this._Community_Lighting_PlayerColor.clone();
 };
 Game_Variables.prototype.SetPlayerBrightness = function (value) { // don't set if invalid.
@@ -3196,7 +3196,7 @@ Game_Variables.prototype.GetDaynightColorArray = function () {
   if (hoursInDay > result.length) { // lazy check bounds before returning and add colors if too small
     let origLength = result.length;
     result.length = hoursInDay;     // more efficient than a for loop
-    result.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+    result.fill({ "color": VRGBA.maxRGBA(), "isNight": false }, origLength);
   }
   this._Community_Lighting_DayNightColorArray = result; // assign reference
   return result;

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -1046,20 +1046,20 @@ class LightProperties {
     // properties with no suffix 'clear' the target
     properties.forEach((e) => {
       // clear checks (back to initial value for the given property)
-      if      (        e.equalsIC('t'))        this.transitionDuration = 0;
-      else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
-      else if (        e.equalsIC('#'))        this.color      = void (0);
-      else if (        e.equalsIC('a#'))       this.color      = void (0);
-      else if (        e.equalsIC('e'))        this.enable     = void (0);
-      else if (        e.equalsIC('b'))        this.brightness = void (0);
-      else if (        e.equalsIC('x'))        this.xOffset    = void (0);
-      else if (        e.equalsIC('y'))        this.yOffset    = void (0);
-      else if (isOL && e.equalsIC('r'))        this.radius     = void (0);
-      else if (isFL && e.equalsIC('l'))        this.beamLength = void (0);
-      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void (0);
-      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void (0);
+      if      (        e.equalsIC('t'))  { this.transitionDuration = 0; return; }
+      else if (        e.equalsIC('p'))  { this.pauseDuration      = 0; return; }
+      else if (        e.equalsIC('#'))  { this.color      = void (0); return; }
+      else if (        e.equalsIC('a#')) { this.color      = void (0); return; }
+      else if (        e.equalsIC('e'))  { this.enable     = void (0); return; }
+      else if (        e.equalsIC('b'))  { this.brightness = void (0); return; }
+      else if (        e.equalsIC('x'))  { this.xOffset    = void (0); return; }
+      else if (        e.equalsIC('y'))  { this.yOffset    = void (0); return; }
+      else if (isOL && e.equalsIC('r'))  { this.radius     = void (0); return; }
+      else if (isFL && e.equalsIC('l'))  { this.beamLength = void (0); return; }
+      else if (isFL && e.equalsIC('w'))  { this.beamWidth  = void (0); return; }
+      else if (isFL && e.equalsIC('a'))  { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('+a')) { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('-a')) { this.clockwise  = this.direction = void (0); return; }
 
       // parse suffix (individual & random ranges)
       let suffix, rand = (min, max) => Math.random() * (max - min) + min;
@@ -1667,7 +1667,7 @@ class ColorDelta {
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
       this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
-      this._cl.enable        = orBoolean(this._cl.enable, true);
+      this._cl.enable        = orBoolean(this._cl.enable, this._cl.id ? false : true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
       this._cl.id            = orNullish(this._cl.id, 0); // Alphanumeric

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -307,16 +307,19 @@ Imported[Community.Lighting.name] = true;
 * Events
 * --------------------------------------------------------------------------
 * Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
-*               that will be cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
-*               fadeDuration and growRadius are optional argument used to transition between colors
-*               and radius sizes over the provided cycle interval. If growRadius is not provided
-*               the default radius is used for the given color. In Terrax Lighting, there was a hard
-*               limit of 4, but now you can use as many as you want. [optional]
+* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+*               through before repeating from the beginning. See the examples below for usage.
+*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+*               To cycle any light property or for fade transitions, use the cycleProps
+*               format instead. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
 * - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
@@ -329,40 +332,43 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not begin with 'd', 'x' or 'y' otherwise
-*               they will be mistaken for one of the previous optional parameters.
+*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
+*               where N is a number otherwise they will be mistaken for one of the previous
+*               optional parameters.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
 * Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
-*             grow_bw tuples to follow that will be cycled through before repeating
-*             from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
-*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
-*             transition between colors and beam lengths & widths over the provided
-*             cycle interval. If grow_bl or grow_bw are not provided, the default
-*             length or width is used for the given color. There's no limit to how
-*             many colors can be cycled. [optional]
-* - color     #ffffff, #ff0000, etc
-* - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
-* - day       Sets the event's light to only show during the day [optional]
-* - night     Sets the event's light to only show during night time [optional]
-* - sdir:     Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*             Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:    Forced direction in degrees (optional): must be preceded by "A". If
-*             omitted, sdir is used. [optional]
-* - x         x[offset] Work the same as regular light [optional]
-* - y         y[offset] [optional]
-* - id        1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*             These should not begin with 'a', 'd', 'x' or 'y' otherwise
-*             they will be mistaken for one of the previous optional parameters.
+* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
+* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+*               through before repeating from the beginning. See the examples below for usage.
+*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+*               To cycle any light property or for fade transitions, use the cycleProps
+*               format instead. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
+* - color       #ffffff, #ff0000, etc
+* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - day         Sets the event's light to only show during the day [optional]
+* - night       Sets the event's light to only show during night time [optional]
+* - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
+*               Can be preceded by "D", so D4.  If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               omitted, sdir is used. [optional]
+* - x           x[offset] Work the same as regular light [optional]
+* - y           y[offset] [optional]
+* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
+*               where N is a number otherwise they will be mistaken for one of the previous
+*               optional parameters.
 *
 * Example note tags:
 *
@@ -370,12 +376,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
+* <cl: light 300 {#ff0000 p15} {#ffff00 p15} {#00ff00 p15} {#00ffff p15} {#0000ff p15}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* <cl: light 300 {#ff0000 t30 p60} {#ffff00 t30 p60} {#00ff00 t30 p60} {#00ffff t30 p60}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
-* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* <cl: light {#ff0000 t30 p60 r250} {#ffff00 t30 p60 r300} {#00ff00 t30 p60 r250} {#00ffff t30 p60 r300}>
 * Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
 * and transitions to the next color and size over 60 frames.
 *
@@ -386,9 +393,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
-* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
+* <cl: Flashlight l8 w12 #ff0000 on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
+*
+* <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15>
+* <cl: Flashlight l8 w12 {#f00 p15} {#ff0 p15} {#0f0 p15}>
+* Creates a flashlight beam that rotates every 15 frames.
 *
 * --------------------------------------------------------------------------
 * Additive Lighting Effects
@@ -397,12 +408,54 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 cycle a#990000 15 a#999900 15 a#009900 15 a#009999 15 a#000099 15>
+* <cl: light 300 {a#990000 t15} {a#999900 t15} {a#009900 t15} {a#009999 t15} {a#000099 t15}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
 * Creates a red volumetric flashlight beam with id asdf which can be turned on or off
 * via plugin commands.
+*
+* --------------------------------------------------------------------------
+* Conditional Lighting
+* --------------------------------------------------------------------------
+* Conditional Lighting allows light properties to be changed either cyclically or
+* dynamically over time via properties that consist of a prefix followed by a property
+* value. This is useful for creating any number of transitional lighting effects.
+*
+* The properties are supported in light tags or via the 'light cond' command. Light tags
+* support any number of light properties wrapped in {} brackets See the example note tags
+* above.
+*
+* The 'light cond' command allows for conditional lights to be dynamically changed on demand.
+* See the Plugin Commands section for more details.
+*
+* The following chart shows all supported properties:
+* --------------------------------------------------------------------------------------------------------------------
+* |   Property     |  Prefix   |        Format           | Examples          | Description                            |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     pause      |     p     |           pN            |    p0, p1, p20    | time period in cycles to pause after   |
+* |    duration    |           |                         |                   | transitioning for cycling lights       |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   transition   |     t     |           tN            |    t0, t1, t30    | time period to transition the          |
+* |    duration    |           |                         |                   | specified properties over              |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     color      |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | a#FFEEDD, #ffeedd | color or additive color                |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     angle      | a, +a, -a |       <a|+a|-a>N        |  a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |                |           |                         |                   | clockwise, '-' moves counterclockwise  |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   brightness   |     b     |           bN            |    b0, b1, b5     | brightness                             |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    x offset    |     x     |           xN            |     x2, x-2       | x offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    y offset    |     y     |           yN            |     y2, y-2       | y offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     radius     |     r     |           rN            |    r50, r150      | light radius                           |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam length  |     l     |           lN            |   l8, l9, l10     | flashlight beam length                 |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam width   |     w     |           wN            |  w12, w13, w14    | flashlight beam width                  |
+* --------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
 * Easy hex color references
@@ -484,6 +537,13 @@ Imported[Community.Lighting.name] = true;
 *
 * Light off id
 * - Turn off light with matching id number
+*
+* Light cond id [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+* - transitions a conditional light to the specified properties over the the given
+* - time period in cycles. Supported propreties are color, flashlight angle (a),
+* - brightness (b), x offset (x), y offset (y), radius (r), flashlight beam length (l),
+* - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
+* - ignored. See the Conditional Light section for more detail on each property.
 *
 * Light color id c
 * - Change the color (c) of lightsource with id (id)
@@ -659,16 +719,17 @@ Imported[Community.Lighting.name] = true;
 * ....where # is the max distance you want in tiles.
 */
 
-Number.prototype.is           = function (...a) { return a.includes(Number(this)); };
-Number.prototype.inRange      = function (min, max) { return this >= min && this <= max; };
-String.prototype.equalsIC     = function (...a) { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function (s) { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Math.min(...a) : Math.max(...a); }; // min if positive
+const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
+const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
+
+Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
+String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
-
-let cmpFloat = (x, y) => Math.abs(x - y) < 1e-3; // custom epsilon
 
 function orBoolean(...a) {
   for (let i = 0; i < a.length; i++) {
@@ -681,6 +742,85 @@ function orBoolean(...a) {
 }
 function orNullish(...a) { for (let i = 0; i < a.length; i++) if (a[i] != null) return a[i]; }
 function orNaN(...a)     { for (let i = 0; i < a.length; i++) if (!isNaN(a[i])) return a[i]; }
+
+let isOn         = (x) => x.toLowerCase() === "on";
+let isOff        = (x) => x.toLowerCase() === "off";
+let isActivate   = (x) => x.toLowerCase() === "activate";
+let isDeactivate = (x) => x.toLowerCase() === "deactivate";
+
+// Map community light directions to polar angles (360 degrees)
+const CLDirectionMap = {
+  0: undefined,       // auto
+  1: 3 * Math.PI / 2, // up
+  2: 2 * Math.PI,     // right
+  3: Math.PI / 2,     // down
+  4: Math.PI          // left
+};
+
+// Map RM directions to polar angles (360 degrees)
+const RMDirectionMap = {
+  1: 3 * Math.PI / 4, // down-left
+  2: Math.PI / 2,     // down
+  3: Math.PI / 4,     // down-right
+  4: Math.PI,         // left
+  6: 2 * Math.PI,     // right
+  7: 5 * Math.PI / 4, // up-left
+  8: 3 * Math.PI / 2, // up
+  9: 7 * Math.PI / 4  // up-right
+};
+
+const TileType = {
+  Terrain: 1, terrain: 1, 1: 1,
+  Region:  2, region:  2, 2: 2
+};
+
+const LightType = {
+  Light     : 1, light     : 1, 1: 1,
+  Fire      : 2, fire      : 2, 2: 2,
+  Flashlight: 3, flashlight: 3, 3: 3,
+  Glow      : 4, glow      : 4, 4: 4
+};
+
+const TileLightType = {
+  tilelight:   [TileType.Terrain, LightType.Light],
+  tilefire:    [TileType.Terrain, LightType.Fire],
+  tileglow:    [TileType.Terrain, LightType.Glow],
+  regionlight: [TileType.Region,  LightType.Light],
+  regionfire:  [TileType.Region,  LightType.Fire],
+  regionglow:  [TileType.Region,  LightType.Glow],
+};
+
+const TileBlockType = {
+  tileblock:   TileType.Terrain,
+  regionblock: TileType.Region
+};
+
+class TileLight {
+  constructor(tileType, lightType, id, onoff, color, radius, brightness) {
+    this.tileType   = TileType[tileType];
+    this.lightType  = LightType[lightType];
+    this.id         = +id || 0;
+    this.enabled    = isOn(onoff);
+    this.color      = new VRGBA(color);
+    this.radius     = +radius || 0;
+    this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) ||
+                      Community.Lighting.defaultBrightness || 0;
+  }
+}
+
+class TileBlock {
+  constructor(tileType, id, onoff, color, shape, xOffset, yOffset, blockWidth, blockHeight) {
+    this.tileType    = TileType[tileType];
+    this.id          = +id || 0;
+    this.enabled     = isOn(onoff);
+    this.color       = new VRGBA(color);
+    this.shape       = +shape || 0;
+    this.xOffset     = +xOffset || 0;
+    this.yOffset     = +yOffset || 0;
+    this.blockWidth  = +blockWidth || 0;
+    this.blockHeight = +blockHeight || 0;
+  }
+}
 
 const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive lighting
 
@@ -695,18 +835,18 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
-/** Class to handle volumetric/additive coloring with rgba colors uniformly.
- *  Additive coloring prefixes an 'a' on a normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
+/** Class to handle volumetric/additive coloring with rgba colors uniformly. Additive coloring prefixes an 'a' on a
+ *  normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
  */
 class VRGBA {
   /**
-   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a hex String
-   * can be passed with an optional default alternative Hex string, or another VRGBA object can be passed to create a clone.
+   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a
+   * hex String can be passed with an optional default alternative Hex string which is used in case of parsing failure.
    * @param {String|Boolean|VRGBA} vOrHex     - Boolean representing the additive component, or
    *                                            String representing the hex color, or
    *                                            other VRGBA object to clone.
    * @param {String|Number}        rOrDefault - Number representing the red component, or
-   *                                            String representing a default hex string in case the provided one cannot be parsed.
+   *                                            String representing a default hex string.
    * @param {null|Number}          g          - Number representing the green component.
    * @param {null|Number}          b          - Number representing the blue component.
    * @param {null|Number}          a          - Number representing the alpha component.
@@ -757,26 +897,15 @@ class VRGBA {
   set(that) { for (let k in that) if (this[k] != null) this[k] = that[k]; }
 
   /**
-   * Compares this Object to that Object and returns true if the v, r, g, b, and a properties are equal; otherwise false.
-   * @param {VRGBA} that
-   * @returns {Boolean}
-   */
-  equals(that) { // fastest non-exactness comparison -- only checks v, r, g, b, a properties
-    let [a, b] = [this, that];
-    if (b && cmpFloat(a.v, b.v) && cmpFloat(a.r, b.r) && cmpFloat(a.g, b.g) && cmpFloat(a.b, b.b) && cmpFloat(a.a, b.a))
-      return true;
-    return false;
-  }
-
-  /**
    * Adds together the r, g, and b properties and returns the result.
    * @returns {Number}
    */
   magnitude() { return this.r + this.g + this.b; }
 
   /**
-   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String. If invalid, a default
-   * value of "#000000ff" is returned. If either provided String is valid, it will be returned as an 'a#rrggbbaa' formatted color hex String.
+   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String.
+   * If invalid, a default value of "#000000ff" is returned. If either provided String is valid, it will be returned
+   * as an 'a#rrggbbaa' formatted color hex String.
    * @param {String} hex
    * @param {String} alt
    * @returns {String}
@@ -796,9 +925,10 @@ class VRGBA {
   }
 
   /**
-   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the hex is additive or not.
-   * The setWebSafe parameter is used to to strip the additive property (v) so that the resulting color can be used with Canvas APIs. An
-   * override Object can be provided to override the existing v, r, g, b, or a properties in the output.
+   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the
+   * hex is additive or not. The setWebSafe parameter is used to to strip the additive property (v) so that the
+   * resulting color can be used with Canvas APIs. An override Object can be provided to override the existing v, r, g,
+   * b, or a properties in the output.
    * @param {Boolean} setWebSafe
    * @param {VRGBA} override
    * @returns {String}
@@ -827,31 +957,37 @@ class VRGBA {
 }
 
 /**
- * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability to compute deltas
- * between the current parameter values and the target values, and allows for current values to be extracted.
+ * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability
+ * to compute deltas between the current parameter values and the target values, and allows for current values to be
+ * extracted.
  **/
 class ConditionalLight {
   /**
    * Creates a ConditionalLight object with the provided parameters
-   * @param {VRGBA}  color
-   * @param {Number} direction
-   * @param {Number} brightness
-   * @param {Number} xOffset
-   * @param {Number} yOffset
-   * @param {Number} radius
-   * @param {Number} beamLength
-   * @param {Number} beamWidth
+   * @param {LightType} type
+   * @param {VRGBA}     currentColor
+   * @param {Number}    currentDirection
+   * @param {Number}    currentBrightness
+   * @param {Number}    currentXOffset
+   * @param {Number}    currentYOffset
+   * @param {Number}    currentRadius
+   * @param {Number}    currentBeamLength
+   * @param {Number}    currentBeamWidth
    **/
-  constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
+              currentBeamLength, currentBeamWidth) {
     if (arguments.length == 0) return;
-    this.color      = color;
-    this.direction  = direction;
-    this.brightness = brightness;
-    this.xOffset    = xOffset;
-    this.yOffset    = yOffset;
-    this.radius     = radius;
-    this.beamLength = beamLength;
-    this.beamWidth  = beamWidth;
+    this.transitionDuration = 0;
+    this.pauseDuration      = 0;
+    this.type               = type;
+    this.currentColor       = currentColor;
+    this.currentDirection   = this.isFlashlight() ? currentDirection  : void(0);
+    this.currentBrightness  = currentBrightness;
+    this.currentXOffset     = currentXOffset;
+    this.currentYOffset     = currentYOffset;
+    this.currentRadius      = this.isOtherLight() ? currentRadius     : void(0);
+    this.currentBeamLength  = this.isFlashlight() ? currentBeamLength : void(0);
+    this.currentBeamWidth   = this.isFlashlight() ? currentBeamWidth  : void(0);
   }
 
   /**
@@ -860,89 +996,162 @@ class ConditionalLight {
    **/
   clone() {
     let that = new ConditionalLight();
-    // clone properties
-    if (this.color      != null) that.color      = this.color.clone();
-    if (this.direction  != null) that.direction  = this.direction;
-    if (this.brightness != null) that.brightness = this.brightness;
-    if (this.xOffset    != null) that.xOffset    = this.xOffset;
-    if (this.yOffset    != null) that.yOffset    = this.yOffset;
-    if (this.radius     != null) that.radius     = this.radius;
-    if (this.beamLength != null) that.beamLength = this.beamLength;
-    if (this.beamWidth  != null) that.beamWidth  = this.beamWidth;
+    // clone durations
+    if (this.transitionDuration != null) that.transitionDuration = this.transitionDuration;
+    if (this.pauseDuration      != null) that.pauseDuration      = this.pauseDuration;
+    // clone type
+    if (this.type               != null) that.type               = this.type;
+    // clone currents
+    if (this.currentColor       != null) that.currentColor       = this.currentColor.clone();
+    if (this.currentDirection   != null) that.currentDirection   = this.currentDirection;
+    if (this.currentBrightness  != null) that.currentBrightness  = this.currentBrightness;
+    if (this.currentXOffset     != null) that.currentXOffset     = this.currentXOffset;
+    if (this.currentYOffset     != null) that.currentYOffset     = this.currentYOffset;
+    if (this.currentRadius      != null) that.currentRadius      = this.currentRadius;
+    if (this.currentBeamLength  != null) that.currentBeamLength  = this.currentBeamLength;
+    if (this.currentBeamWidth   != null) that.currentBeamWidth   = this.currentBeamWidth;
+    // clone targets
+    if (this.targetColor        != null) that.targetColor        = this.targetColor.clone();
+    if (this.targetDirection    != null) that.targetDirection    = this.targetDirection;
+    if (this.targetBrightness   != null) that.targetBrightness   = this.targetBrightness;
+    if (this.targetXOffset      != null) that.targetXOffset      = this.targetXOffset;
+    if (this.targetYOffset      != null) that.targetYOffset      = this.targetYOffset;
+    if (this.targetRadius       != null) that.targetRadius       = this.targetRadius;
+    if (this.targetBeamLength   != null) that.targetBeamLength   = this.targetBeamLength;
+    if (this.targetBeamWidth    != null) that.targetBeamWidth    = this.targetBeamWidth;
     // clone deltas
-    if (this.colorDelta      != null) that.colorDelta      = this.colorDelta     .clone();
-    if (this.directionDelta  != null) that.directionDelta  = this.directionDelta .clone();
-    if (this.brightnessDelta != null) that.brightnessDelta = this.brightnessDelta.clone();
-    if (this.xOffsetDelta    != null) that.xOffsetDelta    = this.xOffsetDelta   .clone();
-    if (this.yOffsetDelta    != null) that.yOffsetDelta    = this.yOffsetDelta   .clone();
-    if (this.radiusDelta     != null) that.radiusDelta     = this.radiusDelta    .clone();
-    if (this.beamLengthDelta != null) that.beamLengthDelta = this.beamLengthDelta.clone();
-    if (this.beamWidthDelta  != null) that.beamWidthDelta  = this.beamWidthDelta .clone();
+    if (this.deltaColor         != null) that.deltaColor         = this.deltaColor     .clone();
+    if (this.deltaDirection     != null) that.deltaDirection     = this.deltaDirection .clone();
+    if (this.deltaBrightness    != null) that.deltaBrightness    = this.deltaBrightness.clone();
+    if (this.deltaXOffset       != null) that.deltaXOffset       = this.deltaXOffset   .clone();
+    if (this.deltaYOffset       != null) that.deltaYOffset       = this.deltaYOffset   .clone();
+    if (this.deltaRadius        != null) that.deltaRadius        = this.deltaRadius    .clone();
+    if (this.deltaBeamLength    != null) that.deltaBeamLength    = this.deltaBeamLength.clone();
+    if (this.deltaBeamWidth     != null) that.deltaBeamWidth     = this.deltaBeamWidth .clone();
     return that;
   }
 
   /**
-   * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
-   * @param {Number} fadeDuration
-   * @param {Number} pauseDuration
-   * @param {VRGBA}  tColor
-   * @param {Number} tDirection
-   * @param {Number} tBrightness
-   * @param {Number} tXOffset
-   * @param {Number} tYOffset
-   * @param {Number} tRadius
-   * @param {Number} tBeamLength
-   * @param {Number} tBeamWidth
+   * Returns true if the light type is a flashlight; otherwise false.
    */
-  setupTargets(fadeDuration, pauseDuration, tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
-    if (this.color      != null) this.colorDelta      = ColorDelta.createLight(this.color,  tColor,      fadeDuration, pauseDuration);
-    if (this.direction  != null) this.directionDelta  = NumberDelta.create(this.direction,  tDirection,  fadeDuration);
-    if (this.brightness != null) this.brightnessDelta = NumberDelta.create(this.brightness, tBrightness, fadeDuration);
-    if (this.xOffset    != null) this.xOffsetDelta    = NumberDelta.create(this.xOffset,    tXOffset,    fadeDuration);
-    if (this.yOffset    != null) this.yOffsetDelta    = NumberDelta.create(this.yOffset,    tYOffset,    fadeDuration);
-    if (this.radius     != null) this.radiusDelta     = NumberDelta.create(this.radius,     tRadius,     fadeDuration);
-    if (this.beamLength != null) this.beamLengthDelta = NumberDelta.create(this.beamLength, tBeamLength, fadeDuration);
-    if (this.beamWidth  != null) this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  tBeamWidth,  fadeDuration);
+  isFlashlight() { return this.type.is(LightType.Flashlight); }
+
+  /**
+   * Returns true if the light type is light, fire, or glow; otherwise false.
+   */
+  isOtherLight() { return this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
+
+  /**
+   * Sets up all supported targets.
+   * @param {VRGBA}  targetColor
+   * @param {Number} targetDirection
+   * @param {Number} targetBrightness
+   * @param {Number} targetXOffset
+   * @param {Number} targetYOffset
+   * @param {Number} targetRadius
+   * @param {Number} targetBeamLength
+   * @param {Number} targetBeamWidth
+   */
+  setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
+             targetBeamLength, targetBeamWidth) {
+    if (targetColor       != null) this.targetColor      = targetColor;
+    if (targetDirection   != null) this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
+    if (targetBrightness  != null) this.targetBrightness = targetBrightness;
+    if (targetXOffset     != null) this.targetXOffset    = targetXOffset;
+    if (targetYOffset     != null) this.targetYOffset    = targetYOffset;
+    if (targetRadius      != null) this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
+    if (targetBeamLength  != null) this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
+    if (targetBeamWidth   != null) this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
   }
 
   /**
-   * Processes and sets current conditional light properties from a string array.
+   * Processes and sets target transition and pause duration properties from a string array.
    * @param {String[]} properties
    **/
-  parseCondLightProps(properties) {
-    properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.direction  = orNaN(Math.PI / 180 * +(e.slice(1)));
-      else if (e.startsWithIC('b'))  this.brightness = orNaN(+e.slice(1));
-      else if (e.startsWithIC('x'))  this.xOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('y'))  this.yOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('r'))  this.radius     = orNaN(+e.slice(1));
-      else if (e.startsWithIC('l'))  this.beamLength = orNaN(+e.slice(1));
-      else if (e.startsWithIC('w'))  this.beamWidth  = orNaN(+e.slice(1));
-    });
+  parseDurationProps(properties) {
+    this.transitionDuration = properties.find((e) => (e.startsWithIC('t')));
+    this.pauseDuration      = properties.find((e) => (e.startsWithIC('p')));
+    this.transitionDuration = this.transitionDuration ? +this.transitionDuration.slice(1) : 0;
+    this.pauseDuration      = this.pauseDuration      ? +this.pauseDuration.slice(1)      : 0;
   }
 
   /**
-   * Processes and sets target conditional light properties from a string array.
+   * Processes and sets current properties from a string array.
    * @param {String[]} properties
    **/
-  parseTargetCondLightProps(properties) {
-    let fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
-    let pauseDuration = properties.find((e) => (e.startsWithIC('p')));
-    fadeDuration      = fadeDuration ?  +fadeDuration.slice(1)  : 0;
-    pauseDuration     = pauseDuration ? +pauseDuration.slice(1) : 0;
+  parseCurrentProps(properties) {
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
-      else if (e.startsWithIC('a#')) this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
-      else if (e.startsWithIC('a'))  this.directionDelta  = NumberDelta.create(this.direction,  Math.PI / 180 * +(e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('b'))  this.brightnessDelta = NumberDelta.create(this.brightness, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('x'))  this.xOffsetDelta    = NumberDelta.create(this.xOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('y'))  this.yOffsetDelta    = NumberDelta.create(this.yOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('r'))  this.radiusDelta     = NumberDelta.create(this.radius,     orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('l'))  this.beamLengthDelta = NumberDelta.create(this.beamLength, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('w'))  this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  orNaN(+e.slice(1)), fadeDuration);
-    });
+      if      (                       e.startsWithIC('#'))  this.currentColor      = new VRGBA(e);
+      else if (                       e.startsWithIC('a#')) this.currentColor      = new VRGBA(e);
+      else if (this.isFlashlight() && e.startsWithIC('a'))  this.currentDirection  = M_PI_180 * orNaN(+e.slice(1), 0);
+      else if (this.isFlashlight() && e.startsWithIC('+a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
+      else if (this.isFlashlight() && e.startsWithIC('-a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
+      else if (                       e.startsWithIC('b'))  this.currentBrightness = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('x'))  this.currentXOffset    = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('y'))  this.currentYOffset    = orNaN(+e.slice(1));
+      else if (this.isOtherLight() && e.startsWithIC('r'))  this.currentRadius     = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('l'))  this.currentBeamLength = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('w'))  this.currentBeamWidth  = orNaN(+e.slice(1));
+    }, this);
+  }
+
+  /**
+   * Processes and sets target properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseTargetProps(properties) {
+    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
+
+    let normalizeClockwiseMovement = (target) => {
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
+      if (this.currentDirection > this.targetDirection) this.targetDirection += M_2PI; // clockwise normalize
+    };
+    let normalizeCounterClockwiseMovement = (target) => {
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
+      if (this.currentDirection < this.targetDirection) this.targetDirection -= M_2PI; // c-clockwise normalize
+    };
+    properties.forEach((e) => {
+      if      (                       e.startsWithIC('#'))  this.targetColor = new VRGBA(e);
+      else if (                       e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
+      else if (this.isFlashlight() && e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
+      else if (this.isFlashlight() && e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (this.isFlashlight() && e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (                       e.startsWithIC('b'))  this.targetBrightness = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('x'))  this.targetXOffset    = orNaN(+e.slice(1));
+      else if (                       e.startsWithIC('y'))  this.targetYOffset    = orNaN(+e.slice(1));
+      else if (this.isOtherLight() && e.startsWithIC('r'))  this.targetRadius     = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('l'))  this.targetBeamLength = orNaN(+e.slice(1));
+      else if (this.isFlashlight() && e.startsWithIC('w'))  this.targetBeamWidth  = orNaN(+e.slice(1));
+    }, this);
+  }
+
+  /**
+   * Create deltas from currents, targets, and transition duration.
+   **/
+  createDeltas() {
+    let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
+    let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
+    // assign deltas if current & targets exist
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.transitionDuration);
+    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.transitionDuration);
+    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.transitionDuration);
+    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.transitionDuration);
+    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.transitionDuration);
+    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.transitionDuration);
+    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.transitionDuration);
+    // assign new currents for existing deltas (to propagate currents for duration = 0)
+    if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
+    if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
+    if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.get();
+    if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .get();
+    if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .get();
+    if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .get();
+    if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.get();
+    if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .get();
   }
 
   /**
@@ -950,14 +1159,19 @@ class ConditionalLight {
    * @returns {this}
    */
   next() {
-    if (this.colorDelta      != null) this.color      = this.colorDelta     .next().get();
-    if (this.directionDelta  != null) this.direction  = this.directionDelta .next().get();
-    if (this.brightnessDelta != null) this.brightness = this.brightnessDelta.next().get();
-    if (this.xOffsetDelta    != null) this.xOffset    = this.xOffsetDelta   .next().get();
-    if (this.yOffsetDelta    != null) this.yOffset    = this.yOffsetDelta   .next().get();
-    if (this.radiusDelta     != null) this.radius     = this.radiusDelta    .next().get();
-    if (this.beamLengthDelta != null) this.beamLength = this.beamLengthDelta.next().get();
-    if (this.beamWidthDelta  != null) this.beamWidth  = this.beamWidthDelta .next().get();
+    if (this.finished()) return this;
+    if (this.transitionDuration > 0) { // only update if transition duration isn't 0 (finished)
+      if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
+      if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
+      if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
+      if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .next().get();
+      if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .next().get();
+      if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
+      if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
+      if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
+      this.transitionDuration--;
+    } else
+      this.pauseDuration--;
     return this;
   }
 
@@ -965,12 +1179,12 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() {
-    return this.colorDelta.finished();
-  }
+  finished() { return this.transitionDuration <= 0 && this.pauseDuration <= 0; }
 }
 
-/** Class representing individual number deltas for providing number changes over time at different speeds. **/
+/**
+ * Class representing individual number deltas for providing number changes over time at different speeds.
+ **/
 class NumberDelta {
   /**
    * Creates a number delta from the start number, target number, and duration.
@@ -981,8 +1195,9 @@ class NumberDelta {
    */
   constructor(start, target, duration) {
     if (arguments.length == 0) return;
-    [this.current, this.target, this.duration, this.lazyEquals, this.delta] =
-    [start,        target,      duration,      false,           (target - start) / duration];
+    let delta = target == start ? 0 : (target - start) / duration;
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta] = [start, target, duration, false, delta];
+    this.finished(); // check for duration = 0
   }
 
   /**
@@ -1003,17 +1218,17 @@ class NumberDelta {
    * @param {Number} duration
    * @returns {NumberDelta}
    */
-  static create(start, target, duration) { return new NumberDelta(start, target, duration, duration); }
+  static create(start, target, duration) { return new NumberDelta(start, target, duration); }
 
   /**
    * Computes the next delta number in between the current number and target number.
    * @returns {this}
    */
   next() {
-    if (this.equals()) return this; // lazy-short-circuit
+    if (this.finished()) return this; // lazy-short-circuit
+    if (this.current != this.target) this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
     this.duration -= 1;
-    this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
-    this.equals();
+    this.finished();
     return this;
   }
 
@@ -1027,7 +1242,7 @@ class NumberDelta {
    * Returns true if the current number is equal to the target number; otherwise false.
    * @returns {Boolean}
    */
-  equals() {
+  finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
     if ((this.lazyEquals = this.duration <= 0))
       return (this.current = this.target, true); // set cur to refer to target on match
@@ -1035,53 +1250,56 @@ class NumberDelta {
   }
 }
 
-/** Class representing a color delta for providing color changes over time at different speeds. **/
+/**
+ * Class representing a color delta for providing color changes over time at different speeds.
+ **/
 class ColorDelta {
   /**
-   * Create a color delta from the start color, target color, fade & on durations, and
+   * Create a color delta from the start color, target color, fade duration, and
    * whether to consider the remaining ticks or not for speed purposes.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
    * @param {Number} fadeDuration
-   * @param {Number} onDuration
    * @param {Number} useTicksRemaining
    * @returns {ColorDelta}
    */
-  constructor(start, target = start, fadeDuration = 0, onDuration = 0, useTicksRemaining = false) {
+  constructor(start, target = start, fadeDuration = 0, useTicksRemaining = false) {
     if (arguments.length == 0) return;
-    this.current     = start.clone();           // - deep copy
-    this.target      = target.clone();          // - deep copy
-    this.onDuration  = orNaN(onDuration, 0);    // - parse onDuration
-    this.lazyEquals  = false;                   // - true when current value == target value
-    fadeDuration     = orNaN(fadeDuration, 0);  // - use either the remaining time (of the hour) or total fade duration
-    fadeDuration    -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
-    this.delta       = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
-                                (this.target.r - this.current.r) / fadeDuration,
-                                (this.target.g - this.current.g) / fadeDuration,
-                                (this.target.b - this.current.b) / fadeDuration,
-                                (this.target.a - this.current.a) / fadeDuration);
+    this.current       = start.clone();           // - deep copy
+    this.target        = target.clone();          // - deep copy
+    this.fadeDuration  = orNaN(fadeDuration, 0);  // - use the remaining time (of the hour) or total fade duration
+    this.fadeDuration -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.lazyEqual     = false;                   // - true when current value == target value
+    this.delta         = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                  (this.target.r - this.current.r) / this.fadeDuration,
+                                  (this.target.g - this.current.g) / this.fadeDuration,
+                                  (this.target.b - this.current.b) / this.fadeDuration,
+                                  (this.target.a - this.current.a) / this.fadeDuration);
+    this.finished(); // check for duration = 0
   }
   /**
    * Creates a copy of the ColorDelta object.
    * @returns {ColorDelta}
    **/
   clone() {
-    let that = new ColorDelta();
-    [that.current,           that.target,         that.onDuration, that.lazyEquals, that.delta] =
-    [this.current.clone(),   this.target.clone(), this.onDuration, this.lazyEquals, this.delta.clone()];
+    let that = new  ColorDelta();
+    that.current      = this.current.clone();
+    that.target       = this.target.clone();
+    that.fadeDuration = this.fadeDuration;
+    that.lazyEquals   = this.lazyEquals;
+    that.delta        = this.delta.clone();
     return that;
   }
 
   /**
-   * Creates a light delta from the start color, target color, and fade & on durations.
+   * Creates a light delta from the start color, target color, and fade duration.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
    * @param {Number} fadeDuration
-   * @param {Number} onDuration
    * @returns {ColorDelta}
    */
-  static createLight(start, target, fadeDuration, onDuration) {
-    return new ColorDelta(start, target, fadeDuration, onDuration, false /* don't use remaining ticks */);
+  static create(start, target, fadeDuration) {
+    return new ColorDelta(start, target, fadeDuration, false /* don't use remaining ticks */);
   }
 
   /**
@@ -1090,7 +1308,9 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration, 0, false); }
+  static createTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration);
+  }
 
   /**
    * Creates a battle color delta from the current battle tint, target tint, and fade duration.
@@ -1098,7 +1318,9 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createBattleTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration, 0, false); }
+  static createBattleTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration);
+  }
 
   /**
    * Creates a time color delta from the current time and speed. useCurrentTint specifies whether to
@@ -1108,13 +1330,14 @@ class ColorDelta {
    * @returns {ColorDelta}
    */
   static createTimeTint(useCurrentTint = true) {
-    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
+    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed(); // fade duration
     if (useCurrentTint) { // delta should fade from current color to target
-      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, true);
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, true);
     } else {              // start color should be the color it would normally be at the given time
-      let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
-      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a ref speed to compute the start color
-      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, false);
+      let CL = Community.Lighting; // reference CL
+      let ticks    = fadeDuration == 0 ? CL.minutes() * 60 + CL.seconds() : CL.ticks();
+      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // dur = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration);
       delta.next(ticks); // get current color based off of ticks elapsed in hour
       return delta;
     }
@@ -1127,13 +1350,14 @@ class ColorDelta {
    * @returns {this}
    */
   next(scale = 1) {
-    if (this.equals()) return (this.onDuration = Math.max(this.onDuration - 1, 0), this); // subtract onDuration and lazy-short-circuit
-    this.current.v = this.delta.v;  // Compute next color step and clamp to target
-    this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
-    this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
-    this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
-    this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
-    if (this.equals()) this.onDuration = Math.max(this.onDuration - 1, 0); // check if done and if so subtract onDuration
+    if (this.finished()) return this; // lazy-short-circuit
+    let current = this.current, target = this.target, delta = this.delta; // reference
+    if(current.v != target.v) current.v = target.v;  // Compute next step & clamp to target, check to avoid recomputing
+    if(current.r != target.r) current.r = Math.minmax(delta.r > 0, current.r + scale * delta.r, target.r);
+    if(current.g != target.g) current.g = Math.minmax(delta.g > 0, current.g + scale * delta.g, target.g);
+    if(current.b != target.b) current.b = Math.minmax(delta.b > 0, current.b + scale * delta.b, target.b);
+    if(current.a != target.a) current.a = Math.minmax(delta.a > 0, current.a + scale * delta.a, target.a);
+    this.fadeDuration -= 1;
     return this;
   }
 
@@ -1144,101 +1368,17 @@ class ColorDelta {
   get() { return this.current.clone(); } // duplicate color so reference can't be messed with
 
   /**
-   * Returns true if the current color is equal to the target color; otherwise false.
+   * Returns true if the current color is equal to the target; otherwise false.
    * @returns {Boolean}
    */
-  equals() {
+  finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
-    if ((this.lazyEquals = this.current.equals(this.target)))
-      return (this.current = this.target, true); // set cur to refer to target on match
+    if ((this.lazyEquals = this.fadeDuration <= 0)) return (this.current = this.target, true);
     return false;
-  }
-
-  /**
-   * Returns true if the current color is equal to the target and on duration has been reached; otherwise false.
-   * @returns {Boolean}
-   */
-  finished() { return this.equals() && this.onDuration == 0; }
+   }
 }
 
 (function ($$) {
-  let isOn = (x) => x.toLowerCase() === "on";
-  let isOff = (x) => x.toLowerCase() === "off";
-  let isActivate = (x) => x.toLowerCase() === "activate";
-  let isDeactivate = (x) => x.toLowerCase() === "deactivate";
-
-  // Map community light directions to polar angles (360 degrees)
-  const CLDirectionMap = {
-    0: undefined,       // auto
-    1: 3 * Math.PI / 2, // up
-    2: 2 * Math.PI,     // right
-    3: Math.PI / 2,     // down
-    4: Math.PI          // left
-  };
-
-  // Map RM directions to polar angles (360 degrees)
-  const RMDirectionMap = {
-    1: 3 * Math.PI / 4, // down-left
-    2: Math.PI / 2,     // down
-    3: Math.PI / 4,     // down-right
-    4: Math.PI,         // left
-    6: 2 * Math.PI,     // right
-    7: 5 * Math.PI / 4, // up-left
-    8: 3 * Math.PI / 2, // up
-    9: 7 * Math.PI / 4  // up-right
-  };
-
-  const TileType = {
-    Terrain: 1, terrain: 1, 1: 1,
-    Region:  2, region:  2, 2: 2
-  };
-
-  const LightType = {
-    Light     : 1, light     : 1, 1: 1,
-    Fire      : 2, fire      : 2, 2: 2,
-    Flashlight: 3, flashlight: 3, 3: 3,
-    Glow      : 4, glow      : 4, 4: 4
-  };
-
-  const TileLightType = {
-    tilelight:   [TileType.Terrain,   LightType.Light],
-    tilefire:    [TileType.Terrain,   LightType.Fire],
-    tileglow:    [TileType.Terrain,   LightType.Glow],
-    regionlight: [TileType.Region, LightType.Light],
-    regionfire:  [TileType.Region, LightType.Fire],
-    regionglow:  [TileType.Region, LightType.Glow],
-  };
-
-  const TileBlockType = {
-    tileblock:   TileType.Terrain,
-    regionblock: TileType.Region
-  };
-
-  class TileLight {
-    constructor(tileType, lightType, id, onoff, color, radius, brightness) {
-      this.tileType   = TileType[tileType];
-      this.lightType  = LightType[lightType];
-      this.id         = +id || 0;
-      this.enabled    = isOn(onoff);
-      this.color      = new VRGBA(color);
-      this.radius     = +radius || 0;
-      this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) || $$.defaultBrightness || 0;
-    }
-  }
-
-  class TileBlock {
-    constructor(tileType, id, onoff, color, shape, xOffset, yOffset, blockWidth, blockHeight) {
-      this.tileType    = TileType[tileType];
-      this.id          = +id || 0;
-      this.enabled     = isOn(onoff);
-      this.color       = new VRGBA(color);
-      this.shape       = +shape || 0;
-      this.xOffset     = +xOffset || 0;
-      this.yOffset     = +yOffset || 0;
-      this.blockWidth  = +blockWidth || 0;
-      this.blockHeight = +blockHeight || 0;
-    }
-  }
 
   class Mask_Bitmaps {
     constructor(width, height) {
@@ -1256,22 +1396,22 @@ class ColorDelta {
   let light_tiles = [];
   let block_tiles = [];
 
-  let parameters = $$.parameters;
-  let lightMaskPadding = Number(parameters["Lightmask Padding"]) || 0;
-  let useSmootherLights = orBoolean(parameters['Use smoother lights'], false);
-  let light_event_required = orBoolean(parameters["Light event required"], false);
-  let triangular_flashlight = orBoolean(parameters["Triangular flashlight"], false);
-  let shift_lights_with_events = orBoolean(parameters['Shift lights with events'], false);
-  let player_radius = Number(parameters['Player radius']) || 0;
-  let reset_each_map = orBoolean(parameters['Reset Lights'], false);
-  let noteTagKey = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
-  let dayNightSaveSeconds = Number(parameters['Save DaynightSeconds']) || 0;
-  let dayNightSaveNight = Number(parameters["Save Night Switch"]) || 0;
-  let dayNightNoAutoshadow = orBoolean(parameters["No Autoshadow During Night"], false);
-  let hideAutoShadow = false;
-  let daynightCycleEnabled = orBoolean(parameters['Daynight Cycle'], true);
-  let daynightTintEnabled = false;
-  let dayNightList = (function (dayNight, nightHours) {
+  let parameters                = $$.parameters;
+  let lightMaskPadding          = +parameters["Lightmask Padding"] || 0;
+  let useSmootherLights         = orBoolean(parameters['Use smoother lights'], false);
+  let light_event_required      = orBoolean(parameters["Light event required"], false);
+  let triangular_flashlight     = orBoolean(parameters["Triangular flashlight"], false);
+  let shift_lights_with_events  = orBoolean(parameters['Shift lights with events'], false);
+  let player_radius             = +parameters['Player radius'] || 0;
+  let reset_each_map            = orBoolean(parameters['Reset Lights'], false);
+  let noteTagKey                = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
+  let dayNightSaveSeconds       = +parameters['Save DaynightSeconds'] || 0;
+  let dayNightSaveNight         = +parameters["Save Night Switch"] || 0;
+  let dayNightNoAutoshadow      = orBoolean(parameters["No Autoshadow During Night"], false);
+  let hideAutoShadow            = false;
+  let daynightCycleEnabled      = orBoolean(parameters['Daynight Cycle'], true);
+  let daynightTintEnabled       = false;
+  let dayNightList              = (function (dayNight, nightHours) {
     let result = [];
     try {
       dayNight = JSON.parse(dayNight);
@@ -1281,7 +1421,8 @@ class ColorDelta {
         result[i] = { "color": new VRGBA(dayNight[i]), "isNight": nightHours.contains(i) };
     }
     catch (e) {
-      console.log(`${Community.Lighting.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
+      let CL = Community.Lighting;
+      console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
       result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
     }
     return result;
@@ -1369,7 +1510,8 @@ class ColorDelta {
   $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
   $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
   $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
-  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
+  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() *
+                                $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
     if (showSeconds) result = result + ":" + $$.seconds().padZero(2);
@@ -1384,9 +1526,7 @@ class ColorDelta {
   * @returns {Boolean}
   */
   Game_Temp.prototype.testAndSet = function (index, value) {
-    if (this[index] && (this[index] == value ||
-       (this[index].equals && this[index].equals(value))))
-      return false;
+    if (this[index] && this[index] == value) return false;
     return (this[index] = value, true);
   };
 
@@ -1412,78 +1552,91 @@ class ColorDelta {
   Game_Event.prototype.initLightData = function () {
     this._lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
-    let CycleGroups = [];
-    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((CycleGroups.push(group.split(/\s+/)), '')));
+
+    // parse new cycle groups format within {} braces and extract from tag data for separate handling
+    // old cycle groups are parsed in tagData loop below and are converted to the new group format
+    let cycleGroups = [];
+    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((cycleGroups.push(group.split(/\s+/)), '')));
     tagData = tagData.split(/\s+/);
     this._clType = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._clType) {
-      let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
-      let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
-      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
-      let isUndef      = (x)       => x === undefined;
-      let hasCycle = false;
+      let isFL       = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
+      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
+      let isNul      = (e)       => e == null;
+      let isDayNight = (e)       => isEq(e, "night", "day");
+      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength = +(e.slice(1));
-        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth  = +(e.slice(1));
-        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      hasCycle           = true;
-        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor      = new VRGBA(e);
-        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff      = true;
-        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff      = false;
-        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch     = e;
-        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness = Number(+(e.slice(1)) / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = +(e.slice(1));
-        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = CLDirectionMap[+(e.slice(1))];
-        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection  = Math.PI / 180 * +(e.slice(1));
-        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset    = +(e.slice(1));
-        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset    = +(e.slice(1));
-        else if (           e.length > 0                   && isUndef(this._clId))         this._clId         = e;
+        let n = clip(e);
+        if      (!isFL() && !isNaN(+e)          && isNul(this._clRadius))     this._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamLength)) this._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l") && n  && isNul(this._clBeamLength)) this._clBeamLength = n;
+        else if (isFL()  && isPre(e, "w") && n  && isNul(this._clBeamWidth))  this._clBeamWidth  = n;
+        else if (           isEq(e, "cycle")    && isNul(this._clColor))      hasCycle           = true;
+        else if (           isPre(e, "#", "a#") && hasCycle)                  cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])   cycleGroups[cycleIndex].push('p' + e);
+        else if (           isPre(e, "#", "a#") && isNul(this._clColor))      this._clColor      = new VRGBA(e);
+        else if (           isOn(e)             && isNul(this._clOnOff))      this._clOnOff      = true;
+        else if (           isOff(e)            && isNul(this._clOnOff))      this._clOnOff      = false;
+        else if (           isDayNight(e)       && isNul(this._clSwitch))     this._clSwitch     = e;
+        else if (           isPre(e, "b") && n  && isNul(this._clBrightness)) this._clBrightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = n;
+        else if ( isFL() && !isNaN(+e)          && isNul(this._clDirection))  this._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = CLDirectionMap[n];
+        else if ( isFL() && isPre(e, "a") && n  && isNul(this._clDirection))  this._clDirection  = Math.PI / 180 * n;
+        else if (           isPre(e, "x") && n  && isNul(this._clXOffset))    this._clXOffset    = n;
+        else if (           isPre(e, "y") && n  && isNul(this._clYOffset))    this._clYOffset    = n;
+        else if (           e.length > 0        && isNul(this._clId))         this._clId         = e;
+        cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);
 
       // normalize parameters
-      this._clRadius     = this._clRadius || 0;
-      this._clColor      = orNullish(this._clColor, VRGBA.empty());
-      this._clBrightness = this._clBrightness || 0;
-      this._clDirection  = orNaN(this._clDirection, undefined); // must be undefined for later checks
-      this._clId         = this._clId || 0;
-      this._clBeamLength = this._clBeamLength || 0;
-      this._clBeamWidth  = this._clBeamWidth || 0;
-      this._clOnOff      = orBoolean(this._clOnOff, true);
-      this._clXOffset    = this._clXOffset || 0;
-      this._clYOffset    = this._clYOffset || 0;
-      this._clCycle      = this._clCycle || null;
+      this._clRadius        = orNaN(this._clRadius, 0);
+      this._clColor         = orNullish(this._clColor, VRGBA.empty());
+      this._clBrightness    = orNaN(this._clBrightness, 0);
+      this._clDirection     = orNaN(this._clDirection, undefined); // must be undefined for later checks
+      this._clId            = orNullish(this._clId, 0); // Alphanumeric
+      this._clBeamLength    = orNaN(this._clBeamLength, 0);
+      this._clBeamWidth     = orNaN(this._clBeamWidth, 0);
+      this._clOnOff         = orBoolean(this._clOnOff, true);
+      this._clXOffset       = orNaN(this._clXOffset, 0);
+      this._clYOffset       = orNaN(this._clYOffset, 0);
+      this._clCycle         = this._clCycle || null;
 
       // Process cycle parameters
-      if (hasCycle && CycleGroups.length) {             // check if tag included color cycling
-        this._clCycle = [];                             // only define if cycle exists
-        let t = this;                                   // refer to this as t
-        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight = new ConditionalLight(...args);  // create conditional light
-        CycleGroups.forEach((e, i, a) => {              // ------ loop each group
-          condLight = condLight.clone();                // - clone existing conditional light (inherit properties)
-          let n = a[++i < CycleGroups.length ? i : 0];  // - get next element
-          condLight.parseCondLightProps(e);             // - parse for new properties
-          condLight.parseTargetCondLightProps(n);       // - parse for target properties
-          this._clCycle.push(condLight);                // - push to list
-        }, this);                                       // ------
-        condLight = this._clCycle.shift();              // pop front
-        this._clCondLight = condLight.clone();          // clone it to be the current cond light delta
-        this._clCycle.push(condLight);                  // push original on back of list
+      if (cycleGroups.length) {                                       // check if tag included color cycling
+        this._clCycle = [];                                           // only define if cycle exists
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
+        let condLight = new ConditionalLight(this._clType, ...args);  // create cond light with initial properties
+        cycleGroups.forEach((e, i, a) => {                            // ------ loop each group
+          condLight = condLight.clone();                              // - clone existing light (inherit properties)
+          let n = a[++i < cycleGroups.length ? i : 0];                // - get next element
+          condLight.parseDurationProps(n);                            // - parse durations
+          condLight.parseCurrentProps(e);                             // - parse for new properties
+          if (i == cycleGroups.length)                                // - last group targets initial properties
+            condLight.setTargets(...args);                            // -- setup targets based off non-cycle properties
+          condLight.parseTargetProps(n);                              // - parse for cycle target properties
+          condLight.createDeltas();                                   // - compute deltas
+          this._clCycle.push(condLight);                              // - push to list
+        }, this);                                                     // ------
+        condLight = this._clCycle.shift();                            // pop front
+        this._clCondLight = condLight.clone();                        // clone it to be the current cond light delta
+        this._clCycle.push(condLight);                                // push original on back of list
       }
 
       // Process conditional lighting
-      if (this._clId) {                                 // check for a conditional lighting ID
-        let t = this;                                   // refer to this as t
-        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight  = new ConditionalLight(...args); // create conditional light
-        condLight.setupTargets(0, 0, ...args);          // create matching targets
-        condLight.next();                               // compute deltas (zeroes)
+      if (this._clId) {                                               // check for a conditional lighting ID
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
+        let condLight  = new ConditionalLight(this._clType, ...args); // create conditional light
+        condLight.setTargets(...args);                                // create matching targets
+        condLight.createDeltas();                                     // compute deltas (zeroes)
         $gameVariables.GetLightArray()[this._clId] = condLight;
-        t._clCondLight = condLight;
+        this._clCondLight = condLight;
       }
     }
   };
@@ -1505,20 +1658,20 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.radius, this._clRadius);
+    return orNullish(this._clCondLight.currentRadius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
     if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.color, this._clColor.clone());
+    return orNullish(this._clCondLight.currentColor, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.brightness, this._clBrightness);
+    return orNullish(this._clCondLight.currentBrightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.direction, this._clDirection);
+    return orNullish(this._clCondLight.currentDirection, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1526,24 +1679,25 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamLength, this._clBeamLength);
+    return orNullish(this._clCondLight.currentBeamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamWidth, this._clBeamWidth);
+    return orNullish(this._clCondLight.currentBeamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.xOffset, this._clXOffset);
+    return orNullish(this._clCondLight.currentXOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.yOffset, this._clYOffset);
+    return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
-    if (!this._clSwitch) return this._clOnOff;
-    return (this._clSwitch.equalsIC("night") &&  $$.isNight()) ||
-           (this._clSwitch.equalsIC("day")   && !$$.isNight());
+    if (!this._clSwitch) return orNullish(this._clCondLight.enabled, this._clOnOff);
+    return orNullish(this._clCondLight.enabled,
+                    (this._clSwitch.equalsIC("night") && $$.isNight()) ||
+                    (this._clSwitch.equalsIC("day")   && !$$.isNight()));
   };
   Game_Event.prototype.getLightCycle = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1581,8 +1735,9 @@ class ColorDelta {
     command = command.toLowerCase();
 
     const allCommands = {
-      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight', tilefire: 'addTileLight', regionfire: 'addTileLight',
-      tileglow: 'addTileLight', regionglow: 'addTileLight', tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
+      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight',
+      tilefire: 'addTileLight', regionfire: 'addTileLight', tileglow: 'addTileLight', regionglow: 'addTileLight',
+      tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
       script: 'scriptF', reload: 'reload', tintbattle: 'tintbattle'
     };
     const result = allCommands[command];
@@ -1590,36 +1745,36 @@ class ColorDelta {
   };
 
   if (isRMMZ()) { // RMMZ only command interface
-    let mapOnOff = (args) => args.enabled === "true" ? "on" : "off";
-    let tileType = (args) => (args.tileType === "terrain" ? "tile" : "region") + (args.lightType ? args.lightType : "block");
-    let tintType = (    ) => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  (args) => args.instant === "true" ? "instant" : "";
-    let tintMode = (args) => args.color ? "set" : "reset";
-    let mathMode = (args) => args.mode === "set" ? "hour" : args.mode; // set, add, or subtract.
-    let showMode = (args) => args.enabled.equalsIC("true") ? (args.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
-    let radMode  = (args) => +args.fadeSpeed ? "radiusgrow" : "radius";
+    let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
+    let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
+    let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
+    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let tintMode = a  => a.color ? "set" : "reset";
+    let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
+    let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
+    let radMode  = a  => +a.fadeSpeed ? "radiusgrow" : "radius";
 
-    let reg = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
-    let f = (cmd, args) => $gameMap._interpreter.communityLighting_Commands(cmd, args.filter(_ => _ !== "")); //command wrapper.
+    let r = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
+    let f = (c, a) => $gameMap._interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
 
-    reg("masterSwitch",       (a)  => f("script",     [mapOnOff(a)]));
-    reg("tileBlock",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.shape,          a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
-    reg("tileLight",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.radius,         a.brightness]));
-    reg("setTint",            (a)  => f(tintType(),   [tintMode(a),     a.color,         a.fadeSpeed]));
-    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a),     dayMode(a)]));
-    reg("setTimeSpeed",       (a)  => f("dayNight",   ["speed",         a.speed]));
-    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes,      dayMode(a)]));
-    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours,         dayMode(a)]));
-    reg("showTime",           (a)  => f("dayNight",   [showMode(a)]));
-    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color,         dayMode(a)]));
-    reg("flashlight",         (a)  => f("flashLight", [mapOnOff(a),     a.beamLength,    a.beamWidth,    a.color,          a.density]));
-    reg("setFire",            (a)  => f("setFire",    [a.radiusShift,   a.redYellowShift]));
-    reg("playerLightRadius",  (a)  => f("light",      [radMode(a),      a.radius,        a.color,        "B"+a.brightness, a.fadeSpeed]));
-    reg("activateById",       (a)  => f("light",      [mapOnOff(a),     a.id]));
-    reg("lightColor",         (a)  => f("light",      ["color",         a.id,            a.color]));
-    reg("resetLightSwitches", ( )  => f("light",      ["switch",        "reset"]));
-    reg("resetTint",          (a)  => f(tintType(),   ["reset",         a.fadeSpeed]));
-    reg("condLight",          (a)  => f("light",      ["cond",          a.id,            a.properties]));
+    r("masterSwitch",       a  => f("script",     [mapOnOff(a)]));
+    r("tileBlock",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape,  a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
+    r("tileLight",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]));
+    r("setTint",            a  => f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]));
+    r("daynightEnable",     a  => f("daynight",   [mapOnOff(a), dayMode(a)]));
+    r("setTimeSpeed",       a  => f("dayNight",   ["speed", a.speed]));
+    r("setTime",            a  => f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]));
+    r("setHoursInDay",      a  => f("dayNight",   ["hoursinday", a.hours, dayMode(a)]));
+    r("showTime",           a  => f("dayNight",   [showMode(a)]));
+    r("setHourColor",       a  => f("dayNight",   ["color", a.hour, a.color, dayMode(a)]));
+    r("flashlight",         a  => f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]));
+    r("setFire",            a  => f("setFire",    [a.radiusShift, a.redYellowShift]));
+    r("playerLightRadius",  a  => f("light",      [radMode(a), a.radius, a.color, "B"+a.brightness, a.fadeSpeed]));
+    r("activateById",       a  => f("light",      [mapOnOff(a), a.id]));
+    r("lightColor",         a  => f("light",      ["color", a.id, a.color]));
+    r("resetLightSwitches", () => f("light",      ["switch", "reset"]));
+    r("resetTint",          a  => f(tintType(),   ["reset", a.fadeSpeed]));
+    r("condLight",          a  => f("light",      ["cond", a.id, a.properties]));
   }
 
   /**
@@ -1632,7 +1787,8 @@ class ColorDelta {
     let [tileType, lightType] = TileLightType[command] || [undefined, undefined];
     let [id, enabled, color, radius, brightness] = args;
     let tile = new TileLight(tileType, lightType, id, enabled, color, radius, brightness);
-    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType && e.id === tile.id);
+    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType &&
+                                    e.id === tile.id);
     void (index === -1 ? tilearray.push(tile) : tilearray[index] = tile);
     $gameVariables.SetTileLightArray(tilearray);
     $$.ReloadTagArea();
@@ -1764,7 +1920,9 @@ class ColorDelta {
   Lightmask.prototype.update = function () { this._updateMask(); };
 
   //@method _createBitmaps
-  Lightmask.prototype._createBitmaps = function () { this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY); };
+  Lightmask.prototype._createBitmaps = function () {
+    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
+  };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
   Game_Map.prototype.setupEvents = function () {
@@ -1826,7 +1984,7 @@ class ColorDelta {
     let lightgrow_target = $gameVariables.GetRadiusTarget();
     let lightgrow_speed = (player_radius < lightgrow_target ? 1 : -1) * $gameVariables.GetRadiusSpeed();
     if (lightgrow_speed != 0 && player_radius != lightgrow_target) {
-      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
+      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // clamp
       $gameVariables.SetRadius(player_radius);
     }
 
@@ -1868,22 +2026,23 @@ class ColorDelta {
     let iplayer_radius = Math.floor(player_radius);
 
     if (playerflashlight == true) {
-      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength, flashlightwidth);
+      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength,
+                                                 flashlightwidth);
     }
     if (iplayer_radius > 0) {
       x1 = x1 - flashlightXoffset;
       y1 = y1 - flashlightYoffset;
       if (iplayer_radius < 100) {
         // dim the light a bit at lower lightradius for a less focused effect.
-        let c = playercolor;
-        c.r = Math.max(0, c.r - 50);
-        c.g = Math.max(0, c.g - 50);
-        c.b = Math.max(0, c.b - 50);
-        let newcolor = c;
+        playercolor.r = Math.max(0, playercolor.r - 50);
+        playercolor.g = Math.max(0, playercolor.g - 50);
+        playercolor.b = Math.max(0, playercolor.b - 50);
 
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
+                                                 playerbrightness);
       } else {
-        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
+                                                 playerflicker, playerbrightness);
       }
 
     }
@@ -1917,8 +2076,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distanceApart > lightsOnRadius) {
+        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distpart > lightsOnRadius) {
           continue;
         }
       }
@@ -1967,7 +2126,8 @@ class ColorDelta {
             if (!isNaN(direction)) ldir = direction;
             this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker, brightness, direction);
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+                                                     brightness, direction);
           }
         }
       }
@@ -1991,16 +2151,15 @@ class ColorDelta {
       let y1 = (ph / 2) + (y - dy) * ph;
 
       let objectflicker = tile.lightType.is(LightType.Fire);
-      let tile_color = tile.color;
+      let tile_color = tile.color.clone();
       if (tile.lightType.is(LightType.Glow)) {
-        let c = tile.color.clone();
-        c.r = Math.floor(c.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.g = Math.floor(c.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.b = Math.floor(c.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        tile_color = c;
+        tile_color.r = Math.floor(tile_color.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.g = Math.floor(tile_color.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker, tile.brightness);
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+                                               tile.brightness);
     });
 
     // Tile blocks
@@ -2145,14 +2304,14 @@ class ColorDelta {
     //ctxMul.save(); // unnecessary significant performance hit
     ctxMul.fillStyle = hex;
     ctxMul.beginPath();
-    ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
+    ctxMul.ellipse(centerX, centerY, xradius, yradius, 0, 0, M_2PI);
     ctxMul.fill();
     if (isRMMV()) this.multiply._setDirty(); // doesn't exist in RMMZ
     if (c.v) {
       let ctxAdd = this.additive._context; // Additive lighting context
       ctxAdd.fillStyle = hex;
       ctxAdd.beginPath();
-      ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, 2 * Math.PI);
+      ctxAdd.ellipse(centerX, centerY, xradius, yradius, 0, 0, M_2PI);
       ctxAdd.fill();
       if (isRMMV()) this.additive._setDirty(); // doesn't exist in RMMZ
     }
@@ -2302,8 +2461,8 @@ class ColorDelta {
       let distance = 3 * (flashlength * (flashlength - 1));
 
       // Compute spotlight radiuses
-      r1 = (flashlength - 1) * flashlightdensity;
-      r2 = (flashlength - 1) * flashwidth;
+      r1 = Math.max((flashlength - 1) * flashlightdensity, 0);
+      r2 = Math.max((flashlength - 1) * flashwidth, 0);
 
       // Compute beam left start coordinates
       let xLeftBeamStart = x1 - (r2 / 7) * Math.sin(dirAngle);
@@ -2354,7 +2513,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2365,7 +2525,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2377,7 +2538,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2388,7 +2550,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2407,7 +2570,7 @@ class ColorDelta {
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
       } else {
-        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are always guarded
+        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are conditional
         ctxAdd.shadowBlur = 0;
         ctxAdd.fillStyle = grad;
         ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2); // single call as to not blur things so much.
@@ -2524,7 +2687,7 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
     // Prevent the battle scene from being too dark
-    let c = $gameTemp._BattleTintTarget.next().get(); // reference
+    let c = $gameTemp._BattleTintTarget.next().get(); // get next color
     if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66) {
       c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
       $gameTemp._BattleTintTarget.current = c; // reassign if out of bounds. Shouldn't be possible.
@@ -2796,13 +2959,18 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for default (i.e. no passed color)
+      if (condLight) { condLight.currentColor = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.parseTargetCondLightProps(args[2].split(/\s+/)); }
+      if (condLight) {
+        let properties = args[2].split(/\s+/);
+        condLight.parseDurationProps(properties);
+        condLight.parseTargetProps(properties);
+        condLight.createDeltas();
+      }
     }
 
     // **************************** RESET ALL SWITCHES ***********************
@@ -2837,7 +3005,7 @@ class ColorDelta {
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));
       else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0)); // battle initial color
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0));
       }
     }
   };
@@ -2854,8 +3022,8 @@ class ColorDelta {
       seconds = orNaN(seconds, 0);
       seconds += hours * 60 * 60 + minutes * 60;
       let totalSeconds = hoursInDay * 60 * 60;
-      while (seconds >= totalSeconds) seconds -= totalSeconds;
-      while (seconds < 0) seconds += totalSeconds;
+      seconds %= totalSeconds; // clamp to within total seconds
+      if (seconds < 0) seconds += totalSeconds;
       gV.SetDaynightSeconds(seconds);
       gV.SetDaynightHoursinDay(hoursInDay);
       setTimeColorDelta();
@@ -2869,7 +3037,7 @@ class ColorDelta {
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
         let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed()); // whether to change tint instantly
+        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }
@@ -2879,13 +3047,13 @@ class ColorDelta {
     let [gV, a]                    = [$gameVariables, args];
     let [secondsTotal, hoursInDay] = [gV.GetDaynightSeconds(), gV.GetDaynightHoursinDay()];
     let [hours, minutes, seconds]  = [$$.hours(), $$.minutes(), $$.seconds()];
-    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint changes
-    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disabled daynight tint changes
-    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // daynight speed
-    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to current time
-    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // subtract from current time
-    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the current time
-    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day (must be >0, err = 24)
+    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint
+    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disable daynight tint
+    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // set daynight speed
+    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to cur time
+    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // sub from cur time
+    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the cur time
+    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day
     else if (isCmd('show'))        void showTime(true, false);                                          // show clock
     else if (isCmd('showseconds')) void showTime(true, true);                                           // show clock seconds
     else if (isCmd('hide'))        void showTime(false, false);                                         // hide clock

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -458,7 +458,7 @@ Imported[Community.Lighting.name] = true;
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
 * | beam width  |     w     |           wN            |   w, w12, w13, w14   | flashlight beam width                  |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | * Omitting N or RBG value will reset the given property back to its initial state                                 |
+* | * Omitting N or RBG value will transition the given property back to its initial state                                 |
 * ---------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
@@ -1130,13 +1130,13 @@ class LightDelta {
     let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
     let normalizeClockwiseMovement = () => {
       this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
-      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
-      if (this.current.direction > this.target.direction) this.target.direction += M_2PI; // clockwise normalize
+      target.direction  = normalizeAngle(target.direction);  // convert target to radians before normalization
+      if (this.current.direction > target.direction) target.direction += M_2PI; // clockwise normalize
     };
     let normalizeCounterClockwiseMovement = () => {
       this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
-      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
-      if (this.current.direction < this.target.direction) this.target.direction -= M_2PI; // c-clockwise normalize
+      target.direction  = normalizeAngle(target.direction);  // convert target to radians before normalization
+      if (this.current.direction < target.direction) target.direction -= M_2PI; // c-clockwise normalize
     };
     let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
     let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
@@ -1144,37 +1144,50 @@ class LightDelta {
     // set delta creation at current frame time
     this.current.updateFrame = Graphics.frameCount;
 
+    // Duplicate target so that any target normalization is local to this LightDelta instance
+    let target = this.target.clone();
+
     // Set current durations or 0 if not fading
-    this.current.transitionDuration = fade ? this.target.transitionDuration : 0;
-    this.current.pauseDuration      = fade ? this.target.pauseDuration : 0;
+    this.current.transitionDuration = fade ? target.transitionDuration : 0;
+    this.current.pauseDuration      = fade ? target.pauseDuration : 0;
 
     // Enable or disable the current immediately based off of target value
-    this.current.enable = this.target.enable != null ? this.target.enable : this.defaults.enable;
+    this.current.enable = target.enable != null ? target.enable : this.defaults.enable;
 
     // For currents (flashlights) check the movement direction and normalize the current and target
-    if      (this.current.direction != null && this.target.clockwise)  normalizeClockwiseMovement();
-    else if (this.current.direction != null && !this.target.clockwise) normalizeCounterClockwiseMovement();
+    if      (this.current.direction != null && target.clockwise)  normalizeClockwiseMovement();
+    else if (this.current.direction != null && !target.clockwise) normalizeCounterClockwiseMovement();
+
+    // Set any null targets to default (normalization for nulls) (allows defaults to gradually transition)
+    if(target.color == null)      target.color      = this.defaults.color;
+    if(target.direction == null)  target.direction  = this.defaults.direction;
+    if(target.brightness == null) target.brightness = this.defaults.brightness;
+    if(target.xOffset == null)    target.xOffset    = this.defaults.xOffset;
+    if(target.yOffset == null)    target.yOffset    = this.defaults.yOffset;
+    if(target.radius == null)     target.radius     = this.defaults.radius;
+    if(target.beamLength == null) target.beamLength = this.defaults.beamLength;
+    if(target.beamWidth == null)  target.beamWidth  = this.defaults.beamWidth;
 
     // assign deltas if current & targets exist
-    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
-    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
-    this.delta.direction  = createNumber(this.current.direction,  this.target.direction,  this.current.transitionDuration);
-    this.delta.brightness = createNumber(this.current.brightness, this.target.brightness, this.current.transitionDuration);
-    this.delta.xOffset    = createNumber(this.current.xOffset,    this.target.xOffset,    this.current.transitionDuration);
-    this.delta.yOffset    = createNumber(this.current.yOffset,    this.target.yOffset,    this.current.transitionDuration);
-    this.delta.radius     = createNumber(this.current.radius,     this.target.radius,     this.current.transitionDuration);
-    this.delta.beamLength = createNumber(this.current.beamLength, this.target.beamLength, this.current.transitionDuration);
-    this.delta.beamWidth  = createNumber(this.current.beamWidth,  this.target.beamWidth,  this.current.transitionDuration);
+    this.delta.color      = createColor (this.current.color,      target.color,      this.current.transitionDuration);
+    this.delta.color      = createColor (this.current.color,      target.color,      this.current.transitionDuration);
+    this.delta.direction  = createNumber(this.current.direction,  target.direction,  this.current.transitionDuration);
+    this.delta.brightness = createNumber(this.current.brightness, target.brightness, this.current.transitionDuration);
+    this.delta.xOffset    = createNumber(this.current.xOffset,    target.xOffset,    this.current.transitionDuration);
+    this.delta.yOffset    = createNumber(this.current.yOffset,    target.yOffset,    this.current.transitionDuration);
+    this.delta.radius     = createNumber(this.current.radius,     target.radius,     this.current.transitionDuration);
+    this.delta.beamLength = createNumber(this.current.beamLength, target.beamLength, this.current.transitionDuration);
+    this.delta.beamWidth  = createNumber(this.current.beamWidth,  target.beamWidth,  this.current.transitionDuration);
 
-    // assign new currents for existing deltas to propagate currents for duration = 0 or target.<value> = null
-    this.current.color      = this.delta.color      != null  ? this.delta.color     .get() : this.defaults.color;
-    this.current.direction  = this.delta.direction  != null  ? this.delta.direction .get() : this.defaults.direction;
-    this.current.brightness = this.delta.brightness != null  ? this.delta.brightness.get() : this.defaults.brightness;
-    this.current.xOffset    = this.delta.xOffset    != null  ? this.delta.xOffset   .get() : this.defaults.xOffset;
-    this.current.yOffset    = this.delta.yOffset    != null  ? this.delta.yOffset   .get() : this.defaults.yOffset;
-    this.current.radius     = this.delta.radius     != null  ? this.delta.radius    .get() : this.defaults.radius;
-    this.current.beamLength = this.delta.beamLength != null  ? this.delta.beamLength.get() : this.defaults.beamLength;
-    this.current.beamWidth  = this.delta.beamWidth  != null  ? this.delta.beamWidth .get() : this.defaults.beamWidth;
+    // assign new currents for existing deltas to propagate currents for duration = 0
+    if(this.delta.color != null)      this.current.color      = this.delta.color     .get();
+    if(this.delta.direction != null)  this.current.direction  = this.delta.direction .get();
+    if(this.delta.brightness != null) this.current.brightness = this.delta.brightness.get();
+    if(this.delta.xOffset != null)    this.current.xOffset    = this.delta.xOffset   .get();
+    if(this.delta.yOffset != null)    this.current.yOffset    = this.delta.yOffset   .get();
+    if(this.delta.radius != null)     this.current.radius     = this.delta.radius    .get();
+    if(this.delta.beamLength != null) this.current.beamLength = this.delta.beamLength.get();
+    if(this.delta.beamWidth != null)  this.current.beamWidth  = this.delta.beamWidth .get();
   }
 
   /**

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -882,12 +882,22 @@ class VRGBA {
   }
 
   /**
-   * Creates an empty VRGBA object will all properties initialized to false and 0.
+   * Creates an VRGBA object will r,g,b,a = 0 and v = false.
    * @returns {VRGBA}
    */
-  static empty() {
+  static minRGBA() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
+    return that;
+  }
+
+  /**
+   * Creates an VRGBA object will r,g,b,a = 255 and v = false.
+   * @returns {VRGBA}
+   */
+  static maxRGBA() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [false, 255, 255, 255, 255];
     return that;
   }
 
@@ -1440,7 +1450,7 @@ class ColorDelta {
     catch (e) {
       let CL = Community.Lighting;
       console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
-      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
+      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.minRGBA(), "isNight": false }));
     }
     return result;
   })(parameters["DayNight Colors"], parameters["Night Hours"]);
@@ -1592,7 +1602,7 @@ class ColorDelta {
 
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
-      this._cl.color         = orNullish(this._cl.color, VRGBA.empty());
+      this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
       this._cl.enable        = orBoolean(this._cl.enable, true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
@@ -3098,8 +3108,8 @@ Game_Variables.prototype.SetTintAtHour = function (hour, color) {
 Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   let hours = Community.Lighting.hours() + inc; // increment from current hour
   let hoursinDay = this.GetDaynightHoursinDay();
-  while (hours >= hoursinDay) hours -= hoursinDay;
-  while (hours < 0) hours += hoursinDay;
+  hours %= hoursinDay; // clamp to within total hours in day
+  if (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
   return result ? result.color.clone() : VRGBA.minRGBA();
 };

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -436,7 +436,8 @@ Imported[Community.Lighting.name] = true;
 * See the Plugin Commands section for more details.
 *
 * Ranges can be used if random values are desired. Cycle tags are statically generated at map
-* load. If dynamically random property values are desired, use the 'light cond' command instead.
+* load. If dynamic random property values are desired, use the 'light cond' command instead in
+* combination with the 'light wait' command.
 * See the table below for property specific formatting.
 *
 * The following table shows supported properties:

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -435,36 +435,43 @@ Imported[Community.Lighting.name] = true;
 * The 'light cond' command allows for conditional lights to be dynamically changed on demand.
 * See the Plugin Commands section for more details.
 *
-* The following chart shows all supported properties:
+* Ranges can be used if random values are desired. Cycle tags are statically generated at map
+* load. If dynamically random property values are desired, use the 'light cond' command instead.
+* See the table below for property specific formatting.
+*
+* The following table shows supported properties:
 * ---------------------------------------------------------------------------------------------------------------------
-* | Property    |  Prefix   |         Format*         |       Examples       |              Description               |
+* | Property    |  Prefix   |         Format*†        |       Examples       |              Description               |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   pause     |     p     |           pN            |     p0, p1, p20      | time period in cycles to pause after   |
-* |  duration   |           |                         |                      | transitioning for cycling lights       |
+* |   pause     |     p     |         p<N|N:N>        |     p0, p1, p20,     | time period in cycles to pause after   |
+* |  duration   |           |                         |    p0:20, p1:20      | transitioning for cycling lights       |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | transition  |     t     |           tN            |     t0, t1, t30      | time period to transition the          |
-* |  duration   |           |                         |                      | specified properties over              |
+* | transition  |     t     |         t<N|N:N>        |     t0, t1, t30      | time period to transition the          |
+* |  duration   |           |                         |    t0:30, t1:30      | specified properties over              |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   color     |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | #, a#FFEEDD, #ffeedd | color or additive color                |
+* |   color     |   #, #a   |   <#|#a><hex|hex:hex>   | #, #FFEEDD, #ffeedd, | color or additive color                |
+* |             |           |                         |  a#000000:a#ffffff   |                                        |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |  enable     |     e     |         e<1|0>          |        e1, e0        | turns light on or off instantly        |
+* |  enable     |     e     |        e<1|0|0:1>       |     e1, e0, e0:1     | turns light on or off instantly        |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   angle     | a, +a, -a |       <a|+a|-a>N        |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
-* |             |           |                         |                      | clockwise, '-' moves counterclockwise  |
+* |   angle     | a, +a, -a |     <a|+a|-a><N|N:N>    |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |             |           |                         |    +a0:30, -a0:30    | clockwise, '-' moves counterclockwise  |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | brightness  |     b     |           bN            |    b, b0, b1, b5     | brightness                             |
+* | brightness  |     b     |         b<N|N:N>        | b, b0, b1, b5, b1:5  | brightness                             |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |  x offset   |     x     |           xN            |      x, x2, x-2      | x offset                               |
+* |  x offset   |     x     |         x<N|N:N>        |  x, x2, x-2, x-2:2   | x offset                               |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |  y offset   |     y     |           yN            |      y, y2, y-2      | y offset                               |
+* |  y offset   |     y     |         y<N|N:N>        |  y, y2, y-2, y-2:2   | y offset                               |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* |   radius    |     r     |           rN            |     r, r50, r150     | light radius                           |
+* |   radius    |     r     |         r<N|N:N>        | r, r50, r150, r50:75 | light radius                           |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | beam length |     l     |           lN            |    l, l8, l9, l10    | flashlight beam length                 |
+* | beam length |     l     |         l<N|N:N>        | l, l8, l9, l10, l7:9 | flashlight beam length                 |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | beam width  |     w     |           wN            |   w, w12, w13, w14   | flashlight beam width                  |
+* | beam width  |     w     |         w<N|N:N>        |   w, w8, w14, w7:9   | flashlight beam width                  |
 * |-------------|-----------|-------------------------|----------------------|----------------------------------------|
-* | * Omitting N or RBG value will transition the given property back to its initial state                                 |
+* | * Omitting N or hex value will transition the given property back to its initial state                            |
+* |-------------------------------------------------------------------------------------------------------------------|
+* | † using the N:N or hex:hex format allows for a randomly generated value within the given range (inclusive)        |
 * ---------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
@@ -1036,34 +1043,54 @@ class LightProperties {
       // clear checks (back to initial value for the given property)
       if      (        e.equalsIC('t'))        this.transitionDuration = 0;
       else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
-      else if (        e.equalsIC('#'))        this.color      = void(0);
-      else if (        e.equalsIC('a#'))       this.color      = void(0);
-      else if (        e.equalsIC('e'))        this.enable     = void(0);
-      else if (        e.equalsIC('b'))        this.brightness = void(0);
-      else if (        e.equalsIC('x'))        this.xOffset    = void(0);
-      else if (        e.equalsIC('y'))        this.yOffset    = void(0);
-      else if (isOL && e.equalsIC('r'))        this.radius     = void(0);
-      else if (isFL && e.equalsIC('l'))        this.beamLength = void(0);
-      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void(0);
-      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void(0);
-      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void(0);
-      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void(0);
-      // on or off checks
+      else if (        e.equalsIC('#'))        this.color      = void (0);
+      else if (        e.equalsIC('a#'))       this.color      = void (0);
+      else if (        e.equalsIC('e'))        this.enable     = void (0);
+      else if (        e.equalsIC('b'))        this.brightness = void (0);
+      else if (        e.equalsIC('x'))        this.xOffset    = void (0);
+      else if (        e.equalsIC('y'))        this.yOffset    = void (0);
+      else if (isOL && e.equalsIC('r'))        this.radius     = void (0);
+      else if (isFL && e.equalsIC('l'))        this.beamLength = void (0);
+      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void (0);
+      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void (0);
+      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void (0);
+      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void (0);
+
+      // parse suffix (individual & random ranges)
+      let suffix, rand = (min, max) => Math.random() * (max - min) + min;
+      if (!e.contains(':') && !e.contains('#')) {                               // single number
+        suffix = orNaN(+e.slice(1), +e.slice(2), 0);                            // - get number
+      } else if (!e.contains(':') && e.contains('#')) {                         // single color
+        suffix = new VRGBA(e);                                                  // - get color
+      } else if (!e.contains('#')) {                                            // number range
+        let eSplit = e.split(':');                                              // - explode range
+        let min = orNaN(+eSplit[0].slice(1), +eSplit[0].slice(2), 0);           // - get suffix (prefix size 1 or 2)
+        let max = orNaN(+eSplit[1], 0);                                         // - get suffix (no prefix)
+        suffix = e[0] != 'e' ? rand(min, max) : Math.floor(rand(min, max + 1)); // - for 'e' we need int ranges
+      } else {                                                                  // color range
+        let eSplit = e.split(':');                                              // - explode range
+        let min = new VRGBA(eSplit[0]);                                         // - get the whole hex value
+        let max = new VRGBA(eSplit[1]);                                         // - get the whole hex value
+        suffix = new VRGBA(Boolean(Math.floor(rand(min.v, max.v + 1))), Math.floor(rand(min.r, max.r + 1)),
+                                   Math.floor(rand(min.g, max.g + 1)),  Math.floor(rand(min.b, max.b + 1)),
+                                   Math.floor(rand(min.a, max.a + 1)));
+      }
+
       // prefix checks
-      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); }
-      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); }
-      else if (        e.startsWithIC('#'))    this.color      = new VRGBA(e);
-      else if (        e.startsWithIC('a#'))   this.color      = new VRGBA(e);
-      else if (        e.startsWithIC('e'))    this.enable     = Boolean(orNaN(+e.slice(1), 0));
-      else if (        e.startsWithIC('b'))    this.brightness = orNaN(+e.slice(1), 0);
-      else if (        e.startsWithIC('x'))    this.xOffset    = orNaN(+e.slice(1), 0);
-      else if (        e.startsWithIC('y'))    this.yOffset    = orNaN(+e.slice(1), 0);
-      else if (isOL && e.startsWithIC('r'))    this.radius     = orNaN(+e.slice(1), 0);
-      else if (isFL && e.startsWithIC('l'))    this.beamLength = orNaN(+e.slice(1), 0);
-      else if (isFL && e.startsWithIC('w'))    this.beamWidth  = orNaN(+e.slice(1), 0);
-      else if (isFL && e.startsWithIC('a'))  { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(1), 0); }
-      else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
-      else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
+      if (             e.startsWithIC('t'))    this.transitionDuration = suffix;
+      else if (        e.startsWithIC('p'))    this.pauseDuration      = suffix;
+      else if (        e.startsWithIC('#'))    this.color      = suffix;
+      else if (        e.startsWithIC('a#'))   this.color      = suffix;
+      else if (        e.startsWithIC('e'))    this.enable     = Boolean(suffix);
+      else if (        e.startsWithIC('b'))    this.brightness = suffix;
+      else if (        e.startsWithIC('x'))    this.xOffset    = suffix;
+      else if (        e.startsWithIC('y'))    this.yOffset    = suffix;
+      else if (isOL && e.startsWithIC('r'))    this.radius     = suffix;
+      else if (isFL && e.startsWithIC('l'))    this.beamLength = suffix;
+      else if (isFL && e.startsWithIC('w'))    this.beamWidth  = suffix;
+      else if (isFL && e.startsWithIC('a'))  { this.clockwise  = true;  this.direction = M_PI_180 * suffix; }
+      else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * suffix; }
+      else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * suffix; }
     }, this);
   }
 
@@ -1607,7 +1634,6 @@ class ColorDelta {
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
         let n = clipNum(e);
-        console.log()
         if      (!isFL() && isPreNum(e, 'r', n) && isNul(this._cl.radius))     this._cl.radius     = n;
         else if (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -1637,7 +1637,6 @@ class ColorDelta {
           lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
         let targetProps = lightArray[this._cl.id];                          // get target prop reference
         this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
-        console.log(this._cl.delta);
       }
       // Non-conditional light
       else {
@@ -2928,8 +2927,7 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      console.log(args[2]);
-      if (targetProps) targetProps.parseProps([args[2] != null ? args[2] : "#"]);
+      if (targetProps) targetProps.parseProps([(args[2] != null && !args[2].equalsIC("defaultcolor")) ? args[2] : "#"]);
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -562,6 +562,10 @@ Imported[Community.Lighting.name] = true;
 * - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
 * - ignored. See the Conditional Light section for more detail on each property.
 *
+* Light wait id
+* - wait for the conditional light to finish both transitioning and pausing before continuing
+* - the event script.
+*
 * Light color id c
 * - Change the color (c) of lightsource with id (id)
 * - Work even if the associated light is currently off.
@@ -1247,7 +1251,7 @@ class LightDelta {
   }
 
   /**
-   * Returns whether all deltas are finished or not.
+   * Returns whether the light has finished transitioning and pausing.
    * @returns {Boolean}
    */
   finished() { return this.current.transitionDuration <= 0 && this.current.pauseDuration <= 0; }
@@ -1767,6 +1771,7 @@ class ColorDelta {
    * @param {String[]} args
    */
   Game_Interpreter.prototype.communityLighting_Commands = function (command, args) {
+    $$.interpreter = this; //assign 'local' interpreter (for parallel processes)
     command = command.toLowerCase();
 
     const allCommands = {
@@ -1790,26 +1795,27 @@ class ColorDelta {
     let radMode  = a  => +a.fadeSpeed ? "radiusgrow" : "radius";
 
     let r = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
-    let f = (c, a) => $gameMap._interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
+    let f = (c, a) => $$.interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
 
-    r("masterSwitch",       a  => f("script",     [mapOnOff(a)]));
-    r("tileBlock",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape,  a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
-    r("tileLight",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]));
-    r("setTint",            a  => f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]));
-    r("daynightEnable",     a  => f("daynight",   [mapOnOff(a), dayMode(a)]));
-    r("setTimeSpeed",       a  => f("dayNight",   ["speed", a.speed]));
-    r("setTime",            a  => f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]));
-    r("setHoursInDay",      a  => f("dayNight",   ["hoursinday", a.hours, dayMode(a)]));
-    r("showTime",           a  => f("dayNight",   [showMode(a)]));
-    r("setHourColor",       a  => f("dayNight",   ["color", a.hour, a.color, dayMode(a)]));
-    r("flashlight",         a  => f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]));
-    r("setFire",            a  => f("setFire",    [a.radiusShift, a.redYellowShift]));
-    r("playerLightRadius",  a  => f("light",      [radMode(a), a.radius, a.color, "B"+a.brightness, a.fadeSpeed]));
-    r("activateById",       a  => f("light",      [mapOnOff(a), a.id]));
-    r("lightColor",         a  => f("light",      ["color", a.id, a.color]));
-    r("resetLightSwitches", () => f("light",      ["switch", "reset"]));
-    r("resetTint",          a  => f(tintType(),   ["reset", a.fadeSpeed]));
-    r("condLight",          a  => f("light",      ["cond", a.id, a.properties]));
+    r("masterSwitch",       function (a) { $$.interpreter = this; f("script",     [mapOnOff(a)]); });
+    r("tileBlock",          function (a) { $$.interpreter = this; f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape, a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]); });
+    r("tileLight",          function (a) { $$.interpreter = this; f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]); });
+    r("setTint",            function (a) { $$.interpreter = this; f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]); });
+    r("daynightEnable",     function (a) { $$.interpreter = this; f("daynight",   [mapOnOff(a), dayMode(a)]); });
+    r("setTimeSpeed",       function (a) { $$.interpreter = this; f("dayNight",   ["speed", a.speed]); });
+    r("setTime",            function (a) { $$.interpreter = this; f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]); });
+    r("setHoursInDay",      function (a) { $$.interpreter = this; f("dayNight",   ["hoursinday", a.hours, dayMode(a)]); });
+    r("showTime",           function (a) { $$.interpreter = this; f("dayNight",   [showMode(a)]); });
+    r("setHourColor",       function (a) { $$.interpreter = this; f("dayNight",   ["color", a.hour, a.color, dayMode(a)]); });
+    r("flashlight",         function (a) { $$.interpreter = this; f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]); });
+    r("setFire",            function (a) { $$.interpreter = this; f("setFire",    [a.radiusShift, a.redYellowShift]); });
+    r("playerLightRadius",  function (a) { $$.interpreter = this; f("light",      [radMode(a), a.radius, a.color, "B" + a.brightness, a.fadeSpeed]); });
+    r("activateById",       function (a) { $$.interpreter = this; f("light",      [mapOnOff(a), a.id]); });
+    r("lightColor",         function (a) { $$.interpreter = this; f("light",      ["color", a.id, a.color]); });
+    r("resetLightSwitches", function ()  { $$.interpreter = this; f("light",      ["switch", "reset"]); });
+    r("resetTint",          function (a) { $$.interpreter = this; f(tintType(),   ["reset", a.fadeSpeed]); });
+    r("condLight",          function (a) { $$.interpreter = this; f("light",      ["cond", a.id].concat(a.properties.split(/\s+/))); });
+    r("condLightWait",      function (a) { $$.interpreter = this; f("light",      ["wait", a.id]); });
   }
 
   /**
@@ -3002,7 +3008,26 @@ class ColorDelta {
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
       let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (targetProps) targetProps.parseProps(args[2] != null ? args[2].split(/\s+/) : ['']);
+      if (targetProps) targetProps.parseProps(args[2] != null ? args.slice(2) : ['']);
+    }
+
+    // *********************** WAIT on CONDITIONAL LIGHT *********************
+    else if (args[0].equalsIC('wait')) { // wait for conditional light to finish processing
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) {
+        if (targetProps.updateFrame == Graphics.frameCount) {
+          // light was scheduled to transition this frame and the deltas haven't been updated to use targets duration
+          $$.interpreter.wait(targetProps.transitionDuration + targetProps.pauseDuration);
+        } else { // light was scheduled to transition in a prior frame so lookup how much time is left
+          for (let i = 0, len = eventObjId.length; i < len; i++) {
+            let cur = events[eventObjId[i]];
+            if (cur._cl.delta.target == targetProps) {
+              $$.interpreter.wait(cur._cl.delta.current.transitionDuration + cur._cl.delta.current.pauseDuration);
+              break;
+            }
+          }
+        }
+      }
     }
 
     // **************************** RESET ALL SWITCHES ***********************

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -2624,13 +2624,10 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // if we came from a map, script is active, configuration authorizes using lighting effects,
-    // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
+    // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
             $gameVariables.GetTint() : new VRGBA("#ffffff");
-
-    // Set initial tint for battle
-    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -1461,9 +1461,6 @@ class ColorDelta {
   let options_lighting_on = true;
   let maxX = (Number(parameters['Screensize X']) || 816) + 2 * lightMaskPadding;
   let maxY = Number(parameters['Screensize Y']) || 624;
-  let battleMaxX = maxX;
-  let battleMaxY = maxY;
-  if (isRMMZ()) battleMaxY += 24; // Plus 24 for RMMZ Spriteset_Battle.prototype.battleFieldOffsetY
   let event_reload_counter = 0;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = new VRGBA(useSmootherLights ? "#00000000" : "#000000");
@@ -1890,7 +1887,7 @@ class ColorDelta {
 
   //@method _createBitmaps
   Lightmask.prototype._createBitmaps = function () {
-    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
+    this._maskBitmaps = new Mask_Bitmaps(maxX, maxY);
   };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
@@ -1960,8 +1957,8 @@ class ColorDelta {
     // ****** PLAYER LIGHTGLOBE ********
     let ctxMul = this._maskBitmaps.multiply.context;
     let ctxAdd = this._maskBitmaps.additive.context;
-    this._maskBitmaps.multiply.fillRect(0, 0, maxX + lightMaskPadding, maxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, maxX + lightMaskPadding, maxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, maxX, maxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     ctxMul.globalCompositeOperation = 'lighter';
     ctxAdd.globalCompositeOperation = 'lighter';
@@ -2006,14 +2003,9 @@ class ColorDelta {
         playercolor.r = Math.max(0, playercolor.r - 50);
         playercolor.g = Math.max(0, playercolor.g - 50);
         playercolor.b = Math.max(0, playercolor.b - 50);
-
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
-                                                 playerbrightness);
-      } else {
-        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
-                                                 playerflicker, playerbrightness);
       }
-
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
+                                               playerbrightness);
     }
 
     // *********************************** DAY NIGHT CYCLE TIMER **************************
@@ -2169,7 +2161,7 @@ class ColorDelta {
     // Compute tint for next frame
     let tintValue = $gameVariables.GetTintTarget().next().get();
     $gameVariables.SetTint(tintValue);
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX + lightMaskPadding, maxY, tintValue);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX, maxY, tintValue); // offset to fill entire mask
 
     // reset drawmode to normal
     ctxMul.globalCompositeOperation = 'source-over';
@@ -2611,12 +2603,16 @@ class ColorDelta {
     this._sprites = [];
     this._createBitmaps();
 
-    //Initialize the bitmap
-    this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.multiply, PIXI.BLEND_MODES.MULTIPLY);
-    this._addSprite(-lightMaskPadding, 0, this._maskBitmaps.additive, PIXI.BLEND_MODES.ADD);
+    // Initialize the bitmap
+    // +24 on Y to inverse RMMZ Spriteset_Battle.prototype.battleFieldOffsetY() math
+    // Graphics width/height adjustments to inverse Spriteset_Battle.prototype.createBattleField() offsets
+    let spriteXOffset = -lightMaskPadding - (Graphics.width - Graphics.boxWidth) / 2;
+    let spriteYOffset = (isRMMZ() ? 24 : 0) - (Graphics.height - Graphics.boxHeight) / 2;
+    this._addSprite(spriteXOffset, spriteYOffset, this._maskBitmaps.multiply, PIXI.BLEND_MODES.MULTIPLY);
+    this._addSprite(spriteXOffset, spriteYOffset, this._maskBitmaps.additive, PIXI.BLEND_MODES.ADD);
 
-    this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, maxX, maxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // if we came from a map, script is active, configuration authorizes using lighting effects,
     // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
@@ -2641,19 +2637,19 @@ class ColorDelta {
 
     $gameTemp._BattleTintInitial = c;
     $gameTemp._BattleTintTarget = ColorDelta.createTint(c);
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX, maxY, c); // offset to fill entire mask
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };
 
   //@method _createBitmaps
   BattleLightmask.prototype._createBitmaps = function () {
-    this._maskBitmaps = new Mask_Bitmaps(battleMaxX + lightMaskPadding, battleMaxY);
+    this._maskBitmaps = new Mask_Bitmaps(maxX, maxY);
   };
 
   BattleLightmask.prototype.update = function () {
-    this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
-    this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
+    this._maskBitmaps.multiply.fillRect(0, 0, maxX, maxY, '#000000');
+    this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // Prevent the battle scene from being too dark
     let c = $gameTemp._BattleTintTarget.next().get(); // get next color
@@ -2663,7 +2659,7 @@ class ColorDelta {
     }
 
     // Compute tint for next frame
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX, maxY, c);
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -306,14 +306,17 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* Light radius [cycle] color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color + duration pairs to follow that will be
-*               cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 #0f0 15 #00f 15 ...etc>
-*               In Terrax Lighting, there was a hard limit of 4, but now you can use
-*               as many as you want. [optional]
+* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
+*               that will be cycled through before repeating from the beginning:
+*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
+*               fadeDuration and growRadius are optional argument used to transition between colors
+*               and radius sizes over the provided cycle interval. If growRadius is not provided
+*               the default radius is used for the given color. In Terrax Lighting, there was a hard
+*               limit of 4, but now you can use as many as you want. [optional]
 * - color       #ffffff, #ff0000, etc
 * - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
@@ -332,15 +335,21 @@ Imported[Community.Lighting.name] = true;
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight bl bw [cycle] color [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
 * - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
 * - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color + duration pairs to follow that will be
-*             cycled through before repeating from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15 on someId d3>
-*             There's no limit to how many colors can be cycled. [optional]
+* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
+*             grow_bw tuples to follow that will be cycled through before repeating
+*             from the beginning:
+*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
+*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
+*             transition between colors and beam lengths & widths over the provided
+*             cycle interval. If grow_bl or grow_bw are not provided, the default
+*             length or width is used for the given color. There's no limit to how
+*             many colors can be cycled. [optional]
 * - color     #ffffff, #ff0000, etc
 * - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day       Sets the event's light to only show during the day [optional]
@@ -363,10 +372,21 @@ Imported[Community.Lighting.name] = true;
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
+* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
+*
+* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
+* and transitions to the next color and size over 60 frames.
+*
 * <cl: fire 150 #ff8800 b15 night>
 * Creates a fire that only lights up at night.
 *
 * <cl: Flashlight l8 w12 #ff0000 on asdf>
+* Creates a flashlight beam with id asdf which can be turned on or off via
+* plugin commands.
+*
+* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
@@ -492,23 +512,31 @@ Imported[Community.Lighting.name] = true;
 * Flashlight off
 * - Turn off the flashlight.  yup.
 *
-* DayNight on|off
-* - Activates or deactivates the day/night cycle. Defaults to on.
+* DayNight on|off [instant]
+* - Activates or deactivates the day/night cycle. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Daynight speed n
 * - Changes the speed by which hours pass in game in relation to real life seconds
 *
-* Daynight hour h m
-* - Sets the in game time to hh:mm
+* Daynight hour h m [instant]
+* - Sets the in game time to hh:mm. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Daynight color h c
 * - Sets the hour (h) to use color (c)
 *
-* Daynight add h m
-* - Adds the specified hours (h) and minutes (m) to the in game clock
+* Daynight add h m [instant]
+* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
-* Daynight subtract h m
-* - Subtracts the specified hours (h) and minutes (m) from the in game clock
+* Daynight subtract h m [instant]
+* - Subtracts the specified hours (h) and minutes (m) from the in game clock. Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Daynight show
 * - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -519,8 +547,10 @@ Imported[Community.Lighting.name] = true;
 * Daynight hide
 * - Hides the current time of day mini-window
 *
-* Daynight hoursinday h
-* - Sets the number of hours in a day to [h] (set hour colors  if doing this)
+* Daynight hoursinday h [instant]
+* - Sets the number of hours in a day to [h] (set hour colors if doing this), Specifying 'instant' will set the
+*   tint for the current hour instantly, otherwise it will change gradually to that of
+*   the next hour
 *
 * Tint set c [s]
 * Tint fade c [s]
@@ -638,6 +668,8 @@ Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Ma
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
 
+let cmpFloat = (x, y) => Math.abs(x - y) < 1e-3; // custom epsilon
+
 function orBoolean(...a) {
   for (let i = 0; i < a.length; i++) {
     if (typeof a[i] === "boolean") return a[i];
@@ -652,58 +684,128 @@ function orNaN(...a)     { for (let i = 0; i < a.length; i++) if (!isNaN(a[i])) 
 
 const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive lighting
 
-class VRGBA { // Class to handle volumetric/additive coloring with rgba colors uniformly
+/**
+ * @param {Number} r
+ * @param {Number} g
+ * @param {Number} b
+ * @param {Number} a
+ * @returns {String}
+ */
+ function rgba(r, g, b, a) {
+  return "rgba(" + r + "," + g + "," + b + "," + a + ")";
+}
+
+/** Class to handle volumetric/additive coloring with rgba colors uniformly.
+ *  Additive coloring prefixes an 'a' on a normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
+ */
+class VRGBA {
+  /**
+   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a hex String
+   * can be passed with an optional default alternative Hex string, or another VRGBA object can be passed to create a clone.
+   * @param {String|Boolean|VRGBA} vOrHex     - Boolean representing the additive component, or
+   *                                            String representing the hex color, or
+   *                                            other VRGBA object to clone.
+   * @param {String|Number}        rOrDefault - Number representing the red component, or
+   *                                            String representing a default hex string in case the provided one cannot be parsed.
+   * @param {null|Number}          g          - Number representing the green component.
+   * @param {null|Number}          b          - Number representing the blue component.
+   * @param {null|Number}          a          - Number representing the alpha component.
+   * @returns {VRGBA}
+   */
   constructor(vOrHex, rOrDefault = "#000000ff", g = undefined, b = undefined, a = 0xff) {
-    if (vOrHex != null && vOrHex.constructor === VRGBA) { // passed another VRGBA instance
-      Object.assign(this, vOrHex);
-    } else if (typeof vOrHex === "boolean") { // Passed v, r, g, b, a
-      [this.v, this.r, this.g, this.b, this.a] = [vOrHex, +rOrDefault || 0, +g || 0, +b || 0, +a || 0xff];
-    } else if (vOrHex == null || typeof vOrHex === "string") { // passed a hex String or nullish
-      vOrHex = this.validateHex(vOrHex, rOrDefault);
-      this.v = vOrHex.startsWithIC("a#");
-      const shift = this.v ? 1 : 0; // shift for volumetric/additive prefix
-      this.r = parseInt(vOrHex.slice(1 + shift, 3 + shift), 16); // red
-      this.g = parseInt(vOrHex.slice(3 + shift, 5 + shift), 16); // green
-      this.b = parseInt(vOrHex.slice(5 + shift, 7 + shift), 16); // blue
-      this.a = parseInt(vOrHex.slice(7 + shift, 9 + shift), 16); // alpha
+    if (arguments.length == 0) return;                           // return if no arguments (allows construction).
+    else if (typeof vOrHex === "boolean")                        // Passed v, r, g, b, a
+      [this.v, this.r,           this.g,  this.b,  this.a] =     // - assign
+      [vOrHex, +rOrDefault || 0, +g || 0, +b || 0, +a || 0xff];  // -
+    else if (vOrHex == null || typeof vOrHex === "string") {     // passed a hex String or nullish
+      vOrHex = this.normalizeHex(vOrHex, rOrDefault);            //  - parse hex
+      this.v = vOrHex.startsWithIC("a#");                        //  - assign v
+      const shift = this.v ? 1 : 0;                              //  - shift for volumetric/additive prefix
+      this.r = parseInt(vOrHex.slice(1 + shift, 3 + shift), 16); //  - assign red
+      this.g = parseInt(vOrHex.slice(3 + shift, 5 + shift), 16); //  - assign green
+      this.b = parseInt(vOrHex.slice(5 + shift, 7 + shift), 16); //  - assign blue
+      this.a = parseInt(vOrHex.slice(7 + shift, 9 + shift), 16); //  - assign alpha
     } else {
       throw Error(`${Community.Lighting.name} - VRGBA constructor given incorrect parameters!`);
     }
   }
 
-  set(setters) { for (let k in setters) if (this[k] != null) this[k] = setters[k]; }
+  /**
+   * Creates a copy of the VRGBA object.
+   * @returns {VRGBA}
+   **/
+  clone() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [this.v, this.r, this.g, this.b, this.a];
+    return that;
+  }
 
+  /**
+   * Creates an empty VRGBA object will all properties initialized to false and 0.
+   * @returns {VRGBA}
+   **/
+  static empty() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
+    return that;
+  }
+
+  /**
+   * Sets the v, r, b, g, or a properties to that of the cooresponding properties in the that Object.
+   * @param {VRGBA} that
+   */
+  set(that) { for (let k in that) if (this[k] != null) this[k] = that[k]; }
+
+  /**
+   * Compares this Object to that Object and returns true if the v, r, g, b, and a properties are equal; otherwise false.
+   * @param {VRGBA} that
+   * @returns {Boolean}
+   */
   equals(that) { // fastest non-exactness comparison -- only checks v, r, g, b, a properties
-    if (that && this.v == that.v && this.r == that.r && this.g == that.g && this.b == that.b && this.a == that.a)
+    let [a, b] = [this, that];
+    if (b && cmpFloat(a.v, b.v) && cmpFloat(a.r, b.r) && cmpFloat(a.g, b.g) && cmpFloat(a.b, b.b) && cmpFloat(a.a, b.a))
       return true;
     return false;
   }
 
+  /**
+   * Adds together the r, g, and b properties and returns the result.
+   * @returns {Number}
+   */
   magnitude() { return this.r + this.g + this.b; }
 
-  validateHex(hex, alt) {
-    hex = this.normalizeHex(hex);
-    if (!hex) return this.validateHex(alt, "#000000ff");
-    else if (!isValidColorRegex.test(hex)) {
-      console.log(`${Community.Lighting.name} - Invalid Color: ` + hex);
-      return this.validateHex(alt, "#000000ff");
-    }
-    return hex;
-  }
-
-  normalizeHex(hex) {
-    if (typeof hex !== "string") return undefined;                 // short circuit
+  /**
+   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String. If invalid, a default
+   * value of "#000000ff" is returned. If either provided String is valid, it will be returned as an 'a#rrggbbaa' formatted color hex String.
+   * @param {String} hex
+   * @param {String} alt
+   * @returns {String}
+   */
+  normalizeHex(hex, altHex) {
+    if (typeof hex !== "string") return this.normalizeHex(altHex, "#000000ff");
     let h = hex.toLowerCase().trim();
-    const s = hex.startsWithIC("a#") ? 1 : 0;                        // shift
+    const s = hex.startsWithIC("a#") ? 1 : 0;                      // shift
     if (h.length == 4 + s) h += "f";                               // normalize #RGB format
     if (h.length == 5 + s) h = h.replace(/(^a?#)|(.)/g, "$1$2$2"); // normalize #RGBA
     if (h.length == 7 + s) h += "ff";                              // normalize #RRGGBB format
+    if (!isValidColorRegex.test(h)) {
+      console.log(`${Community.Lighting.name} - Invalid Color: ` + hex);
+      return this.normalizeHex(altHex, "#000000ff");
+    }
     return h;                                                      // return RRGGBBAA
   }
 
-  toHex(setWebSafe = false, setters = undefined) {
-    let temp = new VRGBA(this); // create temporary copy
-    for (let k in setters) if (temp[k]) temp[k] = setters[k]; // assign temporary setters
+  /**
+   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the hex is additive or not.
+   * The setWebSafe parameter is used to to strip the additive property (v) so that the resulting color can be used with Canvas APIs. An
+   * override Object can be provided to override the existing v, r, g, b, or a properties in the output.
+   * @param {Boolean} setWebSafe
+   * @param {VRGBA} override
+   * @returns {String}
+   */
+  toHex(setWebSafe = false, override = undefined) {
+    let temp = this.clone(); // create temporary copy
+    for (let k in override) if (temp[k]) temp[k] = override[k]; // assign temporary setters
     if (temp.r.inRange(0, 255) && temp.g.inRange(0, 255) && temp.b.inRange(0, 255) && temp.a.inRange(0, 255)) {
       let rHex = (temp.r < 16 ? "0" : "") + Math.floor(temp.r).toString(16); // clamp to whole numbers
       let gHex = (temp.g < 16 ? "0" : "") + Math.floor(temp.g).toString(16);
@@ -714,19 +816,349 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     return null; // The hex color code doesn't exist
   }
 
-  toWebHex(setters) { return this.toHex(true, setters); }
+  /**
+   * Converts the VRGBA Object into a websafe '#rrggbbaa' formatted color hex string where the v property is stripped.
+   * An override Object can be provided to override the existing r, g, b, or a properties in the output.
+   * @param {Boolean} setWebSafe
+   * @param {VRGBA} override
+   * @returns {String}
+   */
+  toWebHex(override) { return this.toHex(true, override); }
 }
 
 /**
- *
- * @param {Number} r
- * @param {Number} g
- * @param {Number} b
- * @param {Number} a
- * @returns {String}
- */
-  function rgba(r, g, b, a) {
-    return "rgba(" + r + "," + g + "," + b + "," + a + ")";
+ * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability to compute deltas
+ * between the current parameter values and the target values, and allows for current values to be extracted.
+ **/
+class ConditionalLight {
+  /**
+   * Creates a ConditionalLight object with the provided parameters
+   * @param {VRGBA}  color
+   * @param {Number} direction
+   * @param {Number} brightness
+   * @param {Number} xOffset
+   * @param {Number} yOffset
+   * @param {Number} radius
+   * @param {Number} beamLength
+   * @param {Number} beamWidth
+   **/
+  constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+    if (arguments.length == 0) return;
+    this.color      = color;
+    this.direction  = direction;
+    this.brightness = brightness;
+    this.xOffset    = xOffset;
+    this.yOffset    = yOffset;
+    this.radius     = radius;
+    this.beamLength = beamLength;
+    this.beamWidth  = beamWidth;
+  }
+
+  /**
+   * Creates a copy of the ConditionalLight object.
+   * @returns {ConditionalLight}
+   **/
+  clone() {
+    let that = new ConditionalLight();
+    // clone properties
+    if (this.color      != null) that.color      = this.color.clone();
+    if (this.direction  != null) that.direction  = this.direction;
+    if (this.brightness != null) that.brightness = this.brightness;
+    if (this.xOffset    != null) that.xOffset    = this.xOffset;
+    if (this.yOffset    != null) that.yOffset    = this.yOffset;
+    if (this.radius     != null) that.radius     = this.radius;
+    if (this.beamLength != null) that.beamLength = this.beamLength;
+    if (this.beamWidth  != null) that.beamWidth  = this.beamWidth;
+    // clone deltas
+    if (this.colorDelta      != null) that.colorDelta      = this.colorDelta     .clone();
+    if (this.directionDelta  != null) that.directionDelta  = this.directionDelta .clone();
+    if (this.brightnessDelta != null) that.brightnessDelta = this.brightnessDelta.clone();
+    if (this.xOffsetDelta    != null) that.xOffsetDelta    = this.xOffsetDelta   .clone();
+    if (this.yOffsetDelta    != null) that.yOffsetDelta    = this.yOffsetDelta   .clone();
+    if (this.radiusDelta     != null) that.radiusDelta     = this.radiusDelta    .clone();
+    if (this.beamLengthDelta != null) that.beamLengthDelta = this.beamLengthDelta.clone();
+    if (this.beamWidthDelta  != null) that.beamWidthDelta  = this.beamWidthDelta .clone();
+    return that;
+  }
+
+  /**
+   * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
+   * @param {Number} fadeDuration
+   * @param {Number} pauseDuration
+   * @param {VRGBA}  tColor
+   * @param {Number} tDirection
+   * @param {Number} tBrightness
+   * @param {Number} tXOffset
+   * @param {Number} tYOffset
+   * @param {Number} tRadius
+   * @param {Number} tBeamLength
+   * @param {Number} tBeamWidth
+   */
+  setupTargets(fadeDuration, pauseDuration, tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
+    if (this.color      != null) this.colorDelta      = ColorDelta.createLight(this.color,  tColor,      fadeDuration, pauseDuration);
+    if (this.direction  != null) this.directionDelta  = NumberDelta.create(this.direction,  tDirection,  fadeDuration);
+    if (this.brightness != null) this.brightnessDelta = NumberDelta.create(this.brightness, tBrightness, fadeDuration);
+    if (this.xOffset    != null) this.xOffsetDelta    = NumberDelta.create(this.xOffset,    tXOffset,    fadeDuration);
+    if (this.yOffset    != null) this.yOffsetDelta    = NumberDelta.create(this.yOffset,    tYOffset,    fadeDuration);
+    if (this.radius     != null) this.radiusDelta     = NumberDelta.create(this.radius,     tRadius,     fadeDuration);
+    if (this.beamLength != null) this.beamLengthDelta = NumberDelta.create(this.beamLength, tBeamLength, fadeDuration);
+    if (this.beamWidth  != null) this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  tBeamWidth,  fadeDuration);
+  }
+
+  /**
+   * Processes and sets current conditional light properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseCondLightProps(properties) {
+    properties.forEach((e) => {
+      if      (e.startsWithIC('#'))  this.color      = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.color      = new VRGBA(e);
+      else if (e.startsWithIC('a'))  this.direction  = orNaN(Math.PI / 180 * +(e.slice(1)));
+      else if (e.startsWithIC('b'))  this.brightness = orNaN(+e.slice(1));
+      else if (e.startsWithIC('x'))  this.xOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('y'))  this.yOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('r'))  this.radius     = orNaN(+e.slice(1));
+      else if (e.startsWithIC('l'))  this.beamLength = orNaN(+e.slice(1));
+      else if (e.startsWithIC('w'))  this.beamWidth  = orNaN(+e.slice(1));
+    });
+  }
+
+  /**
+   * Processes and sets target conditional light properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseTargetCondLightProps(properties) {
+    let fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
+    let pauseDuration = properties.find((e) => (e.startsWithIC('p')));
+    fadeDuration      = fadeDuration ?  +fadeDuration.slice(1)  : 0;
+    pauseDuration     = pauseDuration ? +pauseDuration.slice(1) : 0;
+    properties.forEach((e) => {
+      if      (e.startsWithIC('#'))  this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
+      else if (e.startsWithIC('a#')) this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration, pauseDuration);
+      else if (e.startsWithIC('a'))  this.directionDelta  = NumberDelta.create(this.direction,  Math.PI / 180 * +(e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('b'))  this.brightnessDelta = NumberDelta.create(this.brightness, orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('x'))  this.xOffsetDelta    = NumberDelta.create(this.xOffset,    orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('y'))  this.yOffsetDelta    = NumberDelta.create(this.yOffset,    orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('r'))  this.radiusDelta     = NumberDelta.create(this.radius,     orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('l'))  this.beamLengthDelta = NumberDelta.create(this.beamLength, orNaN(+e.slice(1)), fadeDuration);
+      else if (e.startsWithIC('w'))  this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  orNaN(+e.slice(1)), fadeDuration);
+    });
+  }
+
+  /**
+   * Computes the next deltas in between the current parameters and target parameters.
+   * @returns {this}
+   */
+  next() {
+    if (this.colorDelta      != null) this.color      = this.colorDelta     .next().get();
+    if (this.directionDelta  != null) this.direction  = this.directionDelta .next().get();
+    if (this.brightnessDelta != null) this.brightness = this.brightnessDelta.next().get();
+    if (this.xOffsetDelta    != null) this.xOffset    = this.xOffsetDelta   .next().get();
+    if (this.yOffsetDelta    != null) this.yOffset    = this.yOffsetDelta   .next().get();
+    if (this.radiusDelta     != null) this.radius     = this.radiusDelta    .next().get();
+    if (this.beamLengthDelta != null) this.beamLength = this.beamLengthDelta.next().get();
+    if (this.beamWidthDelta  != null) this.beamWidth  = this.beamWidthDelta .next().get();
+    return this;
+  }
+
+  /**
+   * Returns whether all deltas are finished or not.
+   * @returns {Boolean}
+   */
+  finished() {
+    return this.colorDelta.finished();
+  }
+}
+
+/** Class representing individual number deltas for providing number changes over time at different speeds. **/
+class NumberDelta {
+  /**
+   * Creates a number delta from the start number, target number, and duration.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} duration
+   * @returns {NumberDelta}
+   */
+  constructor(start, target, duration) {
+    if (arguments.length == 0) return;
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta] =
+    [start,        target,      duration,      false,           (target - start) / duration];
+  }
+
+  /**
+   * Creates a copy of the NumberDelta object.
+   * @returns {NumberDelta}
+   **/
+  clone() {
+    let that = new NumberDelta();
+    [that.current, that.target, that.duration, that.lazyEquals, that.delta] =
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta];
+    return that;
+  }
+
+  /**
+   * Creates a number delta from the start number, target number, and duration.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} duration
+   * @returns {NumberDelta}
+   */
+  static create(start, target, duration) { return new NumberDelta(start, target, duration, duration); }
+
+  /**
+   * Computes the next delta number in between the current number and target number.
+   * @returns {this}
+   */
+  next() {
+    if (this.equals()) return this; // lazy-short-circuit
+    this.duration -= 1;
+    this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
+    this.equals();
+    return this;
+  }
+
+  /**
+   * Returns the current delta number.
+   * @returns {Number}
+   **/
+  get() { return this.current; }
+
+  /**
+   * Returns true if the current number is equal to the target number; otherwise false.
+   * @returns {Boolean}
+   */
+  equals() {
+    if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
+    if ((this.lazyEquals = this.duration <= 0))
+      return (this.current = this.target, true); // set cur to refer to target on match
+    return false;
+  }
+}
+
+/** Class representing a color delta for providing color changes over time at different speeds. **/
+class ColorDelta {
+  /**
+   * Create a color delta from the start color, target color, fade & on durations, and
+   * whether to consider the remaining ticks or not for speed purposes.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} fadeDuration
+   * @param {Number} onDuration
+   * @param {Number} useTicksRemaining
+   * @returns {ColorDelta}
+   */
+  constructor(start, target = start, fadeDuration = 0, onDuration = 0, useTicksRemaining = false) {
+    if (arguments.length == 0) return;
+    this.current     = start.clone();           // - deep copy
+    this.target      = target.clone();          // - deep copy
+    this.onDuration  = orNaN(onDuration, 0);    // - parse onDuration
+    this.lazyEquals  = false;                   // - true when current value == target value
+    fadeDuration     = orNaN(fadeDuration, 0);  // - use either the remaining time (of the hour) or total fade duration
+    fadeDuration    -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.delta       = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                (this.target.r - this.current.r) / fadeDuration,
+                                (this.target.g - this.current.g) / fadeDuration,
+                                (this.target.b - this.current.b) / fadeDuration,
+                                (this.target.a - this.current.a) / fadeDuration);
+  }
+  /**
+   * Creates a copy of the ColorDelta object.
+   * @returns {ColorDelta}
+   **/
+  clone() {
+    let that = new ColorDelta();
+    [that.current,           that.target,         that.onDuration, that.lazyEquals, that.delta] =
+    [this.current.clone(),   this.target.clone(), this.onDuration, this.lazyEquals, this.delta.clone()];
+    return that;
+  }
+
+  /**
+   * Creates a light delta from the start color, target color, and fade & on durations.
+   * @param {VRGBA}  start
+   * @param {VRGBA}  target
+   * @param {Number} fadeDuration
+   * @param {Number} onDuration
+   * @returns {ColorDelta}
+   */
+  static createLight(start, target, fadeDuration, onDuration) {
+    return new ColorDelta(start, target, fadeDuration, onDuration, false /* don't use remaining ticks */);
+  }
+
+  /**
+   * Creates a map color delta from the current map tint, target tint, and fade duration.
+   * @param {VRGBA}  targetTint
+   * @param {Number} fadeDuration
+   * @returns {ColorDelta}
+   */
+  static createTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration, 0, false); }
+
+  /**
+   * Creates a battle color delta from the current battle tint, target tint, and fade duration.
+   * @param {VRGBA}  targetTint
+   * @param {Number} fadeDuration
+   * @returns {ColorDelta}
+   */
+  static createBattleTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration, 0, false); }
+
+  /**
+   * Creates a time color delta from the current time and speed. useCurrentTint specifies whether to
+   * fade from the current color to the target or to have the start color be the color it would
+   * normally be at the given time interval (difference between current hour and next).
+   * @param {Boolean} useCurrentTint
+   * @returns {ColorDelta}
+   */
+  static createTimeTint(useCurrentTint = true) {
+    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
+    if (useCurrentTint) { // delta should fade from current color to target
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, true);
+    } else {              // start color should be the color it would normally be at the given time
+      let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
+      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration, 0 /*on duration*/, false);
+      delta.next(ticks); // get current color based off of ticks elapsed in hour
+      return delta;
+    }
+  }
+
+  /**
+   * Computes the next delta color in between the current color and target color.
+   * Scale is used to scale the delta increment by a factor of the scale amount.
+   * @param {Number} scale
+   * @returns {this}
+   */
+  next(scale = 1) {
+    if (this.equals()) return (this.onDuration = Math.max(this.onDuration - 1, 0), this); // subtract onDuration and lazy-short-circuit
+    this.current.v = this.delta.v;  // Compute next color step and clamp to target
+    this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
+    this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
+    this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
+    this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
+    if (this.equals()) this.onDuration = Math.max(this.onDuration - 1, 0); // check if done and if so subtract onDuration
+    return this;
+  }
+
+  /**
+   * Returns the current delta color.
+   * @returns {Number}
+   **/
+  get() { return this.current.clone(); } // duplicate color so reference can't be messed with
+
+  /**
+   * Returns true if the current color is equal to the target color; otherwise false.
+   * @returns {Boolean}
+   */
+  equals() {
+    if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
+    if ((this.lazyEquals = this.current.equals(this.target)))
+      return (this.current = this.target, true); // set cur to refer to target on match
+    return false;
+  }
+
+  /**
+   * Returns true if the current color is equal to the target and on duration has been reached; otherwise false.
+   * @returns {Boolean}
+   */
+  finished() { return this.equals() && this.onDuration == 0; }
 }
 
 (function ($$) {
@@ -734,75 +1166,6 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
   let isOff = (x) => x.toLowerCase() === "off";
   let isActivate = (x) => x.toLowerCase() === "activate";
   let isDeactivate = (x) => x.toLowerCase() === "deactivate";
-
-  /**
-   * Gets the value at the  specified index of the $gameTemp object.
-   * @param {String} index
-   * @returns {any}
-   */
-  let get = (index) => $gameTemp[index];
-
-  /**
-   * Sets the value at the specified index of the $gameTemp object.
-   * @param {String} index
-   * @param {any}    value
-   */
-  let set = (index, value) => $gameTemp[index] = value;
-
-  /**
-   * Tests the value at the specified index of the $gameTemp object for equality with the
-   * passed in value and sets it. Returns true if the values match, or false otherwise.
-   * @param {String} index
-   * @param {any}    value
-   * @returns {Boolean}
-   */
-  let testAndSet = (index, value) => {
-    if ($gameTemp[index] && ($gameTemp[index] == value ||
-       ($gameTemp[index].equal && $gameTemp[index].equal(value))))
-        return false;
-    return ($gameTemp[index] = value, true);
-  };
-
-  /**
-   * Computes and returns the next tint color based off of the current tint, target tint, and speed.
-   * @param {VRGBA} current
-   * @param {VRGBA} target
-   * @param {Number} speed
-   * @returns {VRGBA}
-   */
-  class PIXI_Container_Extender extends PIXI.Container {
-    computeNextTint(current, target, speed) {
-      if (current.equals(target)) return target; // Already equal so short-circuit
-
-      // only compute new delta on target or speed change
-      let delta = get('_tintDelta');
-      if (!delta || testAndSet('_OldTintTarget', target) || testAndSet('_OldTintSpeed', speed)) {
-        // tint delta based off of remainder of time in hour if not battle, daynight cycle, & tint enabled OR 60
-        let useMinutesRemaining = !$gameParty.inBattle() && daynightCycleEnabled && daynightTintEnabled;
-        let minutes = 60 - (useMinutesRemaining ? $$.minutes() : 0);
-        // Get deltas for each color.
-        delta = new VRGBA(target.v, // divide by zero is +inf or -inf so deltas work for speed = 0
-          (target.r - current.r) / (minutes * speed),
-          (target.g - current.g) / (minutes * speed),
-          (target.b - current.b) / (minutes * speed),
-          (target.a - current.a) / (minutes * speed));
-
-        set('_tintDelta', delta); // set new tint.
-      }
-
-      // Compute next color step
-      let out = new VRGBA(delta.v, current.r + delta.r, current.g + delta.g, current.b + delta.b, current.a + delta.a);
-
-      // Clamp to target
-      if ((out.r > current.r && out.r > target.r) || (out.r < current.r && out.r < target.r)) out.r = target.r;
-      if ((out.g > current.g && out.g > target.g) || (out.g < current.g && out.g < target.g)) out.g = target.g;
-      if ((out.b > current.b && out.b > target.b) || (out.b < current.b && out.b < target.b)) out.b = target.b;
-      if ((out.a > current.a && out.a > target.a) || (out.a < current.a && out.a < target.a)) out.a = target.a;
-
-      return out;
-    }
-  }
-  PIXI.Container.prototype = PIXI_Container_Extender.prototype;
 
   // Map community light directions to polar angles (360 degrees)
   const CLDirectionMap = {
@@ -827,7 +1190,7 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
   const TileType = {
     Terrain: 1, terrain: 1, 1: 1,
-    Region: 2,  region:  2, 2: 2
+    Region:  2, region:  2, 2: 2
   };
 
   const LightType = {
@@ -902,8 +1265,6 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
   let player_radius = Number(parameters['Player radius']) || 0;
   let reset_each_map = orBoolean(parameters['Reset Lights'], false);
   let noteTagKey = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
-  let dayNightSaveHours = Number(parameters['Save DaynightHours']) || 0;
-  let dayNightSaveMinutes = Number(parameters['Save DaynightMinutes']) || 0;
   let dayNightSaveSeconds = Number(parameters['Save DaynightSeconds']) || 0;
   let dayNightSaveNight = Number(parameters["Save Night Switch"]) || 0;
   let dayNightNoAutoshadow = orBoolean(parameters["No Autoshadow During Night"], false);
@@ -921,7 +1282,7 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     }
     catch (e) {
       console.log(`${Community.Lighting.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
-      result = new Array(24).fill(undefined).map(() => ({ "color": new VRGBA(), "isNight": false }));
+      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
     }
     return result;
   })(parameters["DayNight Colors"], parameters["Night Hours"]);
@@ -989,14 +1350,12 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
   $$.getDayNightList = function () {
     return dayNightList;
   };
-  $$.saveTime = function (hh, mm, ss = null) {
-    let dayNightList = $gameVariables.GetDaynightColorArray();
-    if (dayNightSaveHours > 0) $gameVariables.setValue(dayNightSaveHours, hh);
-    if (dayNightSaveMinutes > 0) $gameVariables.setValue(dayNightSaveMinutes, mm);
-    if (dayNightSaveSeconds > 0 && ss !== null) $gameVariables.setValue(dayNightSaveSeconds, ss);
-    if (dayNightSaveNight > 0 && dayNightList[hh] instanceof Object) $gameSwitches.setValue(dayNightSaveNight, dayNightList[hh].isNight);
-    if (dayNightNoAutoshadow && dayNightList[hh] instanceof Object && dayNightList[hh].isNight !== hideAutoShadow) {
-      hideAutoShadow = dayNightList[hh].isNight; // We can not use $$.isNight because DaynightCycle hasn't been updated yet!
+  $$.saveTime = function () {
+    let index = $gameVariables.GetDaynightColorArray()[$$.hours()];
+    if (dayNightSaveSeconds > 0) $gameVariables.setValue(dayNightSaveSeconds, $gameVariables.GetDaynightSeconds());
+    if (dayNightSaveNight > 0 && index instanceof Object) $gameSwitches.setValue(dayNightSaveNight, index.isNight);
+    if (dayNightNoAutoshadow && index instanceof Object && index.isNight !== hideAutoShadow) {
+      hideAutoShadow = index.isNight; // We can not use $$.isNight because DaynightCycle hasn't been updated yet!
       // Update the shadow manually
       if (SceneManager._scene && SceneManager._scene._spriteset && SceneManager._scene._spriteset._tilemap) {
         SceneManager._scene._spriteset._tilemap.refresh();
@@ -1004,129 +1363,141 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     }
   };
   $$.isNight = function () {
-    let hour = $gameVariables.GetDaynightCycle();
+    let hour = $$.hours();
     return dayNightList[hour] instanceof Object ? dayNightList[hour].isNight : false;
   };
-  $$.hours = function () {
-    return $gameVariables.GetDaynightCycle();
-  };
-  $$.minutes = function () {
-    return Math.floor($gameVariables.GetDaynightTimer() / $gameVariables.GetDaynightSpeed());
-  };
-  $$.seconds = function () {
-    let speed = $gameVariables.GetDaynightSpeed();
-    let value = Math.floor($gameVariables.GetDaynightTimer() - speed * $$.minutes());
-    return Math.floor(value / speed * 60);
-  };
+  $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
+  $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
+  $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
+  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
     if (showSeconds) result = result + ":" + $$.seconds().padZero(2);
     return result;
   };
+
+  /**
+  * Tests the value at the specified index of the $gameTemp object for equality with the
+  * passed in value and sets it. Returns true if the values match, or false otherwise.
+  * @param {String} index
+  * @param {any}    value
+  * @returns {Boolean}
+  */
+  Game_Temp.prototype.testAndSet = function (index, value) {
+    if (this[index] && (this[index] == value ||
+       (this[index].equals && this[index].equals(value))))
+      return false;
+    return (this[index] = value, true);
+  };
+
   // Event note tag caching
   Game_Event.prototype.resetLightData = function () {
-    this._clType = undefined;
+    this._clType        = undefined;
     this._lastLightPage = undefined;
-    this._clRadius = undefined;
-    this._clColor = undefined;
-    this._clCycle = undefined;
-    this._clBrightness = undefined;
-    this._clSwitch = undefined;
-    this._clDirection = undefined;
-    this._clXOffset = undefined;
-    this._clYOffset = undefined;
-    this._clId = undefined;
-    this._clBeamColor = undefined;
-    this._clBeamLength = undefined;
-    this._clBeamWidth = undefined;
-    this._clFlashlightDirection = undefined;
-    this._clOnOff = undefined;
-    this._clCycleTimer = undefined;
-    this._clCycleIndex = undefined;
+    this._clRadius      = undefined;
+    this._clColor       = undefined;
+    this._clCycle       = undefined;
+    this._clBrightness  = undefined;
+    this._clSwitch      = undefined;
+    this._clDirection   = undefined;
+    this._clXOffset     = undefined;
+    this._clYOffset     = undefined;
+    this._clId          = undefined;
+    this._clBeamLength  = undefined;
+    this._clBeamWidth   = undefined;
+    this._clOnOff       = undefined;
+    this._clCondLight   = {};
     this.initLightData();
   };
   Game_Event.prototype.initLightData = function () {
     this._lastLightPage = this._pageIndex;
-    let tagData = this.getCLTag().toLowerCase().split(/\s+/);
-    let needsCycleDuration = false;
+    let tagData = this.getCLTag().toLowerCase();
+    let CycleGroups = [];
+    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((CycleGroups.push(group.split(/\s+/)), '')));
+    tagData = tagData.split(/\s+/);
     this._clType = LightType[tagData.shift()];
+    // Handle parsing of light, fire, and flashlight
+    if (this._clType) {
+      let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+      let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
+      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
+      let isUndef      = (x)       => x === undefined;
+      let hasCycle = false;
+      tagData.forEach((e) => {
+        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength = +(e.slice(1));
+        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth  = +(e.slice(1));
+        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      hasCycle           = true;
+        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor      = new VRGBA(e);
+        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff      = true;
+        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff      = false;
+        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch     = e;
+        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness = Number(+(e.slice(1)) / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = +(e.slice(1));
+        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = CLDirectionMap[+(e.slice(1))];
+        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection  = Math.PI / 180 * +(e.slice(1));
+        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset    = +(e.slice(1));
+        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset    = +(e.slice(1));
+        else if (           e.length > 0                   && isUndef(this._clId))         this._clId         = e;
+      }, this);
 
-    // Handle parsing of light and fire
-    if (this._clType && this._clType.is(LightType.Light, LightType.Fire)) {
-      this._clRadius = undefined;
-      for (let x of tagData) {
-        if (!isNaN(+x) && this._clRadius === undefined) this._clRadius = +x;
-        else if (x.equalsIC("cycle") && this._clColor === undefined) this._clCycle = [];
-        else if (this._clCycle && !needsCycleDuration && (x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#"))) {
-          this._clCycle.push({ "color": new VRGBA(x), "duration": 1 });
-          needsCycleDuration = true;
-        }
-        else if (this._clCycle && needsCycleDuration && !isNaN(+x)) {
-          this._clCycle[this._clCycle.length - 1].duration = +x || 1;
-          needsCycleDuration = false;
-        }
-        else if ((x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#")) &&
-                  this._clColor === undefined) this._clColor = new VRGBA(x);
-        else if (isOn(x) && this._clOnOff === undefined) this._clOnOff = true;
-        else if (isOff(x) && this._clOnOff === undefined) this._clOnOff = false;
-        else if (x.equalsIC("night", "day") && this._clSwitch === undefined) this._clSwitch = x;
-        else if (x[0].equalsIC("b") && this._clBrightness === undefined) {
-          this._clBrightness = Number(+(x.slice(1, x.length)) / 100).clamp(0, 1);
-        }
-        else if (x[0].equalsIC("d") && this._clDirection === undefined) this._clDirection = +(x.slice(1, x.length));
-        else if (x[0].equalsIC("x") && this._clXOffset === undefined) this._clXOffset = +(x.slice(1, x.length));
-        else if (x[0].equalsIC("y") && this._clYOffset === undefined) this._clYOffset = +(x.slice(1, x.length));
-        else if (x.length > 0 && this._clId === undefined) this._clId = x;
+      // normalize parameters
+      this._clRadius     = this._clRadius || 0;
+      this._clColor      = orNullish(this._clColor, VRGBA.empty());
+      this._clBrightness = this._clBrightness || 0;
+      this._clDirection  = orNaN(this._clDirection, undefined); // must be undefined for later checks
+      this._clId         = this._clId || 0;
+      this._clBeamLength = this._clBeamLength || 0;
+      this._clBeamWidth  = this._clBeamWidth || 0;
+      this._clOnOff      = orBoolean(this._clOnOff, true);
+      this._clXOffset    = this._clXOffset || 0;
+      this._clYOffset    = this._clYOffset || 0;
+      this._clCycle      = this._clCycle || null;
+
+      // Process cycle parameters
+      if (hasCycle && CycleGroups.length) {             // check if tag included color cycling
+        this._clCycle = [];                             // only define if cycle exists
+        let t = this;                                   // refer to this as t
+        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
+        let condLight = new ConditionalLight(...args);  // create conditional light
+        CycleGroups.forEach((e, i, a) => {              // ------ loop each group
+          condLight = condLight.clone();                // - clone existing conditional light (inherit properties)
+          let n = a[++i < CycleGroups.length ? i : 0];  // - get next element
+          condLight.parseCondLightProps(e);             // - parse for new properties
+          condLight.parseTargetCondLightProps(n);       // - parse for target properties
+          this._clCycle.push(condLight);                // - push to list
+        }, this);                                       // ------
+        condLight = this._clCycle.shift();              // pop front
+        this._clCondLight = condLight.clone();          // clone it to be the current cond light delta
+        this._clCycle.push(condLight);                  // push original on back of list
+      }
+
+      // Process conditional lighting
+      if (this._clId) {                                 // check for a conditional lighting ID
+        let t = this;                                   // refer to this as t
+        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
+        let condLight  = new ConditionalLight(...args); // create conditional light
+        condLight.setupTargets(0, 0, ...args);          // create matching targets
+        condLight.next();                               // compute deltas (zeroes)
+        $gameVariables.GetLightArray()[this._clId] = condLight;
+        t._clCondLight = condLight;
       }
     }
-    // Handle parsing of flashlight
-    else if (this._clType && this._clType.is(LightType.Flashlight)) {
-      this._clBeamLength = undefined;
-      this._clBeamWidth = undefined;
-      this._clOnOff = undefined;
-      this._clFlashlightDirection = undefined;
-      this._clRadius = 1;
-      for (let x of tagData) {
-        if (!isNaN(+x) && this._clBeamLength === undefined) this._clBeamLength = +x;
-        else if (!isNaN(+x) && this._clBeamWidth === undefined) this._clBeamWidth = +x;
-        else if (x[0].equalsIC("l") && this._clBeamLength === undefined) this._clBeamLength = this._clBeamLength = +(x.slice(1, x.length));
-        else if (x[0].equalsIC("w") && this._clBeamWidth === undefined) this._clBeamWidth = this._clBeamWidth = +(x.slice(1, x.length));
-        else if (x.equalsIC("cycle") && this._clColor === undefined) this._clCycle = [];
-        else if (this._clCycle && !needsCycleDuration && (x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#"))) {
-          this._clCycle.push({ "color": new VRGBA(x), "duration": 1 });
-          needsCycleDuration = true;
-        }
-        else if (this._clCycle && needsCycleDuration && !isNaN(+x)) {
-          this._clCycle[this._clCycle.length - 1].duration = +x || 1;
-          needsCycleDuration = false;
-        }
-        else if ((x[0].equalsIC("#") || x.slice(0, 2).equalsIC("a#")) &&
-                  this._clBeamColor === undefined) this._clColor = new VRGBA(x);
-        else if (isOn(x) && this._clOnOff === undefined) this._clOnOff = true;
-        else if (isOff(x) && this._clOnOff === undefined) this._clOnOff = false;
-        else if (x.equalsIC("night", "day") && this._clSwitch === undefined) this._clSwitch = x;
-        else if (!isNaN(+x) && this._clFlashlightDirection === undefined) this._clFlashlightDirection = +x;
-        else if (x[0].equalsIC("d") && this._clFlashlightDirection === undefined) this._clFlashlightDirection = CLDirectionMap[+(x.slice(1, x.length))];
-        else if (x[0].equalsIC("a") && this._clFlashlightDirection === undefined) this._clFlashlightDirection = Math.PI/180*+(x.slice(1, x.length));
-        else if (x[0].equalsIC("x") && this._clXOffset === undefined) this._clXOffset = +(x.slice(1, x.length));
-        else if (x[0].equalsIC("y") && this._clYOffset === undefined) this._clYOffset = +(x.slice(1, x.length));
-        else if (x.length > 0 && this._clId === undefined) this._clId = x;
-      }
+  };
+  Game_Event.prototype.cycleLightingNext = function () {
+    let cycleList = this.getLightCycle();
+    if (cycleList && this._clCondLight.finished()) {
+      let condLight = cycleList.shift();     // pop delta from front
+      this._clCondLight = condLight.clone(); // duplicate delta
+      cycleList.push(condLight);             // push delta on back
     }
-    this._clRadius = this._clRadius || 0;
-    this._clColor = new VRGBA(this._clColor);
-    this._clBrightness = this._clBrightness || 0;
-    this._clDirection = this._clDirection || 0;
-    this._clId = this._clId || 0;
-    this._clBeamWidth = this._clBeamWidth || 0;
-    this._clBeamLength = this._clBeamLength || 0;
-    this._clOnOff = orBoolean(this._clOnOff, true);
-    this._clFlashlightDirection = this._clFlashlightDirection || undefined; // Must be undefined.
-    this._clXOffset = this._clXOffset || 0;
-    this._clYOffset = this._clYOffset || 0;
-    this._clCycle = this._clCycle || null;
-    this._clCycleTimer = 0;
-    this._clCycleIndex = 0;
+  };
+  Game_Event.prototype.conditionalLightingNext = function () {
+    if (this._clType === undefined) this.initLightData();
+    if (this.getLightCycle() || this.getLightId()) this._clCondLight.next();
   };
   Game_Event.prototype.getLightType = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1134,19 +1505,20 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clRadius;
+    return orNullish(this._clCondLight.radius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
-    return new VRGBA(this._clColor);
+    if (!this._clColor) this._clColor = VRGBA.empty();
+    return orNullish(this._clCondLight.color, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clBrightness;
+    return orNullish(this._clCondLight.brightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clDirection;
+    return orNullish(this._clCondLight.direction, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1154,23 +1526,19 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clBeamLength;
+    return orNullish(this._clCondLight.beamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clBeamWidth;
-  };
-  Game_Event.prototype.getLightFlashlightDirection = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clFlashlightDirection;
+    return orNullish(this._clCondLight.beamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clXOffset;
+    return orNullish(this._clCondLight.xOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return this._clYOffset;
+    return orNullish(this._clCondLight.yOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
     if (!this._clSwitch) return this._clOnOff;
@@ -1181,22 +1549,8 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     if (this._clType === undefined) this.initLightData();
     return this._clCycle;
   };
-  Game_Event.prototype.incrementLightCycle = function () {
-    if (this._clCycle) {
-      this._clCycleTimer--;
-      if (this._clCycleTimer < 1) {
-        let cycleList = this.getLightCycle();
-        this._clCycleIndex++;
-        if (this._clCycleIndex >= cycleList.length) this._clCycleIndex = 0;
-        if (this._clCycleIndex < cycleList.length) {
-          this._clColor = new VRGBA(cycleList[this._clCycleIndex].color);
-          this._clCycleTimer = cycleList[this._clCycleIndex].duration;
-        }
-      }
-    }
-  };
-  let _Game_Interpreter_pluginCommand = Game_Interpreter.prototype.pluginCommand;
 
+  let _Game_Interpreter_pluginCommand = Game_Interpreter.prototype.pluginCommand;
   /**
    *
    * @param {String} command
@@ -1215,6 +1569,7 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
       $$.defaultBrightness = 0;
       $$.mapBrightness = undefined;
       $gameVariables.SetTint(null);
+      $gameVariables.SetTintTarget(null);
     }
   };
   /**
@@ -1236,10 +1591,9 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
   if (isRMMZ()) { // RMMZ only command interface
     let mapOnOff = (args) => args.enabled === "true" ? "on" : "off";
-
     let tileType = (args) => (args.tileType === "terrain" ? "tile" : "region") + (args.lightType ? args.lightType : "block");
     let tintType = (    ) => $gameParty.inBattle() ? "tintbattle" : "tint";
-
+    let dayMode =  (args) => args.instant === "true" ? "instant" : "";
     let tintMode = (args) => args.color ? "set" : "reset";
     let mathMode = (args) => args.mode === "set" ? "hour" : args.mode; // set, add, or subtract.
     let showMode = (args) => args.enabled.equalsIC("true") ? (args.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
@@ -1252,19 +1606,20 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     reg("tileBlock",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.shape,          a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
     reg("tileLight",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.radius,         a.brightness]));
     reg("setTint",            (a)  => f(tintType(),   [tintMode(a),     a.color,         a.fadeSpeed]));
-    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a)]));
+    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a),     dayMode(a)]));
     reg("setTimeSpeed",       (a)  => f("dayNight",   ["speed",         a.speed]));
-    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes]));
-    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours]));
+    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes,      dayMode(a)]));
+    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours,         dayMode(a)]));
     reg("showTime",           (a)  => f("dayNight",   [showMode(a)]));
-    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color]));
+    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color,         dayMode(a)]));
     reg("flashlight",         (a)  => f("flashLight", [mapOnOff(a),     a.beamLength,    a.beamWidth,    a.color,          a.density]));
     reg("setFire",            (a)  => f("setFire",    [a.radiusShift,   a.redYellowShift]));
     reg("playerLightRadius",  (a)  => f("light",      [radMode(a),      a.radius,        a.color,        "B"+a.brightness, a.fadeSpeed]));
     reg("activateById",       (a)  => f("light",      [mapOnOff(a),     a.id]));
     reg("lightColor",         (a)  => f("light",      ["color",         a.id,            a.color]));
     reg("resetLightSwitches", ( )  => f("light",      ["switch",        "reset"]));
-    reg("resetBattleTint",    (a)  => f("tintbattle", ["reset",         a.fadeSpeed]));
+    reg("resetTint",          (a)  => f(tintType(),   ["reset",         a.fadeSpeed]));
+    reg("condLight",          (a)  => f("light",      ["cond",          a.id,            a.properties]));
   }
 
   /**
@@ -1470,8 +1825,10 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     // compute radius lightgrow.
     let lightgrow_target = $gameVariables.GetRadiusTarget();
     let lightgrow_speed = (player_radius < lightgrow_target ? 1 : -1) * $gameVariables.GetRadiusSpeed();
-    player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
-    $gameVariables.SetRadius(player_radius);
+    if (lightgrow_speed != 0 && player_radius != lightgrow_target) {
+      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
+      $gameVariables.SetRadius(player_radius);
+    }
 
     // ****** PLAYER LIGHTGLOBE ********
     let ctxMul = this._maskBitmaps.multiply.context;
@@ -1533,31 +1890,22 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
     // *********************************** DAY NIGHT CYCLE TIMER **************************
     if (daynightCycleEnabled) { //
-      let daynightspeed = $gameVariables.GetDaynightSpeed();
-      if (daynightspeed > 0 && daynightspeed < 5000) {
-
-        let daynighttimer = $gameVariables.GetDaynightTimer();     // timer = minutes * speed
-        let daynightcycle = $gameVariables.GetDaynightCycle();     // cycle = hours
-        let daynighthoursinday = $gameVariables.GetDaynightHoursinDay();   // 24
-
-        if (testAndSet('_daynightTimeout', Math.floor((new Date()).getTime() / 10))) {
-          daynighttimer = daynighttimer + 1;
-          let daynightminutes = Math.floor(daynighttimer / daynightspeed);
-          let daynighttimeover = daynighttimer - (daynightspeed * daynightminutes);
-          let daynightseconds = Math.floor(daynighttimeover / daynightspeed * 60);
-
-          if (daynighttimer >= (daynightspeed * 60)) {
-            daynightcycle = daynightcycle + 1;
-            if (daynightcycle >= daynighthoursinday) daynightcycle = 0;
-            daynighttimer = 0;
+      let speed = $gameVariables.GetDaynightSpeed();
+      if (speed > 0 && speed < 5000) {
+        if ($gameTemp.testAndSet('_daynightTimeout', Math.floor((new Date()).getTime() / 10))) {
+          let seconds = $gameVariables.GetDaynightSeconds();                   // current time in seconds
+          seconds += $gameVariables.GetDaynightTick();                         // add tick amount in (seconds)
+          let secondsinDay = $gameVariables.GetDaynightHoursinDay() * 60 * 60; // convert to total seconds in day
+          if (seconds >= secondsinDay) seconds = 0;                            // clamp
+          $gameVariables.SetDaynightSeconds(seconds);                          // set
+          $$.saveTime();                                                       // save
+          // Set target to the next hour tint if enabled and the tint matches the current target
+          if (daynightTintEnabled && $gameVariables.GetTintTarget().finished()) {
+            let delta = ColorDelta.createTimeTint(true, 60 * speed);
+            $gameVariables.SetTint(delta.get());
+            $gameVariables.SetTintTarget(delta);
           }
-          $$.saveTime(daynightcycle, daynightminutes, daynightseconds);
-          $gameVariables.SetDaynightTimer(daynighttimer);     // timer = minutes * speed
-          $gameVariables.SetDaynightCycle(daynightcycle);     // cycle = hours
         }
-
-        // Set target to next hour tint if enabled
-        if (daynightTintEnabled) $gameVariables.SetTintTarget($gameVariables.GetTintByTime(1), daynightspeed);
       }
     }
 
@@ -1577,70 +1925,49 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
       let lightType = cur.getLightType();
       if (lightType) {
-        let objectflicker = lightType.is(LightType.Fire);
-        let light_radius = cur.getLightRadius();
-        let flashlength = cur.getLightFlashlightLength();
-        let flashwidth = cur.getLightFlashlightWidth();
-        let xoffset = cur.getLightXOffset() * $gameMap.tileWidth();
-        let yoffset = cur.getLightYOffset() * $gameMap.tileHeight();
-        if (light_radius >= 0) {
+        cur.cycleLightingNext();       // Cycle colors
+        cur.conditionalLightingNext(); // conditional lighting
+        let objectflicker  = lightType.is(LightType.Fire);
+        let lightId        = cur.getLightId();
+        let light_radius   = cur.getLightRadius();
+        let color          = cur.getLightColor();      // light color
+        let direction      = cur.getLightDirection();  // direction
+        let brightness     = cur.getLightBrightness(); // brightness
+        let xoffset        = cur.getLightXOffset() * $gameMap.tileWidth();
+        let yoffset        = cur.getLightYOffset() * $gameMap.tileHeight();
+        let state          = cur.getLightEnabled();    // checks for on, off, day, and night
 
-          // light color
-          let colorvalue = cur.getLightColor();
-
-          // Cycle colors
-          cur.incrementLightCycle();
-
-          // brightness and direction
-
-          let brightness = cur.getLightBrightness();
-          let direction = cur.getLightDirection();
-          let state = cur.getLightEnabled(); // checks for on, off, day, and night
-          // conditional lighting
-          let lightid = cur.getLightId();
-          if (lightid) {
-            let lightarray = $gameVariables.GetLightArray();
-            if (lightarray[lightid]) {
-              let [tstate, tcolorvalue] = lightarray[lightid];
-              if (tstate != null) state = tstate;
-              if (tcolorvalue != null) colorvalue = tcolorvalue; // no color so use default
-            }
-
-            // Set kill switch to ON if the conditional light is deactivated,
-            // or to OFF if it is active.
-            if (killSwitchAuto && killswitch !== 'None') {
-              let key = [map_id, evid, killswitch];
-              if ($gameSelfSwitches.value(key) === state) $gameSelfSwitches.setValue(key, !state);
-            }
+        // Set kill switch to ON if the conditional light is deactivated,
+        // or to OFF if it is active.
+        if (lightId && killSwitchAuto && killswitch !== 'None') {
+          let key = [map_id, evid, killswitch];
+          if ($gameSelfSwitches.value(key) === state) $gameSelfSwitches.setValue(key, !state);
+        }
+        // kill switch
+        if (killswitch !== 'None' && state) {
+          let key = [map_id, evid, killswitch];
+          if ($gameSelfSwitches.value(key) === true) state = false;
+        }
+        // show light
+        if (state === true) {
+          let lx1 = $gameMap.events()[event_stacknumber[i]].screenX();
+          let ly1 = $gameMap.events()[event_stacknumber[i]].screenY() - 24;
+          if (!shift_lights_with_events) {
+            ly1 += $gameMap.events()[event_stacknumber[i]].shiftY();
           }
 
-          // kill switch
-          if (killswitch !== 'None' && state) {
-            let key = [map_id, evid, killswitch];
-            if ($gameSelfSwitches.value(key) === true) state = false;
-          }
+          // apply offsets
+          lx1 += +xoffset;
+          ly1 += +yoffset;
 
-          // show light
-          if (state === true) {
-            let lx1 = $gameMap.events()[event_stacknumber[i]].screenX();
-            let ly1 = $gameMap.events()[event_stacknumber[i]].screenY() - 24;
-            if (!shift_lights_with_events) {
-              ly1 += $gameMap.events()[event_stacknumber[i]].shiftY();
-            }
-
-            // apply offsets
-            lx1 += +xoffset;
-            ly1 += +yoffset;
-
-            if (lightType.is(LightType.Flashlight)) {
-              let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
-
-              let tldir = cur.getLightFlashlightDirection();
-              if (!isNaN(tldir)) ldir = tldir;
-              this._maskBitmaps.radialgradientFlashlight(lx1, ly1, colorvalue, new VRGBA(), ldir, flashlength, flashwidth);
-            } else if(lightType.is(LightType.Light, LightType.Fire)) {
-              this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, colorvalue, new VRGBA(), objectflicker, brightness, direction);
-            }
+          if (lightType.is(LightType.Flashlight)) {
+            let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
+            let flashlength = cur.getLightFlashlightLength();
+            let flashwidth  = cur.getLightFlashlightWidth();
+            if (!isNaN(direction)) ldir = direction;
+            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
+          } else if (lightType.is(LightType.Light, LightType.Fire)) {
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker, brightness, direction);
           }
         }
       }
@@ -1648,13 +1975,11 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
     // *************************** TILE TAG *********************
     //glow/colorfade
-    if (testAndSet('_glowTimeout', Math.floor((new Date()).getTime() / 100))) {
-      let glowAmount    = orNaN(get('_glowAmount'), 0);
-      let glowDirection = orNaN(get('_glowDirection'), 1);
-      glowAmount += glowDirection;
-      if (glowAmount > 120) set('_glowDirection', -1);
-      if (glowAmount < 1)   set('_glowDirection', 1);
-      set('_glowAmount', glowAmount);
+    if ($gameTemp.testAndSet('_glowTimeout', Math.floor((new Date()).getTime() / 100))) {
+      $gameTemp._glowDirection = orNaN($gameTemp._glowDirection, 1);
+      $gameTemp._glowAmount    = orNaN($gameTemp._glowAmount, 0) + $gameTemp._glowDirection;
+      if ($gameTemp._glowAmount > 120) $gameTemp._glowDirection = -1;
+      if ($gameTemp._glowAmount < 1)   $gameTemp._glowDirection = 1;
     }
 
     light_tiles = $gameVariables.GetLightTiles();
@@ -1668,15 +1993,14 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
       let objectflicker = tile.lightType.is(LightType.Fire);
       let tile_color = tile.color;
       if (tile.lightType.is(LightType.Glow)) {
-        let c = new VRGBA(tile.color);
-        let glowAmount = get('_glowAmount');
-        c.r = Math.floor(c.r + (60 - glowAmount)).clamp(0, 255);
-        c.g = Math.floor(c.g + (60 - glowAmount)).clamp(0, 255);
-        c.b = Math.floor(c.b + (60 - glowAmount)).clamp(0, 255);
-        c.a = Math.floor(c.a + (60 - glowAmount)).clamp(0, 255);
+        let c = tile.color.clone();
+        c.r = Math.floor(c.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        c.g = Math.floor(c.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        c.b = Math.floor(c.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
         tile_color = c;
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, new VRGBA(), objectflicker, tile.brightness);
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker, tile.brightness);
     });
 
     // Tile blocks
@@ -1711,13 +2035,11 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
         y1 = y1 + tile.yOffset;
         this._maskBitmaps.FillEllipse(x1, y1, tile.blockWidth, tile.blockHeight, tile.color);
       }
-    });
+    }, this);
     ctxMul.globalCompositeOperation = 'lighter';
 
     // Compute tint for next frame
-    let tintValue = $gameVariables.GetTint();
-    let [tintTarget, tintSpeed] = $gameVariables.GetTintTarget();
-    tintValue = this.computeNextTint(tintValue, tintTarget, tintSpeed);
+    let tintValue = $gameVariables.GetTintTarget().next().get();
     $gameVariables.SetTint(tintValue);
     this._maskBitmaps.FillRect(-lightMaskPadding, 0, maxX + lightMaskPadding, maxY, tintValue);
 
@@ -2150,7 +2472,6 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
   BattleLightmask.prototype = Object.create(PIXI.Container.prototype);
   BattleLightmask.prototype.constructor = BattleLightmask;
-
   BattleLightmask.prototype.initialize = function () {
     PIXI.Container.call(this);
     this._width = Graphics.width;
@@ -2171,6 +2492,9 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
             $gameVariables.GetTint() : new VRGBA("#ffffff");
 
+    // Set initial tint for battle
+    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
+
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {
       let data = note.split(/\s+/);
@@ -2183,16 +2507,14 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66)
       c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
 
-    // Set initial tint for battle
-    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
-    set('_BattleTintTarget', c); set('_BattleTint', c);
+    $gameTemp._BattleTintInitial = c;
+    $gameTemp._BattleTintTarget = ColorDelta.createTint(c);
     this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };
 
   //@method _createBitmaps
-
   BattleLightmask.prototype._createBitmaps = function () {
     this._maskBitmaps = new Mask_Bitmaps(battleMaxX + lightMaskPadding, battleMaxY);
   };
@@ -2201,20 +2523,15 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
     this._maskBitmaps.multiply.fillRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY, '#000000');
     this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
-    // Grab tint information
-    let tintValue  = get('_BattleTint');
-    let tintTarget = get('_BattleTintTarget');
-    let tintSpeed  = get('_BattleTintSpeed');
-
     // Prevent the battle scene from being too dark
-    let c = tintTarget; // reference
-    if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66)
+    let c = $gameTemp._BattleTintTarget.next().get(); // reference
+    if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66) {
       c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
+      $gameTemp._BattleTintTarget.current = c; // reassign if out of bounds. Shouldn't be possible.
+    }
 
     // Compute tint for next frame
-    tintValue = this.computeNextTint(tintValue, tintTarget, tintSpeed);
-    set('_BattleTint', tintValue);
-    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, tintValue);
+    this._maskBitmaps.FillRect(-lightMaskPadding, 0, battleMaxX + lightMaskPadding, battleMaxY, c);
     this._maskBitmaps.multiply._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
     this._maskBitmaps.additive._baseTexture.update(); // Required to update battle texture in RMMZ optional for RMMV
   };
@@ -2328,12 +2645,17 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
       if (mapnote) {
         mapnote = mapnote.toLowerCase().trim();
         if ((/^daynight\b/i).test(mapnote)) {
-          daynightTintEnabled = true;
-          let dnspeed = note.match(/\d+/);
-          if (dnspeed) {
-            let daynightspeed = +dnspeed[0];
-            if (daynightspeed < 1) daynightspeed = 5000;
-            $gameVariables.SetDaynightSpeed(daynightspeed);
+          if (daynightCycleEnabled && !daynightTintEnabled) {
+            daynightTintEnabled = true;
+            let dnspeed = note.match(/\d+/);
+            if (dnspeed) {
+              let daynightspeed = +dnspeed[0];
+              if (daynightspeed < 1) daynightspeed = 5000;
+              $gameVariables.SetDaynightSpeed(daynightspeed);
+            }
+            let delta = ColorDelta.createTimeTint(false, 60 * $gameVariables.GetDaynightSpeed());
+            $gameVariables.SetTint(delta.get());
+            $gameVariables.SetTintTarget(delta);
           }
         }
         else if ((/^RegionFire\b/i).test(mapnote)) {
@@ -2461,24 +2783,26 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 
     // *********************** TURN SPECIFIC LIGHT ON *********************
     else if (isOn(args[0])) {
-      let lightid = args[1];
-      let lightarray = $gameVariables.GetLightArray();
-      void (lightarray[lightid] ? lightarray[lightid][0] = true : lightarray[lightid] = [true, null]);
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.enabled = true; }
     }
 
     // *********************** TURN SPECIFIC LIGHT OFF *********************
     else if (isOff(args[0])) {
-      let lightid = args[1];
-      let lightarray = $gameVariables.GetLightArray();
-      void (lightarray[lightid] ? lightarray[lightid][0] = false : lightarray[lightid] = [false, null]);
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.enabled = false; }
     }
 
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
-      let lightid = args[1];
-      let newcolor = args[2] ? new VRGBA(args[2]) : null; // null for default (i.e. no passed color)
-      let lightarray = $gameVariables.GetLightArray();
-      void (lightarray[lightid] ? lightarray[lightid][1] = newcolor : lightarray[lightid] = [null, newcolor]);
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for default (i.e. no passed color)
+    }
+
+    // *********************** SET CONDITIONAL LIGHT *********************
+    else if (args[0].equalsIC('cond')) {
+      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (condLight) { condLight.parseTargetCondLightProps(args[2].split(/\s+/)); }
     }
 
     // **************************** RESET ALL SWITCHES ***********************
@@ -2493,15 +2817,13 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
    */
   $$.tint = function (args) {
     let cmd = args[0].trim();
-    if (cmd.equalsIC('set', 'fade')) {
-      let currentColor = args[1];
-      let speed = +args[2] || 0;
-      $gameVariables.SetTintTarget(currentColor, speed);
-    }
+    if (cmd.equalsIC('set', 'fade'))
+      $gameVariables.SetTintTarget(ColorDelta.createTint(new VRGBA(args[1]), 60 * (+args[2] || 0)));
     else if (cmd.equalsIC("reset", "daylight")) {
-      let currentColor = $gameVariables.GetTintByTime();
-      let speed = +args[1] || 0;
-      $gameVariables.SetTintTarget(currentColor, speed);
+      let fadeDuration = 60 * (+args[1] || 0);
+      let delta = ColorDelta.createTimeTint(false, 0); // get the daynight tint for the current time
+      delta = ColorDelta.createTint(delta.get(), fadeDuration); // use tint for current time as target
+      $gameVariables.SetTintTarget(delta);
     }
   };
 
@@ -2512,13 +2834,10 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
   $$.tintbattle = function (args, overrideInBattleCheck = false) {
     if ($gameParty.inBattle() || overrideInBattleCheck) {
       let cmd = args[0].trim();
-      if (cmd.equalsIC("set", 'fade')) {
-        set('_BattleTintTarget', new VRGBA(args[1], "#666666"));
-        set('_BattleTintSpeed', +args[2] || 0);
-      }
+      if (cmd.equalsIC("set", 'fade'))
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));
       else if (cmd.equalsIC('reset', 'daylight')) {
-        set('_BattleTintTarget', $gameVariables.GetTint());
-        set('_BattleTintSpeed', +args[1] || 0);
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0)); // battle initial color
       }
     }
   };
@@ -2528,94 +2847,50 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
    * @param {String[]} args
    */
   $$.DayNight = function (args) {
-    let daynightspeed = $gameVariables.GetDaynightSpeed();
-    let daynighttimer = $gameVariables.GetDaynightTimer();     // timer = minutes * speed
-    let daynightcycle = $gameVariables.GetDaynightCycle();     // cycle = hours
-    let daynighthoursinday = $gameVariables.GetDaynightHoursinDay();   // 24
-    let daynightcolors = $gameVariables.GetDaynightColorArray();
-
-    function addTime(houradd, minuteadd) {
-      let daynightminutes = Math.floor(daynighttimer / daynightspeed);
-      daynightminutes = daynightminutes + minuteadd + 60*(daynightcycle + houradd);
-      daynightcycle = Math.trunc(daynightminutes/60)%daynighthoursinday;
-      daynightminutes = daynightminutes%60;
-
-      if (daynightminutes < 0) { daynightminutes += 60; daynightcycle--; }
-      if (daynightcycle < 0) { daynightcycle += daynighthoursinday; }
-      daynighttimer = daynightminutes * daynightspeed;
-
-      $$.saveTime(daynightcycle, daynightminutes);
-      $gameVariables.SetDaynightTimer(daynighttimer);     // timer = minutes * speed
-      $gameVariables.SetDaynightCycle(daynightcycle);     // cycle = hours
-    }
-
-    if (args.length == 0 || args[0].equalsIC('on')) {
-      daynightTintEnabled = true;
-    }
-
-    else if (args[0].equalsIC('off')) {
-      $gameVariables.SetTintTarget($gameVariables.GetTint(), 0);
-      daynightTintEnabled = false;
-    }
-
-    else if (args[0].equalsIC('speed')) {
-      daynightspeed = +args[1] || 5000;
-      $gameVariables.SetDaynightSpeed(daynightspeed);
-    }
-
-    else if (args[0].equalsIC('add')) {
-      addTime(+args[1], args.length > 2 ? +args[2] : 0);
-    }
-
-    else if (args[0].equalsIC('subtract')) {
-      addTime(+args[1]*-1, args.length > 2 ? +args[2]*-1 : 0);
-    }
-
-    else if (args[0].equalsIC('hour')) {
-      daynightcycle = Math.max(+args[1], 0) || 0;
-      let daynightminutes = Math.max(+args[2], 0) || 0;
-      daynighttimer = daynightminutes * daynightspeed;
-
-      if (daynightcycle >= daynighthoursinday) daynightcycle = daynighthoursinday - 1;
-
-      $$.saveTime(daynightcycle, daynightminutes);
-      $gameVariables.SetDaynightTimer(daynighttimer);     // timer = minutes * speed
-      $gameVariables.SetDaynightCycle(daynightcycle);     // cycle = hours
-    }
-
-    else if (args[0].equalsIC('hoursinday')) {
-      daynighthoursinday = Math.max(orNaN(+args[1], 0), 0);
-      if (daynighthoursinday > daynightcolors.length) {
-        let origLength = daynightcolors.length;
-        daynightcolors.length = daynighthoursinday; // more efficient than a for loop
-        daynightcolors.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+    let modTime = (hoursInDay, hours, minutes, seconds) => { // helper function to modify (set/add/subtract) time
+      hoursInDay = Math.max(orNaN(+hoursInDay, 24), 1); // minimum of 1, err results in 24
+      hours = orNaN(hours, 0);
+      minutes = orNaN(minutes, 0);
+      seconds = orNaN(seconds, 0);
+      seconds += hours * 60 * 60 + minutes * 60;
+      let totalSeconds = hoursInDay * 60 * 60;
+      while (seconds >= totalSeconds) seconds -= totalSeconds;
+      while (seconds < 0) seconds += totalSeconds;
+      gV.SetDaynightSeconds(seconds);
+      gV.SetDaynightHoursinDay(hoursInDay);
+      setTimeColorDelta();
+      $$.saveTime();
+    };
+    let setColorDelta = () => {
+      let delta = ColorDelta.createTint(gV.GetTint());
+      $gameVariables.SetTint(delta.get());
+      $gameVariables.SetTintTarget(delta);
+    };
+    let setTimeColorDelta = () => {
+      if (daynightCycleEnabled && daynightTintEnabled) {
+        let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
+        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed()); // whether to change tint instantly
+        $gameVariables.SetTint(delta.get());
+        $gameVariables.SetTintTarget(delta);
       }
-      $gameVariables.SetDaynightColorArray(daynightcolors);
-      $gameVariables.SetDaynightHoursinDay(daynighthoursinday);
-    }
-
-    else if (args[0].equalsIC('show')) {
-      $gameVariables._clShowTimeWindow = true;
-      $gameVariables._clShowTimeWindowSeconds = false;
-    }
-
-    else if (args[0].equalsIC('showseconds')) {
-      $gameVariables._clShowTimeWindow = true;
-      $gameVariables._clShowTimeWindowSeconds = true;
-    }
-
-    else if (args[0].equalsIC('hide')) {
-      $gameVariables._clShowTimeWindow = false;
-      $gameVariables._clShowTimeWindowSeconds = false;
-    }
-
-    else if (args[0].equalsIC('color')) {
-      let hour = (+args[1] || 0).clamp(0, daynighthoursinday - 1);
-      let hourcolor = args[2];
-      if (hourcolor) daynightcolors[hour].color = new VRGBA(hourcolor);
-      $gameVariables.SetDaynightColorArray(daynightcolors);
-    }
-  };
+    };
+    let isCmd                      = (s)    => a[0].equalsIC(s);
+    let showTime                   = (w, s) => [gV._clShowTimeWindow, gV._clShowTimeWindowSeconds] = [w, s];
+    let [gV, a]                    = [$gameVariables, args];
+    let [secondsTotal, hoursInDay] = [gV.GetDaynightSeconds(), gV.GetDaynightHoursinDay()];
+    let [hours, minutes, seconds]  = [$$.hours(), $$.minutes(), $$.seconds()];
+    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint changes
+    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disabled daynight tint changes
+    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // daynight speed
+    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to current time
+    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // subtract from current time
+    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the current time
+    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day (must be >0, err = 24)
+    else if (isCmd('show'))        void showTime(true, false);                                          // show clock
+    else if (isCmd('showseconds')) void showTime(true, true);                                           // show clock seconds
+    else if (isCmd('hide'))        void showTime(false, false);                                         // hide clock
+    else if (isCmd('color'))       void (gV.SetTintAtHour(a[1], new VRGBA(a[2])), setTimeColorDelta()); // change hour color
+};
 
   let _Tilemap_drawShadow = Tilemap.prototype._drawShadow;
   Tilemap.prototype._drawShadow = function (bitmap, shadowBits, dx, dy) {
@@ -2640,7 +2915,6 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
 Community.Lighting.distance = function (x1, y1, x2, y2) {
   return Math.abs(Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2)));
 };
-
 Game_Variables.prototype.SetActiveRadius = function (value) {
   this._Player_Light_Radius = orNaN(+value);
 };
@@ -2648,7 +2922,6 @@ Game_Variables.prototype.GetActiveRadius = function () {
   if (this._Player_Light_Radius >= 0) return this._Player_Light_Radius;
   return Number(Community.Lighting.parameters['Lights Active Radius']) || 0;
 };
-
 Game_Variables.prototype.GetFirstRun = function () {
   if (typeof this._Community_Lighting_FirstRun === 'undefined') {
     this._Community_Lighting_FirstRun = true;
@@ -2667,7 +2940,6 @@ Game_Variables.prototype.GetScriptActive = function () {
 Game_Variables.prototype.SetScriptActive = function (value) {
   this._Community_Lighting_ScriptActive = value;
 };
-
 Game_Variables.prototype.GetOldMapId = function () {
   if (typeof this._Community_Lighting_OldMapId === 'undefined') {
     this._Community_Lighting_OldMapId = 0;
@@ -2678,23 +2950,30 @@ Game_Variables.prototype.SetOldMapId = function (value) {
   this._Community_Lighting_OldMapId = value;
 };
 Game_Variables.prototype.SetTint = function (value) {
-  this._Community_Tint_Value = new VRGBA(value);
+  this._Community_Tint_Value = value.clone();
 };
 Game_Variables.prototype.GetTint = function () {
-  return new VRGBA(this._Community_Tint_Value);
+  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.empty();
+  return this._Community_Tint_Value.clone();
+};
+Game_Variables.prototype.SetTintAtHour = function (hour, color) {
+  let result = this.GetDaynightColorArray()[Math.max((+hour || 0), 0)];
+  if (color) result.color = color.clone(); // hour color
 };
 Game_Variables.prototype.GetTintByTime = function (inc = 0) {
-  let cycle = this.GetDaynightCycle() + inc; // increment from current hour
-  if (cycle >= this.GetDaynightHoursinDay) cycle = 0;
-  let result = this.GetDaynightColorArray()[cycle];
-  return new VRGBA(result ? result.color : undefined);
+  let hours = Community.Lighting.hours() + inc; // increment from current hour
+  let hoursinDay = this.GetDaynightHoursinDay();
+  while (hours >= hoursinDay) hours -= hoursinDay;
+  while (hours < 0) hours += hoursinDay;
+  let result = this.GetDaynightColorArray()[hours];
+  return result ? result.color.clone() : VRGBA.empty();
 };
-Game_Variables.prototype.SetTintTarget = function (newTarget, speed) {
-  this._Community_TintTarget = new VRGBA(newTarget);
-  this._Community_TintSpeed = orNaN(speed, 0);
+Game_Variables.prototype.SetTintTarget = function (delta) {
+  this._Community_TintTarget = delta;
 };
 Game_Variables.prototype.GetTintTarget = function () {
-  return [new VRGBA(this._Community_TintTarget), orNaN(this._Community_TintSpeed, 0)];
+  if (!this._Community_TintTarget) this._Community_TintTarget = new ColorDelta(this.GetTint());
+  return this._Community_TintTarget;
 };
 Game_Variables.prototype.SetFlashlight = function (value) {
   this._Community_Lighting_Flashlight = value;
@@ -2727,7 +3006,8 @@ Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if emp
   if (value) this._Community_Lighting_PlayerColor = new VRGBA(value);
 };
 Game_Variables.prototype.GetPlayerColor = function () {
-  return new VRGBA(this._Community_Lighting_PlayerColor, "#ffffff");
+  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = new VRGBA("#ffffff");
+  return this._Community_Lighting_PlayerColor.clone();
 };
 Game_Variables.prototype.SetPlayerBrightness = function (value) { // don't set if invalid.
   if (value && value[0].equalsIC('b')) { // must exist and be prefixed with b or B
@@ -2753,7 +3033,7 @@ Game_Variables.prototype.SetRadiusTarget = function (value) {
 };
 Game_Variables.prototype.GetRadiusTarget = function () {
   if (this._Community_Lighting_RadiusTarget == null) {
-    return 150;
+    return this.GetRadius();
   } else {
     return this._Community_Lighting_RadiusTarget;
   }
@@ -2766,9 +3046,6 @@ Game_Variables.prototype.SetRadiusSpeed = function (value) { // must use AFTER s
 Game_Variables.prototype.GetRadiusSpeed = function () {
   return orNullish(this._Community_Lighting_RadiusSpeed, 0);
 };
-Game_Variables.prototype.SetDaynightColorArray = function (value) {
-  this._Community_Lighting_DayNightColorArray = value;
-};
 Game_Variables.prototype.GetDaynightColorArray = function () {
   let result = this._Community_Lighting_DayNightColorArray || Community.Lighting.getDayNightList();
   if (!result) {
@@ -2780,47 +3057,48 @@ Game_Variables.prototype.GetDaynightColorArray = function () {
       '#000000', '#000000', '#000000', '#000000'].map(x => x = { "color": new VRGBA(x), "isNight": false });
     this._Community_Lighting_DayNightColorArray = result;
   }
-  if (!this._Community_Lighting_DayNightColorArray) this.SetDaynightColorArray(result);
+  let hoursInDay = this.GetDaynightHoursinDay();
+  if (hoursInDay > result.length) { // lazy check bounds before returning and add colors if too small
+    let origLength = result.length;
+    result.length = hoursInDay;     // more efficient than a for loop
+    result.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+  }
+  this._Community_Lighting_DayNightColorArray = result; // assign reference
   return result;
 };
 Game_Variables.prototype.SetDaynightSpeed = function (value) {
-  this._Community_Lighting_DaynightSpeed = orNaN(+value);
+  this._Community_Lighting_DaynightSpeed = orNaN(+value, 5000);
 };
 Game_Variables.prototype.GetDaynightSpeed = function () {
   if (this._Community_Lighting_DaynightSpeed >= 0) return this._Community_Lighting_DaynightSpeed;
   return orNullish(Number(Community.Lighting.parameters['Daynight Initial Speed']), 10);
 };
-Game_Variables.prototype.SetDaynightCycle = function (value) {
-  this._Community_Lighting_DaynightCycle = orNaN(+value);
+Game_Variables.prototype.GetDaynightTick = function () {
+  return 60 / this.GetDaynightSpeed();
 };
-Game_Variables.prototype.GetDaynightCycle = function () {
-  return orNullish(this._Community_Lighting_DaynightCycle, Number(Community.Lighting.parameters['Daynight Initial Hour']), 0);
-
+Game_Variables.prototype.SetDaynightSeconds = function (value) {
+  this._Community_Lighting_DaynightSeconds = orNaN(+value);
 };
-Game_Variables.prototype.SetDaynightTimer = function (value) {
-  this._Community_Lighting_DaynightTimer = orNaN(+value);
-};
-Game_Variables.prototype.GetDaynightTimer = function () {
-  return orNullish(this._Community_Lighting_DaynightTimer, 0);
+Game_Variables.prototype.GetDaynightSeconds = function () {
+  return orNaN(+this._Community_Lighting_DaynightSeconds, 0);
 };
 Game_Variables.prototype.SetDaynightHoursinDay = function (value) {
   this._Community_Lighting_DaynightHoursinDay = orNaN(+value);
 };
 Game_Variables.prototype.GetDaynightHoursinDay = function () {
-  return orNullish(this._Community_Lighting_DaynightHoursinDay, 24);
+  return orNaN(this._Community_Lighting_DaynightHoursinDay, 24);
 };
-
 Game_Variables.prototype.SetFireRadius = function (value) {
   this._Community_Lighting_FireRadius = orNaN(+value);
 };
 Game_Variables.prototype.GetFireRadius = function () {
-  return orNullish(this._Community_Lighting_FireRadius, 7);
+  return orNaN(this._Community_Lighting_FireRadius, 7);
 };
 Game_Variables.prototype.SetFireColorshift = function (value) {
   this._Community_Lighting_FireColorshift = orNaN(+value);
 };
 Game_Variables.prototype.GetFireColorshift = function () {
-  return orNullish(this._Community_Lighting_FireColorshift, 10);
+  return orNaN(this._Community_Lighting_FireColorshift, 10);
 };
 Game_Variables.prototype.SetFire = function (value) {
   this._Community_Lighting_Fire = value;
@@ -2833,7 +3111,7 @@ Game_Variables.prototype.SetLightArray = function (value) {
 };
 Game_Variables.prototype.GetLightArray = function () {
   if (this._Community_Lighting_LightArray == null)
-    this._Community_Lighting_LightArray = {};
+    this._Community_Lighting_LightArray = { 0: {} };
   return this._Community_Lighting_LightArray;
 };
 Game_Variables.prototype.SetTileLightArray = function (value) {

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -974,7 +974,7 @@ class LightProperties {
    * @param {Number}    beamLength
    * @param {Number}    beamWidth
    */
-  constructor(type, enable, color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, color, enable, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
     // Always define in case durations aren't passed to targets
     this.transitionDuration = 0;
     this.pauseDuration      = 0;
@@ -1572,8 +1572,8 @@ class ColorDelta {
         else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
         else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
         else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))      this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))      this._cl.enable    = false;
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
         else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
         else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -576,31 +576,27 @@ Imported[Community.Lighting.name] = true;
 * Flashlight off
 * - Turn off the flashlight.  yup.
 *
-* DayNight on|off [instant]
-* - Activates or deactivates the day/night cycle. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* DayNight on|off [fade]
+* - Activates or deactivates the day/night cycle. Specifying 'fade' will gradually
+*   transition the tint to that of the next hour.
 *
 * Daynight speed n
 * - Changes the speed by which hours pass in game in relation to real life seconds
 *
-* Daynight hour h m [instant]
-* - Sets the in game time to hh:mm. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hour h m [fade]
+* - Sets the in game time to hh:mm. Specifying 'fade' will gradually transition the
+*   tint to that of the next hour.
 *
 * Daynight color h c
 * - Sets the hour (h) to use color (c)
 *
-* Daynight add h m [instant]
-* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight add h m [fade]
+* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying
+*   'fade' will gradually transition the tint to that of the next hour.
 *
-* Daynight subtract h m [instant]
-* - Subtracts the specified hours (h) and minutes (m) from the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight subtract h m [fade]
+* - Subtracts the specified hours (h) and minutes (m) from the in game clock.
+*   Specifying  'fade' will gradually transition the tint to that of the next hour.
 *
 * Daynight show
 * - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -611,10 +607,9 @@ Imported[Community.Lighting.name] = true;
 * Daynight hide
 * - Hides the current time of day mini-window
 *
-* Daynight hoursinday h [instant]
-* - Sets the number of hours in a day to [h] (set hour colors if doing this), Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hoursinday h [fade]
+* - Sets the number of hours in a day to [h] (set hour colors if doing this).
+*   Specifying 'fade' will gradually transition the tint to that of the next hour.
 *
 * Tint set c [s]
 * Tint fade c [s]
@@ -1716,7 +1711,7 @@ class ColorDelta {
     let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
     let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
     let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let dayMode =  a  => a.fade === "true" ? "fade" : "";
     let tintMode = a  => a.color ? "set" : "reset";
     let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
     let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
@@ -3000,8 +2995,8 @@ class ColorDelta {
     };
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
-        let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
+        let hasFade = 'fade'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
+        let delta = ColorDelta.createTimeTint(hasFade, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -376,13 +376,13 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
-* <cl: light 300 {#ff0000 p15} {#ffff00 p15} {#00ff00 p15} {#00ffff p15} {#0000ff p15}>
+* <cl: light 300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 {#ff0000 t30 p60} {#ffff00 t30 p60} {#00ff00 t30 p60} {#00ffff t30 p60}>
+* <cl: light 300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
-* <cl: light {#ff0000 t30 p60 r250} {#ffff00 t30 p60 r300} {#00ff00 t30 p60 r250} {#00ffff t30 p60 r300}>
+* <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
 * Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
 * and transitions to the next color and size over 60 frames.
 *
@@ -398,7 +398,7 @@ Imported[Community.Lighting.name] = true;
 * plugin commands.
 *
 * <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15>
-* <cl: Flashlight l8 w12 {#f00 p15} {#ff0 p15} {#0f0 p15}>
+* <cl: Flashlight l8 w12 {#f00 p15} {#ff0} {#0f0}>
 * Creates a flashlight beam that rotates every 15 frames.
 *
 * --------------------------------------------------------------------------
@@ -408,7 +408,7 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 {a#990000 t15} {a#999900 t15} {a#009900 t15} {a#009999 t15} {a#000099 t15}>
+* <cl: light 300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
@@ -421,6 +421,8 @@ Imported[Community.Lighting.name] = true;
 * Conditional Lighting allows light properties to be changed either cyclically or
 * dynamically over time via properties that consist of a prefix followed by a property
 * value. This is useful for creating any number of transitional lighting effects.
+* Properties will hold their given value until a change or reset (including pause and
+* transition durations).
 *
 * The properties are supported in light tags or via the 'light cond' command. Light tags
 * support any number of light properties wrapped in {} brackets See the example note tags
@@ -1025,12 +1027,12 @@ class LightProperties {
     this.updateFrame = Graphics.frameCount; // set current frame as update frame
     let isOL = this.isOtherLight();
     let isFL = this.isFlashlight();
-    let hasTransitionDuration = false;
-    let haspauseDuration      = false;
     // properties with no suffix 'clear' the target
     properties.forEach((e) => {
       // clear checks (back to initial value for the given property)
-      if      (        e.equalsIC('#'))        this.color      = void(0);
+      if      (        e.equalsIC('t'))        this.transitionDuration = 0;
+      else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
+      else if (        e.equalsIC('#'))        this.color      = void(0);
       else if (        e.equalsIC('a#'))       this.color      = void(0);
       else if (        e.equalsIC('e'))        this.enable     = void(0);
       else if (        e.equalsIC('b'))        this.brightness = void(0);
@@ -1044,8 +1046,8 @@ class LightProperties {
       else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void(0);
       // on or off checks
       // prefix checks
-      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); hasTransitionDuration = true; }
-      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); haspauseDuration = true; }
+      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); }
+      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); }
       else if (        e.startsWithIC('#'))    this.color      = new VRGBA(e);
       else if (        e.startsWithIC('a#'))   this.color      = new VRGBA(e);
       else if (        e.startsWithIC('e'))    this.enable     = Boolean(orNaN(+e.slice(1), 0));
@@ -1059,8 +1061,6 @@ class LightProperties {
       else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
       else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
     }, this);
-    if (!hasTransitionDuration) this.transitionDuration = 0;
-    if (!haspauseDuration)      this.pauseDuration = 0;
   }
 
   /**
@@ -2974,7 +2974,7 @@ class ColorDelta {
     // **************************** RESET ALL SWITCHES ***********************
     else if (args[0].equalsIC('switch') && args[1].equalsIC('reset')) {
       let lightArray = $gameVariables.GetLightArray();
-      for (let i in lightArray) lightArray[i].parseProps(['#', 'e', 'b', 'x', 'y', 'r', 'l', 'w', 'a']); // clear
+      for (let i in lightArray) lightArray[i].parseProps(['t', 'p', '#', 'e', 'b', 'x', 'y', 'r', 'l', 'w', 'a']); // clear
     }
   };
 

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -2965,7 +2965,7 @@ class ColorDelta {
    * @param {String[]} args
    */
   $$.tintbattle = function (args, overrideInBattleCheck = false) {
-    if ($gameParty.inBattle() || overrideInBattleCheck) {
+    if ($gameVariables.GetScriptActive() && lightInBattle && ($gameParty.inBattle() || overrideInBattleCheck)) {
       let cmd = args[0].trim();
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -1087,13 +1087,13 @@ class LightDelta {
    * @param {LightProperties} current
    * @param {LightProperties} target
    */
-  constructor(current, target, defaults) {
+  constructor(current, target, defaults, fade = true) {
     if (arguments.length == 0) return;
     this.current = current;
     this.target  = target;
     this.defaults = defaults;
     this.delta   = new LightProperties();
-    this.createDeltas();
+    this.createDeltas(fade);
   }
 
   /**
@@ -1110,9 +1110,12 @@ class LightDelta {
   }
 
   /**
-   * Create deltas from currents, targets, and transition duration.
+   * Create deltas from currents, targets, and transition duration. If fade is false, then the current will transition
+   * to the target values instantly.
+   *
+   * @param {Boolean} fade
    */
-  createDeltas() {
+  createDeltas(fade = true) {
     // Helper functions
     let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
     let normalizeClockwiseMovement = () => {
@@ -1130,6 +1133,10 @@ class LightDelta {
 
     // set delta creation at current frame time
     this.current.updateFrame = Graphics.frameCount;
+
+    // Set current durations or 0 if not fading
+    this.current.transitionDuration = fade ? this.target.transitionDuration : 0;
+    this.current.pauseDuration      = fade ? this.target.pauseDuration : 0;
 
     // Enable or disable the current immediately based off of target value
     this.current.enable = this.target.enable != null ? this.target.enable : this.defaults.enable;
@@ -1607,31 +1614,30 @@ class ColorDelta {
       let startProps = new LightProperties(this._cl.type, ...props);
 
       // Process cycle parameters - for each cycle group create currentProps and targetProps and cooresponding light
-      // delta. Then put the deltas into a list to loop/cycle through repeatedly
+      // delta. Then put the deltas into a list to loop/cycle through repeatedly. Note: Last cycle targets first.
       if (cycleGroups.length) { // check if tag included color cycling
         this._cl.cycle = [];     // only define if cycle exists
-        let currentProps = startProps, targetProps, delta;
-        cycleGroups.forEach((e, i, a) => {                                  // ------ loop each group ------
-          let n = a[++i < a.length ? i : 0];                                // - get next element: OOB goes to first
-          currentProps = currentProps.clone();                              // - inherit existing props
-          currentProps.parseProps(e);                                       // - parse for new props
-          targetProps = i == a.length ? startProps : currentProps.clone();  // - create target props: last targets start
-          targetProps.parseProps(n);                                        // - parse for new props: last targets start
-          let delta = new LightDelta(currentProps, targetProps, this._cl);  // - create light delta object
-          this._cl.cycle.push(delta);                                       // - push conditional light delta to list
-        }, this);                                                           // -----------------------------
-        delta = this._cl.cycle.shift(); // pop front
-        this._cl.delta = delta.clone(); // clone front as the initial lightDelta state for this cond light
-        this._cl.cycle.push(delta);     // push original on back of list
+        let currentProps = startProps, targetProps;
+        cycleGroups.forEach((e, i, a) => {                                          // ------ loop each group ------
+          let n = a[++i < a.length ? i : 0];                                        // - get next element
+          currentProps = currentProps.clone();                                      // - inherit existing props
+          currentProps.parseProps(e);                                               // - parse for new props
+          targetProps = i == a.length ? startProps : currentProps.clone();          // - create target props
+          targetProps.parseProps(n);                                                // - parse for new props
+          this._cl.cycle.push(new LightDelta(currentProps, targetProps, this._cl)); // - create light delta object
+        }, this);                                                                   // -----------------------------
+        let delta = this._cl.cycle.shift(); // pop front
+        this._cl.delta = delta.clone();     // clone front as the initial lightDelta state for this cond light
+        this._cl.cycle.push(delta);         // push original on back of list
       }
       // Process conditional lighting - for a cond light, currentProps are light specific and targets are shared by ID
       // a target can be updated on the fly using commands and all lights with matching IDs will use the properties
       else if (this._cl.id) { // check for a conditional lighting ID
-        let lightArray = $gameVariables.GetLightArray();                    // get target light Object
-        if (lightArray[this._cl.id] == null)                                // check if target exists since it's shared
-          lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
-        let targetProps = lightArray[this._cl.id];                          // get target prop reference
-        this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
+        let lightArray = $gameVariables.GetLightArray();                            // get target light Object
+        if (lightArray[this._cl.id] == null)                                        // check if shared target exists
+          lightArray[this._cl.id] = new LightProperties();                          // - if not, create empty reference
+        let targetProps = lightArray[this._cl.id];                                  // get target prop reference
+        this._cl.delta  = new LightDelta(startProps, targetProps, this._cl, false); // create light delta object
       }
       // Non-conditional light
       else {

--- a/Community_Lighting.js
+++ b/Community_Lighting.js
@@ -306,11 +306,11 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [enable] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
-* - radius      100, 250, etc
+* - radius      Any number, optionally preceded by "R" or "r", so 100, R100, r100, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -321,7 +321,8 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
 * - night       Causes the light to only come on during the night [optional]
 * - brightness  B50, B25, etc [optional]
@@ -332,20 +333,21 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [enable] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - bl:         Beam length:  Any number, optionally preceded by "L" or "l", so 8, L8, l8, etc.
+* - bw:         Beam width:  Any number, optionally preceded by "W", or 'w', so 12, W12, w12, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -356,19 +358,21 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Sets the event's light to only show during the day [optional]
 * - night       Sets the event's light to only show during night time [optional]
 * - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*               Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               Can be preceded by "D" or "d", so D4, d4, etc. If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A" or "a". If
 *               omitted, sdir is used. [optional]
 * - x           x[offset] Work the same as regular light [optional]
 * - y           y[offset] [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Example note tags:
 *
@@ -376,10 +380,10 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
-* <cl: light 300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
+* <cl: light r300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
+* <cl: light r300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
 * <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
@@ -408,7 +412,7 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
+* <cl: light r300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
@@ -1593,34 +1597,38 @@ class ColorDelta {
     this._cl.type = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._cl.type) {
-      let isFL       = ()        => this._cl.type.is(LightType.Flashlight); // is flashlight
-      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
-      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
-      let isNul      = (e)       => e == null;
-      let isDayNight = (e)       => isEq(e, "night", "day");
-      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let isFL       = ()          => this._cl.type.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, s0, s1) => s0 && e.equalsIC(s0)     || s1 && e.equalsIC(s1);
+      let isPre      = (e, p0, p1) => p0 && e.startsWithIC(p0) || p1 && e.startsWithIC(p1);
+      let isPreNum   = (e, p, n)   => p  && e.startsWithIC(p)  && !isNaN(n);
+      let isNul      = (e)         => e == null;
+      let isDayNight = (e)         => isEq(e, "night", "day");
+      let clipNum    = (e)         => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        let n = clip(e);
-        if      (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
+        let n = clipNum(e);
+        console.log()
+        if      (!isFL() && isPreNum(e, 'r', n) && isNul(this._cl.radius))     this._cl.radius     = n;
+        else if (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamWidth))  this._cl.beamWidth  = +e;
-        else if (isFL()  && isPre(e, "l") && n  && isNul(this._cl.beamLength)) this._cl.beamLength = n;
-        else if (isFL()  && isPre(e, "w") && n  && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
-        else if (           isEq(e, "cycle")    && isNul(this._cl.color))      hasCycle            = true;
-        else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
-        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
-        else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
+        else if (isFL()  && isPreNum(e, 'l', n) && isNul(this._cl.beamLength)) this._cl.beamLength = n;
+        else if (isFL()  && isPreNum(e, 'w', n) && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
+        else if (           isEq(e, 'cycle')    && isNul(this._cl.color))      hasCycle            = true;
+        else if (           isPre(e, '#', 'a#') && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex] .push('p' + e);
+        else if (           isPre(e, '#', 'a#') && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
+        else if (           isPreNum(e, 'e', n) && isNul(this._cl.enable))     this._cl.enable     = Boolean(n);
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable     = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable     = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
-        else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;
+        else if (           isPreNum(e, 'b', n) && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = n;
         else if ( isFL() && !isNaN(+e)          && isNul(this._cl.direction))  this._cl.direction  = +e;
-        else if ( isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
-        else if ( isFL() && isPre(e, "a") && n  && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
-        else if (           isPre(e, "x") && n  && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
-        else if (           isPre(e, "y") && n  && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
+        else if ( isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
+        else if ( isFL() && isPreNum(e, 'a', n) && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
+        else if (           isPreNum(e, 'x', n) && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
+        else if (           isPreNum(e, 'y', n) && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
         else if (           e.length > 0        && isNul(this._cl.id))         this._cl.id         = e;
         cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -773,9 +773,9 @@ Imported[Community.Lighting.name] = true;
 *               that will be cycled through before repeating from the beginning:
 *               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
 *               fadeDuration and growRadius are optional argument used to transition between colors
-*               and radius sizes over the provided cycle interval.
-*               In Terrax Lighting, there was a hard limit of 4, but now you can use
-*               as many as you want. [optional]
+*               and radius sizes over the provided cycle interval. If growRadius is not provided
+*               the default radius is used for the given color. In Terrax Lighting, there was a hard
+*               limit of 4, but now you can use as many as you want. [optional]
 * - color       #ffffff, #ff0000, etc
 * - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
@@ -795,17 +795,20 @@ Imported[Community.Lighting.name] = true;
 * - Same as Light params above, but adds a subtle flicker
 *
 * Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color onDuration [fadeDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
 * - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
 * - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
-*             that will be cycled through before repeating from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15 on someId d3>
-*             fadeDuration is an optional argument used to transition between colors
-*             over the provided cycle interval.
-*             There's no limit to how many colors can be cycled. [optional]
+* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
+*             grow_bw tuples to follow that will be cycled through before repeating
+*             from the beginning:
+*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
+*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
+*             transition between colors and beam lengths & widths over the provided
+*             cycle interval. If grow_bl or grow_bw are not provided, the default
+*             length or width is used for the given color. There's no limit to how
+*             many colors can be cycled. [optional]
 * - color     #ffffff, #ff0000, etc
 * - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day       Sets the event's light to only show during the day [optional]
@@ -839,6 +842,10 @@ Imported[Community.Lighting.name] = true;
 * Creates a fire that only lights up at night.
 *
 * <cl: Flashlight l8 w12 #ff0000 on asdf>
+* Creates a flashlight beam with id asdf which can be turned on or off via
+* plugin commands.
+*
+* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
@@ -1678,7 +1685,7 @@ class Delta {
       let isPrefix     = (x, ...a) => { for (let i of a) if (x.slice(0, i.length).equalsIC(i)) return true; return false; };
       let isUndef      = (x)       => x === undefined;
       let cycleLast    = ()        => colorCycle[colorCycle.length - 1]; // get last element of cycle array
-      let cycleIndex = -1;
+      let cycleIndex   = -1;
       let colorCycle, p;
       tagData.forEach((e, i) => {
         if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius           = +e;

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1634,7 +1634,7 @@ class Delta {
   };
   $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
   $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
-  $$.seconds = () => $gameVariables.GetDaynightSeconds() % 60;
+  $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
   $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
@@ -1682,7 +1682,7 @@ class Delta {
     if (this._clType) {
       let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
       let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
-      let isPre     = (x, ...a) => { for (let i of a) if (x.slice(0, i.length).equalsIC(i)) return true; return false; };
+      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
       let isUndef      = (x)       => x === undefined;
       let cycleLast    = ()        => colorCycle[colorCycle.length - 1]; // get last element of cycle array
       let cycleIndex   = -1;
@@ -3197,7 +3197,6 @@ class Delta {
 Community.Lighting.distance = function (x1, y1, x2, y2) {
   return Math.abs(Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2)));
 };
-
 Game_Variables.prototype.SetActiveRadius = function (value) {
   this._Player_Light_Radius = orNaN(+value);
 };
@@ -3205,7 +3204,6 @@ Game_Variables.prototype.GetActiveRadius = function () {
   if (this._Player_Light_Radius >= 0) return this._Player_Light_Radius;
   return Number(Community.Lighting.parameters['Lights Active Radius']) || 0;
 };
-
 Game_Variables.prototype.GetFirstRun = function () {
   if (typeof this._Community_Lighting_FirstRun === 'undefined') {
     this._Community_Lighting_FirstRun = true;
@@ -3224,7 +3222,6 @@ Game_Variables.prototype.GetScriptActive = function () {
 Game_Variables.prototype.SetScriptActive = function (value) {
   this._Community_Lighting_ScriptActive = value;
 };
-
 Game_Variables.prototype.GetOldMapId = function () {
   if (typeof this._Community_Lighting_OldMapId === 'undefined') {
     this._Community_Lighting_OldMapId = 0;
@@ -3357,7 +3354,7 @@ Game_Variables.prototype.GetDaynightSpeed = function () {
   return orNullish(Number(Community.Lighting.parameters['Daynight Initial Speed']), 10);
 };
 Game_Variables.prototype.GetDaynightTick = function () {
-  return Math.floor(60 / this.GetDaynightSpeed());
+  return 60 / this.GetDaynightSpeed();
 };
 Game_Variables.prototype.SetDaynightSeconds = function (value) {
   this._Community_Lighting_DaynightSeconds = orNaN(+value);

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2170,9 +2170,10 @@ class ColorDelta {
     return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
-    if (!this._clSwitch) return this._clOnOff;
-    return (this._clSwitch.equalsIC("night") &&  $$.isNight()) ||
-           (this._clSwitch.equalsIC("day")   && !$$.isNight());
+    if (!this._clSwitch) return orNullish(this._clCondLight.enabled, this._clOnOff);
+    return orNullish(this._clCondLight.enabled,
+                    (this._clSwitch.equalsIC("night") && $$.isNight()) ||
+                    (this._clSwitch.equalsIC("day")   && !$$.isNight()));
   };
   Game_Event.prototype.getLightCycle = function () {
     if (this._clType === undefined) this.initLightData();
@@ -3434,7 +3435,7 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
+      if (condLight) { condLight.currentColor = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1533,20 +1533,20 @@ class LightProperties {
     // properties with no suffix 'clear' the target
     properties.forEach((e) => {
       // clear checks (back to initial value for the given property)
-      if      (        e.equalsIC('t'))        this.transitionDuration = 0;
-      else if (        e.equalsIC('p'))        this.pauseDuration      = 0;
-      else if (        e.equalsIC('#'))        this.color      = void (0);
-      else if (        e.equalsIC('a#'))       this.color      = void (0);
-      else if (        e.equalsIC('e'))        this.enable     = void (0);
-      else if (        e.equalsIC('b'))        this.brightness = void (0);
-      else if (        e.equalsIC('x'))        this.xOffset    = void (0);
-      else if (        e.equalsIC('y'))        this.yOffset    = void (0);
-      else if (isOL && e.equalsIC('r'))        this.radius     = void (0);
-      else if (isFL && e.equalsIC('l'))        this.beamLength = void (0);
-      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void (0);
-      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void (0);
-      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void (0);
+      if      (        e.equalsIC('t'))  { this.transitionDuration = 0; return; }
+      else if (        e.equalsIC('p'))  { this.pauseDuration      = 0; return; }
+      else if (        e.equalsIC('#'))  { this.color      = void (0); return; }
+      else if (        e.equalsIC('a#')) { this.color      = void (0); return; }
+      else if (        e.equalsIC('e'))  { this.enable     = void (0); return; }
+      else if (        e.equalsIC('b'))  { this.brightness = void (0); return; }
+      else if (        e.equalsIC('x'))  { this.xOffset    = void (0); return; }
+      else if (        e.equalsIC('y'))  { this.yOffset    = void (0); return; }
+      else if (isOL && e.equalsIC('r'))  { this.radius     = void (0); return; }
+      else if (isFL && e.equalsIC('l'))  { this.beamLength = void (0); return; }
+      else if (isFL && e.equalsIC('w'))  { this.beamWidth  = void (0); return; }
+      else if (isFL && e.equalsIC('a'))  { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('+a')) { this.clockwise  = this.direction = void (0); return; }
+      else if (isFL && e.equalsIC('-a')) { this.clockwise  = this.direction = void (0); return; }
 
       // parse suffix (individual & random ranges)
       let suffix, rand = (min, max) => Math.random() * (max - min) + min;
@@ -2154,7 +2154,7 @@ class ColorDelta {
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
       this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
-      this._cl.enable        = orBoolean(this._cl.enable, true);
+      this._cl.enable        = orBoolean(this._cl.enable, this._cl.id ? false : true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
       this._cl.id            = orNullish(this._cl.id, 0); // Alphanumeric

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -923,7 +923,8 @@ Imported[Community.Lighting.name] = true;
 * See the Plugin Commands section for more details.
 *
 * Ranges can be used if random values are desired. Cycle tags are statically generated at map
-* load. If dynamically random property values are desired, use the 'light cond' command instead.
+* load. If dynamic random property values are desired, use the 'light cond' command instead in
+* combination with the 'light wait' command.
 * See the table below for property specific formatting.
 *
 * The following table shows supported properties:

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1298,27 +1298,28 @@ class VRGBA {
 class ConditionalLight {
   /**
    * Creates a ConditionalLight object with the provided parameters
-   * @param {VRGBA}  cColor
-   * @param {Number} cDirection
-   * @param {Number} cBrightness
-   * @param {Number} cXOffset
-   * @param {Number} cYOffset
-   * @param {Number} cRadius
-   * @param {Number} cBeamLength
-   * @param {Number} cBeamWidth
+   * @param {VRGBA}  currentColor
+   * @param {Number} currentDirection
+   * @param {Number} currentBrightness
+   * @param {Number} currentXOffset
+   * @param {Number} currentYOffset
+   * @param {Number} currentRadius
+   * @param {Number} currentBeamLength
+   * @param {Number} currentBeamWidth
    **/
-  constructor(cColor, cDirection, cBrightness, cXOffset, cYOffset, cRadius, cBeamLength, cBeamWidth) {
+  constructor(currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
+              currentBeamLength, currentBeamWidth) {
     if (arguments.length == 0) return;
-    this.fDuration   = 0;
-    this.pDuration   = 0;
-    this.cColor      = cColor;
-    this.cDirection  = cDirection;
-    this.cBrightness = cBrightness;
-    this.cXOffset    = cXOffset;
-    this.cYOffset    = cYOffset;
-    this.cRadius     = cRadius;
-    this.cBeamLength = cBeamLength;
-    this.cBeamWidth  = cBeamWidth;
+    this.fadeDuration      = 0;
+    this.pauseDuration     = 0;
+    this.currentColor      = currentColor;
+    this.currentDirection  = currentDirection;
+    this.currentBrightness = currentBrightness;
+    this.currentXOffset    = currentXOffset;
+    this.currentYOffset    = currentYOffset;
+    this.currentRadius     = currentRadius;
+    this.currentBeamLength = currentBeamLength;
+    this.currentBeamWidth  = currentBeamWidth;
   }
 
   /**
@@ -1328,58 +1329,59 @@ class ConditionalLight {
   clone() {
     let that = new ConditionalLight();
     // clone durations
-    if (this.fDuration   != null) that.fDuration   = this.fDuration;
-    if (this.pDuration   != null) that.pDuration   = this.pDuration;
+    if (this.fadeDuration      != null) that.fadeDuration      = this.fadeDuration;
+    if (this.pauseDuration     != null) that.pauseDuration     = this.pauseDuration;
     // clone currents
-    if (this.cColor      != null) that.cColor      = this.cColor.clone();
-    if (this.cDirection  != null) that.cDirection  = this.cDirection;
-    if (this.cBrightness != null) that.cBrightness = this.cBrightness;
-    if (this.cXOffset    != null) that.cXOffset    = this.cXOffset;
-    if (this.cYOffset    != null) that.cYOffset    = this.cYOffset;
-    if (this.cRadius     != null) that.cRadius     = this.cRadius;
-    if (this.cBeamLength != null) that.cBeamLength = this.cBeamLength;
-    if (this.cBeamWidth  != null) that.cBeamWidth  = this.cBeamWidth;
+    if (this.currentColor      != null) that.currentColor      = this.currentColor.clone();
+    if (this.currentDirection  != null) that.currentDirection  = this.currentDirection;
+    if (this.currentBrightness != null) that.currentBrightness = this.currentBrightness;
+    if (this.currentXOffset    != null) that.currentXOffset    = this.currentXOffset;
+    if (this.currentYOffset    != null) that.currentYOffset    = this.currentYOffset;
+    if (this.currentRadius     != null) that.currentRadius     = this.currentRadius;
+    if (this.currentBeamLength != null) that.currentBeamLength = this.currentBeamLength;
+    if (this.currentBeamWidth  != null) that.currentBeamWidth  = this.currentBeamWidth;
     // clone targets
-    if (this.tColor      != null) that.tColor      = this.tColor.clone();
-    if (this.tDirection  != null) that.tDirection  = this.tDirection;
-    if (this.tBrightness != null) that.tBrightness = this.tBrightness;
-    if (this.tXOffset    != null) that.tXOffset    = this.tXOffset;
-    if (this.tYOffset    != null) that.tYOffset    = this.tYOffset;
-    if (this.tRadius     != null) that.tRadius     = this.tRadius;
-    if (this.tBeamLength != null) that.tBeamLength = this.tBeamLength;
-    if (this.tBeamWidth  != null) that.tBeamWidth  = this.tBeamWidth;
+    if (this.targetColor       != null) that.targetColor       = this.targetColor.clone();
+    if (this.targetDirection   != null) that.targetDirection   = this.targetDirection;
+    if (this.targetBrightness  != null) that.targetBrightness  = this.targetBrightness;
+    if (this.targetXOffset     != null) that.targetXOffset     = this.targetXOffset;
+    if (this.targetYOffset     != null) that.targetYOffset     = this.targetYOffset;
+    if (this.targetRadius      != null) that.targetRadius      = this.targetRadius;
+    if (this.targetBeamLength  != null) that.targetBeamLength  = this.targetBeamLength;
+    if (this.targetBeamWidth   != null) that.targetBeamWidth   = this.targetBeamWidth;
     // clone deltas
-    if (this.dColor      != null) that.dColor      = this.dColor     .clone();
-    if (this.dDirection  != null) that.dDirection  = this.dDirection .clone();
-    if (this.dBrightness != null) that.dBrightness = this.dBrightness.clone();
-    if (this.dXOffset    != null) that.dXOffset    = this.dXOffset   .clone();
-    if (this.dYOffset    != null) that.dYOffset    = this.dYOffset   .clone();
-    if (this.dRadius     != null) that.dRadius     = this.dRadius    .clone();
-    if (this.dBeamLength != null) that.dBeamLength = this.dBeamLength.clone();
-    if (this.dBeamWidth  != null) that.dBeamWidth  = this.dBeamWidth .clone();
+    if (this.deltaColor        != null) that.deltaColor        = this.deltaColor     .clone();
+    if (this.deltaDirection    != null) that.deltaDirection    = this.deltaDirection .clone();
+    if (this.deltaBrightness   != null) that.deltaBrightness   = this.deltaBrightness.clone();
+    if (this.deltaXOffset      != null) that.deltaXOffset      = this.deltaXOffset   .clone();
+    if (this.deltaYOffset      != null) that.deltaYOffset      = this.deltaYOffset   .clone();
+    if (this.deltaRadius       != null) that.deltaRadius       = this.deltaRadius    .clone();
+    if (this.deltaBeamLength   != null) that.deltaBeamLength   = this.deltaBeamLength.clone();
+    if (this.deltaBeamWidth    != null) that.deltaBeamWidth    = this.deltaBeamWidth .clone();
     return that;
   }
 
   /**
    * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
-   * @param {VRGBA}  tColor
-   * @param {Number} tDirection
-   * @param {Number} tBrightness
-   * @param {Number} tXOffset
-   * @param {Number} tYOffset
-   * @param {Number} tRadius
-   * @param {Number} tBeamLength
-   * @param {Number} tBeamWidth
+   * @param {VRGBA}  targetColor
+   * @param {Number} targetDirection
+   * @param {Number} targetBrightness
+   * @param {Number} targetXOffset
+   * @param {Number} targetYOffset
+   * @param {Number} targetRadius
+   * @param {Number} targetBeamLength
+   * @param {Number} targetBeamWidth
    */
-  setTargets(tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
-    this.tColor      = tColor;
-    this.tDirection  = tDirection;
-    this.tBrightness = tBrightness;
-    this.tXOffset    = tXOffset;
-    this.tYOffset    = tYOffset;
-    this.tRadius     = tRadius;
-    this.tBeamLength = tBeamLength;
-    this.tBeamWidth  = tBeamWidth;
+  setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
+             targetBeamLength, targetBeamWidth) {
+    this.targetColor      = targetColor;
+    this.targetDirection  = targetDirection;
+    this.targetBrightness = targetBrightness;
+    this.targetXOffset    = targetXOffset;
+    this.targetYOffset    = targetYOffset;
+    this.targetRadius     = targetRadius;
+    this.targetBeamLength = targetBeamLength;
+    this.targetBeamWidth  = targetBeamWidth;
   }
 
   /**
@@ -1387,10 +1389,10 @@ class ConditionalLight {
    * @param {String[]} properties
    **/
   parseDurationProps(properties) {
-    let fDuration  = properties.find((e) => (e.startsWithIC('f')));
-    let pDuration  = properties.find((e) => (e.startsWithIC('p')));
-    this.fDuration = fDuration ? +fDuration.slice(1) : 0;
-    this.pDuration = pDuration ? +pDuration.slice(1) : 0;
+    this.fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
+    this.pauseDuration = properties.find((e) => (e.startsWithIC('p')));
+    this.fadeDuration  = this.fadeDuration  ? +this.fadeDuration.slice(1)  : 0;
+    this.pauseDuration = this.pauseDuration ? +this.pauseDuration.slice(1) : 0;
   }
 
   /**
@@ -1399,17 +1401,17 @@ class ConditionalLight {
    **/
   parseCurrentProps(properties) {
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.cColor      = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.cColor      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.cDirection  = Math.PI / 180 * orNaN(+e.slice(1), 0);
-      else if (e.startsWithIC('+a')) this.cDirection  = Math.PI / 180 * orNaN(+e.slice(2), 0);
-      else if (e.startsWithIC('-a')) this.cDirection  = Math.PI / 180 * orNaN(+e.slice(2), 0);
-      else if (e.startsWithIC('b'))  this.cBrightness = orNaN(+e.slice(1));
-      else if (e.startsWithIC('x'))  this.cXOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('y'))  this.cYOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('r'))  this.cRadius     = orNaN(+e.slice(1));
-      else if (e.startsWithIC('l'))  this.cBeamLength = orNaN(+e.slice(1));
-      else if (e.startsWithIC('w'))  this.cBeamWidth  = orNaN(+e.slice(1));
+      if      (e.startsWithIC('#'))  this.currentColor      = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.currentColor      = new VRGBA(e);
+      else if (e.startsWithIC('a'))  this.currentDirection  = Math.PI / 180 * orNaN(+e.slice(1), 0);
+      else if (e.startsWithIC('+a')) this.currentDirection  = Math.PI / 180 * orNaN(+e.slice(2), 0);
+      else if (e.startsWithIC('-a')) this.currentDirection  = Math.PI / 180 * orNaN(+e.slice(2), 0);
+      else if (e.startsWithIC('b'))  this.currentBrightness = orNaN(+e.slice(1));
+      else if (e.startsWithIC('x'))  this.currentXOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('y'))  this.currentYOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('r'))  this.currentRadius     = orNaN(+e.slice(1));
+      else if (e.startsWithIC('l'))  this.currentBeamLength = orNaN(+e.slice(1));
+      else if (e.startsWithIC('w'))  this.currentBeamWidth  = orNaN(+e.slice(1));
     }, this);
   }
 
@@ -1420,29 +1422,27 @@ class ConditionalLight {
   parseTargetProps(properties) {
     let normalizeAngle = (rads) => rads % (2 * Math.PI) + (rads < 0) * 2 * Math.PI; // normalize between 0 & 2*Pi
     let normalizeClockwiseMovement = (target) => {
-      this.cDirection = normalizeAngle(this.cDirection); // normalize already assigned current
-      this.tDirection = normalizeAngle(Math.PI / 180 * target); // convert target to radians before normalization
-      if (this.cDirection > this.tDirection) this.tDirection += 2 * Math.PI; // normalize for clockwise movement
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(Math.PI / 180 * target); // convert target to radians before normalization
+      if (this.currentDirection > this.targetDirection) this.targetDirection += 2 * Math.PI; // clockwise normalize
     };
     let normalizeCounterClockwiseMovement = (target) => {
-      this.cDirection = normalizeAngle(this.cDirection); // normalize already assigned current
-      this.tDirection = normalizeAngle(Math.PI / 180 * target); // convert target to radians before normalization
-      if (this.cDirection < this.tDirection) {
-        this.tDirection -= 2 * Math.PI; // normalize for counterclockwise movement
-      }
+      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
+      this.targetDirection  = normalizeAngle(Math.PI / 180 * target); // convert target to radians before normalization
+      if (this.currentDirection < this.targetDirection) this.targetDirection -= 2 * Math.PI; // c-clockwise normalize
     };
     properties.forEach((e) => {
-      if (e.startsWithIC('#'))       this.tColor = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.tColor = new VRGBA(e);
+      if (e.startsWithIC('#'))       this.targetColor = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
       else if (e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
       else if (e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
       else if (e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
-      else if (e.startsWithIC('b'))  this.tBrightness = orNaN(+e.slice(1));
-      else if (e.startsWithIC('x'))  this.tXOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('y'))  this.tYOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('r'))  this.tRadius     = orNaN(+e.slice(1));
-      else if (e.startsWithIC('l'))  this.tBeamLength = orNaN(+e.slice(1));
-      else if (e.startsWithIC('w'))  this.tBeamWidth  = orNaN(+e.slice(1));
+      else if (e.startsWithIC('b'))  this.targetBrightness = orNaN(+e.slice(1));
+      else if (e.startsWithIC('x'))  this.targetXOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('y'))  this.targetYOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('r'))  this.targetRadius     = orNaN(+e.slice(1));
+      else if (e.startsWithIC('l'))  this.targetBeamLength = orNaN(+e.slice(1));
+      else if (e.startsWithIC('w'))  this.targetBeamWidth  = orNaN(+e.slice(1));
     }, this);
   }
 
@@ -1453,24 +1453,24 @@ class ConditionalLight {
     let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
     let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
     // assign deltas if current & targets exist
-    this.dColor      = createColor (this.cColor,      this.tColor,      this.fDuration);
-    this.dColor      = createColor (this.cColor,      this.tColor,      this.fDuration);
-    this.dDirection  = createNumber(this.cDirection,  this.tDirection,  this.fDuration);
-    this.dBrightness = createNumber(this.cBrightness, this.tBrightness, this.fDuration);
-    this.dXOffset    = createNumber(this.cXOffset,    this.tXOffset,    this.fDuration);
-    this.dYOffset    = createNumber(this.cYOffset,    this.tYOffset,    this.fDuration);
-    this.dRadius     = createNumber(this.cRadius,     this.tRadius,     this.fDuration);
-    this.dBeamLength = createNumber(this.cBeamLength, this.tBeamLength, this.fDuration);
-    this.dBeamWidth  = createNumber(this.cBeamWidth,  this.tBeamWidth,  this.fDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.fadeDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.fadeDuration);
+    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.fadeDuration);
+    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.fadeDuration);
+    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.fadeDuration);
+    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.fadeDuration);
+    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.fadeDuration);
+    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.fadeDuration);
+    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.fadeDuration);
     // assign new currents for existing deltas (to propagate currents for duration = 0)
-    if (this.dColor      != null) this.cColor      = this.dColor     .get();
-    if (this.dDirection  != null) this.cDirection  = this.dDirection .get();
-    if (this.dBrightness != null) this.cBrightness = this.dBrightness.get();
-    if (this.dXOffset    != null) this.cXOffset    = this.dXOffset   .get();
-    if (this.dYOffset    != null) this.cYOffset    = this.dYOffset   .get();
-    if (this.dRadius     != null) this.cRadius     = this.dRadius    .get();
-    if (this.dBeamLength != null) this.cBeamLength = this.dBeamLength.get();
-    if (this.dBeamWidth  != null) this.cBeamWidth  = this.dBeamWidth .get();
+    if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
+    if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
+    if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.get();
+    if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .get();
+    if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .get();
+    if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .get();
+    if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.get();
+    if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .get();
   }
 
   /**
@@ -1479,18 +1479,18 @@ class ConditionalLight {
    */
   next() {
     if (this.finished()) return this;
-    if (this.fDuration > 0) { // only update if fade duration isn't 0
-      if (this.dColor      != null) this.cColor      = this.dColor     .next().get();
-      if (this.dDirection  != null) this.cDirection  = this.dDirection .next().get();
-      if (this.dBrightness != null) this.cBrightness = this.dBrightness.next().get();
-      if (this.dXOffset    != null) this.cXOffset    = this.dXOffset   .next().get();
-      if (this.dYOffset    != null) this.cYOffset    = this.dYOffset   .next().get();
-      if (this.dRadius     != null) this.cRadius     = this.dRadius    .next().get();
-      if (this.dBeamLength != null) this.cBeamLength = this.dBeamLength.next().get();
-      if (this.dBeamWidth  != null) this.cBeamWidth  = this.dBeamWidth .next().get();
-      this.fDuration--;
+    if (this.fadeDuration > 0) { // only update if fade duration isn't 0
+      if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
+      if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
+      if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
+      if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .next().get();
+      if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .next().get();
+      if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
+      if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
+      if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
+      this.fadeDuration--;
     } else
-      this.pDuration--;
+      this.pauseDuration--;
     return this;
   }
 
@@ -1498,7 +1498,7 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() { return this.fDuration <= 0 && this.pDuration <= 0; }
+  finished() { return this.fadeDuration <= 0 && this.pauseDuration <= 0; }
 }
 
 /**
@@ -1578,22 +1578,22 @@ class ColorDelta {
    * whether to consider the remaining ticks or not for speed purposes.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
-   * @param {Number} fDuration
+   * @param {Number} fadeDuration
    * @param {Number} useTicksRemaining
    * @returns {ColorDelta}
    */
-  constructor(start, target = start, fDuration = 0, useTicksRemaining = false) {
+  constructor(start, target = start, fadeDuration = 0, useTicksRemaining = false) {
     if (arguments.length == 0) return;
-    this.current    = start.clone();           // - deep copy
-    this.target     = target.clone();          // - deep copy
-    this.fDuration  = orNaN(fDuration, 0);     // - use the remaining time (of the hour) or total fade duration
-    fDuration      -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
-    this.lazyEqual  = false;                   // - true when current value == target value
-    this.delta      = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
-                               (this.target.r - this.current.r) / fDuration,
-                               (this.target.g - this.current.g) / fDuration,
-                               (this.target.b - this.current.b) / fDuration,
-                               (this.target.a - this.current.a) / fDuration);
+    this.current       = start.clone();           // - deep copy
+    this.target        = target.clone();          // - deep copy
+    this.fadeDuration  = orNaN(fadeDuration, 0);  // - use the remaining time (of the hour) or total fade duration
+    this.fadeDuration -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.lazyEqual     = false;                   // - true when current value == target value
+    this.delta         = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                  (this.target.r - this.current.r) / this.fadeDuration,
+                                  (this.target.g - this.current.g) / this.fadeDuration,
+                                  (this.target.b - this.current.b) / this.fadeDuration,
+                                  (this.target.a - this.current.a) / this.fadeDuration);
     this.finished(); // check for duration = 0
   }
   /**
@@ -1602,11 +1602,11 @@ class ColorDelta {
    **/
   clone() {
     let that = new  ColorDelta();
-    that.current    = this.current.clone();
-    that.target     = this.target.clone();
-    that.fDuration  = this.fDuration;
-    that.lazyEquals = this.lazyEquals;
-    that.delta      = this.delta.clone();
+    that.current      = this.current.clone();
+    that.target       = this.target.clone();
+    that.fadeDuration = this.fadeDuration;
+    that.lazyEquals   = this.lazyEquals;
+    that.delta        = this.delta.clone();
     return that;
   }
 
@@ -1614,31 +1614,31 @@ class ColorDelta {
    * Creates a light delta from the start color, target color, and fade duration.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
-   * @param {Number} fDuration
+   * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static create(start, target, fDuration) {
-    return new ColorDelta(start, target, fDuration, false /* don't use remaining ticks */);
+  static create(start, target, fadeDuration) {
+    return new ColorDelta(start, target, fadeDuration, false /* don't use remaining ticks */);
   }
 
   /**
    * Creates a map color delta from the current map tint, target tint, and fade duration.
    * @param {VRGBA}  targetTint
-   * @param {Number} fDuration
+   * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createTint(targetTint, fDuration = 0) {
-    return new ColorDelta($gameVariables.GetTint(), targetTint, fDuration);
+  static createTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration);
   }
 
   /**
    * Creates a battle color delta from the current battle tint, target tint, and fade duration.
    * @param {VRGBA}  targetTint
-   * @param {Number} fDuration
+   * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createBattleTint(targetTint, fDuration = 0) {
-    return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fDuration);
+  static createBattleTint(targetTint, fadeDuration = 0) {
+    return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration);
   }
 
   /**
@@ -1649,14 +1649,14 @@ class ColorDelta {
    * @returns {ColorDelta}
    */
   static createTimeTint(useCurrentTint = true) {
-    let fDuration = 60 * $gameVariables.GetDaynightSpeed(); // fade duration
+    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed(); // fade duration
     if (useCurrentTint) { // delta should fade from current color to target
-      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fDuration, true);
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, true);
     } else {              // start color should be the color it would normally be at the given time
       let CL = Community.Lighting; // reference CL
-      let ticks    = fDuration == 0 ? CL.minutes() * 60 + CL.seconds() : CL.ticks();
-      fDuration = fDuration == 0 ? 60 * 60 : fDuration; // dur = 0 needs a ref speed to compute the start color
-      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fDuration);
+      let ticks    = fadeDuration == 0 ? CL.minutes() * 60 + CL.seconds() : CL.ticks();
+      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // dur = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration);
       delta.next(ticks); // get current color based off of ticks elapsed in hour
       return delta;
     }
@@ -1670,13 +1670,13 @@ class ColorDelta {
    */
   next(scale = 1) {
     if (this.finished()) return this; // lazy-short-circuit
-    let c = this.current, t = this.target, d = this.delta; // reference
-    if(c.v != t.v) c.v = t.v;  // Compute next step and clamp to target, check to avoid recomputing
-    if(c.r != t.r) c.r = Math.minmax(d.r > 0, c.r + scale * d.r, t.r);
-    if(c.g != t.g) c.g = Math.minmax(d.g > 0, c.g + scale * d.g, t.g);
-    if(c.b != t.b) c.b = Math.minmax(d.b > 0, c.b + scale * d.b, t.b);
-    if(c.a != t.a) c.a = Math.minmax(d.a > 0, c.a + scale * d.a, t.a);
-    this.fDuration -= 1;
+    let current = this.current, target = this.target, delta = this.delta; // reference
+    if(current.v != target.v) current.v = target.v;  // Compute next step & clamp to target, check to avoid recomputing
+    if(current.r != target.r) current.r = Math.minmax(delta.r > 0, current.r + scale * delta.r, target.r);
+    if(current.g != target.g) current.g = Math.minmax(delta.g > 0, current.g + scale * delta.g, target.g);
+    if(current.b != target.b) current.b = Math.minmax(delta.b > 0, current.b + scale * delta.b, target.b);
+    if(current.a != target.a) current.a = Math.minmax(delta.a > 0, current.a + scale * delta.a, target.a);
+    this.fadeDuration -= 1;
     return this;
   }
 
@@ -1692,7 +1692,7 @@ class ColorDelta {
    */
   finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
-    if ((this.lazyEquals = this.fDuration <= 0)) return (this.current = this.target, true);
+    if ((this.lazyEquals = this.fadeDuration <= 0)) return (this.current = this.target, true);
     return false;
    }
 }
@@ -1737,12 +1737,12 @@ class ColorDelta {
   };
 
   const TileLightType = {
-    tilelight:   [TileType.Terrain,   LightType.Light],
-    tilefire:    [TileType.Terrain,   LightType.Fire],
-    tileglow:    [TileType.Terrain,   LightType.Glow],
-    regionlight: [TileType.Region, LightType.Light],
-    regionfire:  [TileType.Region, LightType.Fire],
-    regionglow:  [TileType.Region, LightType.Glow],
+    tilelight:   [TileType.Terrain, LightType.Light],
+    tilefire:    [TileType.Terrain, LightType.Fire],
+    tileglow:    [TileType.Terrain, LightType.Glow],
+    regionlight: [TileType.Region,  LightType.Light],
+    regionfire:  [TileType.Region,  LightType.Fire],
+    regionglow:  [TileType.Region,  LightType.Glow],
   };
 
   const TileBlockType = {
@@ -1793,22 +1793,22 @@ class ColorDelta {
   let light_tiles = [];
   let block_tiles = [];
 
-  let parameters = $$.parameters;
-  let lightMaskPadding = Number(parameters["Lightmask Padding"]) || 0;
-  let useSmootherLights = orBoolean(parameters['Use smoother lights'], false);
-  let light_event_required = orBoolean(parameters["Light event required"], false);
-  let triangular_flashlight = orBoolean(parameters["Triangular flashlight"], false);
-  let shift_lights_with_events = orBoolean(parameters['Shift lights with events'], false);
-  let player_radius = Number(parameters['Player radius']) || 0;
-  let reset_each_map = orBoolean(parameters['Reset Lights'], false);
-  let noteTagKey = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
-  let dayNightSaveSeconds = Number(parameters['Save DaynightSeconds']) || 0;
-  let dayNightSaveNight = Number(parameters["Save Night Switch"]) || 0;
-  let dayNightNoAutoshadow = orBoolean(parameters["No Autoshadow During Night"], false);
-  let hideAutoShadow = false;
-  let daynightCycleEnabled = orBoolean(parameters['Daynight Cycle'], true);
-  let daynightTintEnabled = false;
-  let dayNightList = (function (dayNight, nightHours) {
+  let parameters                = $$.parameters;
+  let lightMaskPadding          = +parameters["Lightmask Padding"] || 0;
+  let useSmootherLights         = orBoolean(parameters['Use smoother lights'], false);
+  let light_event_required      = orBoolean(parameters["Light event required"], false);
+  let triangular_flashlight     = orBoolean(parameters["Triangular flashlight"], false);
+  let shift_lights_with_events  = orBoolean(parameters['Shift lights with events'], false);
+  let player_radius             = +parameters['Player radius'] || 0;
+  let reset_each_map            = orBoolean(parameters['Reset Lights'], false);
+  let noteTagKey                = parameters["Note Tag Key"] !== "" ? parameters["Note Tag Key"] : false;
+  let dayNightSaveSeconds       = +parameters['Save DaynightSeconds'] || 0;
+  let dayNightSaveNight         = +parameters["Save Night Switch"] || 0;
+  let dayNightNoAutoshadow      = orBoolean(parameters["No Autoshadow During Night"], false);
+  let hideAutoShadow            = false;
+  let daynightCycleEnabled      = orBoolean(parameters['Daynight Cycle'], true);
+  let daynightTintEnabled       = false;
+  let dayNightList              = (function (dayNight, nightHours) {
     let result = [];
     try {
       dayNight = JSON.parse(dayNight);
@@ -1955,7 +1955,6 @@ class ColorDelta {
     this._clType = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._clType) {
-      let t = this;
       let isFL     = ()        => this._clType.is(LightType.Flashlight); // is flashlight
       let isEq     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
       let isPre    = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
@@ -1963,25 +1962,25 @@ class ColorDelta {
       let clip     = (e)       => +e.slice(1); // clip prefix & convert to number
       let hasCycle = false;
       tagData.forEach((e) => {
-        if      (!isFL() && !isNaN(+e)              && isNul(t._clRadius))     t._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)              && isNul(t._clBeamLength)) t._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)              && isNul(t._clBeamWidth))  t._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l")           && isNul(t._clBeamLength)) t._clBeamLength = clip(e);
-        else if (isFL()  && isPre(e, "w")           && isNul(t._clBeamWidth))  t._clBeamWidth  = clip(e);
-        else if (           isEq(e, "cycle")        && isNul(t._clColor))      hasCycle        = true;
-        else if (           isPre(e, "#", "a#")     && isNul(t._clColor))      t._clColor      = new VRGBA(e);
-        else if (           isOn(e)                 && isNul(t._clOnOff))      t._clOnOff      = true;
-        else if (           isOff(e)                && isNul(t._clOnOff))      t._clOnOff      = false;
-        else if (           isEq(e, "night", "day") && isNul(t._clSwitch))     t._clSwitch     = e;
-        else if (           isPre(e, "b")           && isNul(t._clBrightness)) t._clBrightness = (clip(e) / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d")           && isNul(t._clDirection))  t._clDirection  = clip(e);
-        else if ( isFL() && !isNaN(+e)              && isNul(t._clDirection))  t._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d")           && isNul(t._clDirection))  t._clDirection  = CLDirectionMap[clip(e)];
-        else if ( isFL() && isPre(e, "a")           && isNul(t._clDirection))  t._clDirection  = Math.PI / 180 * clip(e);
-        else if (           isPre(e, "x")           && isNul(t._clXOffset))    t._clXOffset    = clip(e);
-        else if (           isPre(e, "y")           && isNul(t._clYOffset))    t._clYOffset    = clip(e);
-        else if (           e.length > 0            && isNul(t._clId))         t._clId         = e;
-      });
+        if      (!isFL() && !isNaN(+e)              && isNul(this._clRadius))     this._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)              && isNul(this._clBeamLength)) this._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)              && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l")           && isNul(this._clBeamLength)) this._clBeamLength = clip(e);
+        else if (isFL()  && isPre(e, "w")           && isNul(this._clBeamWidth))  this._clBeamWidth  = clip(e);
+        else if (           isEq(e, "cycle")        && isNul(this._clColor))      hasCycle        = true;
+        else if (           isPre(e, "#", "a#")     && isNul(this._clColor))      this._clColor      = new VRGBA(e);
+        else if (           isOn(e)                 && isNul(this._clOnOff))      this._clOnOff      = true;
+        else if (           isOff(e)                && isNul(this._clOnOff))      this._clOnOff      = false;
+        else if (           isEq(e, "night", "day") && isNul(this._clSwitch))     this._clSwitch     = e;
+        else if (           isPre(e, "b")           && isNul(this._clBrightness)) this._clBrightness = (clip(e) / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d")           && isNul(this._clDirection))  this._clDirection  = clip(e);
+        else if ( isFL() && !isNaN(+e)              && isNul(this._clDirection))  this._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d")           && isNul(this._clDirection))  this._clDirection  = CLDirectionMap[clip(e)];
+        else if ( isFL() && isPre(e, "a")           && isNul(this._clDirection))  this._clDirection  = Math.PI / 180 * clip(e);
+        else if (           isPre(e, "x")           && isNul(this._clXOffset))    this._clXOffset    = clip(e);
+        else if (           isPre(e, "y")           && isNul(this._clYOffset))    this._clYOffset    = clip(e);
+        else if (           e.length > 0            && isNul(this._clId))         this._clId         = e;
+      }, this);
 
       // normalize parameters
       this._clRadius     = this._clRadius || 0;
@@ -1999,9 +1998,8 @@ class ColorDelta {
       // Process cycle parameters
       if (hasCycle && cycleGroups.length) {             // check if tag included color cycling
         this._clCycle = [];                             // only define if cycle exists
-        let t         = this;                           // refer to this as t
-        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius,
-                         t._clBeamLength, t._clBeamWidth];
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
         let condLight = new ConditionalLight(...args);  // create conditional light with initial properties
 
         cycleGroups.forEach((e, i, a) => {              // ------ loop each group
@@ -2022,14 +2020,13 @@ class ColorDelta {
 
       // Process conditional lighting
       if (this._clId) {                                 // check for a conditional lighting ID
-        let t          = this;                          // refer to this as t
-        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius,
-                          t._clBeamLength, t._clBeamWidth];
+        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
+                    this._clRadius, this._clBeamLength, this._clBeamWidth];
         let condLight  = new ConditionalLight(...args); // create conditional light
         condLight.setTargets(...args);                  // create matching targets
         condLight.createDeltas();                       // compute deltas (zeroes)
         $gameVariables.GetLightArray()[this._clId] = condLight;
-        t._clCondLight = condLight;
+        this._clCondLight = condLight;
       }
     }
   };
@@ -2051,20 +2048,20 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cRadius, this._clRadius);
+    return orNullish(this._clCondLight.currentRadius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
     if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.cColor, this._clColor.clone());
+    return orNullish(this._clCondLight.currentColor, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cBrightness, this._clBrightness);
+    return orNullish(this._clCondLight.currentBrightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cDirection, this._clDirection);
+    return orNullish(this._clCondLight.currentDirection, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -2072,19 +2069,19 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cBeamLength, this._clBeamLength);
+    return orNullish(this._clCondLight.currentBeamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cBeamWidth, this._clBeamWidth);
+    return orNullish(this._clCondLight.currentBeamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cXOffset, this._clXOffset);
+    return orNullish(this._clCondLight.currentXOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.cYOffset, this._clYOffset);
+    return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
     if (!this._clSwitch) return this._clOnOff;

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1530,14 +1530,14 @@ class ConditionalLight {
    */
   setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
              targetBeamLength, targetBeamWidth) {
-    this.targetColor      = targetColor;
-    this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
-    this.targetBrightness = targetBrightness;
-    this.targetXOffset    = targetXOffset;
-    this.targetYOffset    = targetYOffset;
-    this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
-    this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
-    this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
+    if (targetColor       != null) this.targetColor      = targetColor;
+    if (targetDirection   != null) this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
+    if (targetBrightness  != null) this.targetBrightness = targetBrightness;
+    if (targetXOffset     != null) this.targetXOffset    = targetXOffset;
+    if (targetYOffset     != null) this.targetYOffset    = targetYOffset;
+    if (targetRadius      != null) this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
+    if (targetBeamLength  != null) this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
+    if (targetBeamWidth   != null) this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
   }
 
   /**
@@ -2042,7 +2042,7 @@ class ColorDelta {
       let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
       let isNul      = (e)       => e == null;
       let isDayNight = (e)       => isEq(e, "night", "day");
-      let clip       = (e)       => orNaN(e.slice(1)); // clip prefix & convert to number or undefined
+      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
         let n = clip(e);

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2230,7 +2230,7 @@ class Delta {
         y1 = y1 + tile.yOffset;
         this._maskBitmaps.FillEllipse(x1, y1, tile.blockWidth, tile.blockHeight, tile.color);
       }
-    });
+    }, this);
     ctxMul.globalCompositeOperation = 'lighter';
 
     // Compute tint for next frame
@@ -3218,7 +3218,7 @@ Game_Variables.prototype.SetRadiusTarget = function (value) {
 };
 Game_Variables.prototype.GetRadiusTarget = function () {
   if (this._Community_Lighting_RadiusTarget == null) {
-    return 150;
+    return this.GetRadius();
   } else {
     return this._Community_Lighting_RadiusTarget;
   }

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1196,36 +1196,33 @@ class VRGBA { // Class to handle volumetric/additive coloring with rgba colors u
    * @param {Number} speed
    * @returns {VRGBA}
    */
-  class PIXI_Container_Extender extends PIXI.Container {
-    computeNextTint(current, target, speed) {
-      if (current.equals(target)) return target; // Already equal so short-circuit
+  PIXI.Container.prototype.computeNextTint = function (current, target, speed) {
+    if (current.equals(target)) return target; // Already equal so short-circuit
 
-      // only compute new delta on target or speed change
-      let delta = get('_tintDelta');
-      if (!delta || testAndSet('_OldTintTarget', target) || testAndSet('_OldTintSpeed', speed)) {
-        // tint delta based off of remainder of time in hour if not battle, daynight cycle, & tint enabled OR 60
-        let useMinutesRemaining = !$gameParty.inBattle() && daynightCycleEnabled && daynightTintEnabled;
-        let minutes = 60 - (useMinutesRemaining ? $$.minutes() : 0);
-        // Get deltas for each color.
-        delta = new VRGBA(target.v, // divide by zero is +inf or -inf so deltas work for speed = 0
-          (target.r - current.r) / (minutes * speed),
-          (target.g - current.g) / (minutes * speed),
-          (target.b - current.b) / (minutes * speed),
-          (target.a - current.a) / (minutes * speed));
+    // only compute new delta on target or speed change
+    let delta = get('_tintDelta');
+    if (!delta || testAndSet('_OldTintTarget', target) || testAndSet('_OldTintSpeed', speed)) {
+      // tint delta based off of remainder of time in hour if not battle, daynight cycle, & tint enabled OR 60
+      let useMinutesRemaining = !$gameParty.inBattle() && daynightCycleEnabled && daynightTintEnabled;
+      let minutes = 60 - (useMinutesRemaining ? $$.minutes() : 0);
+      // Get deltas for each color.
+      delta = new VRGBA(target.v, // divide by zero is +inf or -inf so deltas work for speed = 0
+        (target.r - current.r) / (minutes * speed),
+        (target.g - current.g) / (minutes * speed),
+        (target.b - current.b) / (minutes * speed),
+        (target.a - current.a) / (minutes * speed));
 
-        set('_tintDelta', delta); // set new tint.
-      }
-
-      // Compute next color step and clamp to target
-      let out = new VRGBA(delta.v, current.r + delta.r, current.g + delta.g, current.b + delta.b, current.a + delta.a);
-      out.r = Math.minmax(out.r > current.r, out.r, target.r);
-      out.g = Math.minmax(out.g > current.g, out.g, target.g);
-      out.b = Math.minmax(out.b > current.b, out.b, target.b);
-      out.a = Math.minmax(out.a > current.a, out.a, target.a);
-      return out;
+      set('_tintDelta', delta); // set new tint.
     }
-  }
-  PIXI.Container.prototype = PIXI_Container_Extender.prototype;
+
+    // Compute next color step and clamp to target
+    let out = new VRGBA(delta.v, current.r + delta.r, current.g + delta.g, current.b + delta.b, current.a + delta.a);
+    out.r = Math.minmax(out.r > current.r, out.r, target.r);
+    out.g = Math.minmax(out.g > current.g, out.g, target.g);
+    out.b = Math.minmax(out.b > current.b, out.b, target.b);
+    out.a = Math.minmax(out.a > current.a, out.a, target.a);
+    return out;
+  };
 
   // Map community light directions to polar angles (360 degrees)
   const CLDirectionMap = {

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1306,6 +1306,7 @@ class ConditionalLight {
    **/
   constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
     if (arguments.length == 0) return;
+    this.duration   = 0;
     this.color      = color;
     this.direction  = direction;
     this.brightness = brightness;
@@ -1323,6 +1324,7 @@ class ConditionalLight {
   clone() {
     let that = new ConditionalLight();
     // clone properties
+    if (this.duration   != null) that.duration   = this.duration;
     if (this.color      != null) that.color      = this.color.clone();
     if (this.direction  != null) that.direction  = this.direction;
     if (this.brightness != null) that.brightness = this.brightness;

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -782,11 +782,11 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color [pauseDuration]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color [pauseDuration]>... [enable] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [enable] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
-* - radius      100, 250, etc
+* - radius      Any number, optionally preceded by "R" or "r", so 100, R100, r100, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -797,7 +797,8 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
 * - night       Causes the light to only come on during the night [optional]
 * - brightness  B50, B25, etc [optional]
@@ -808,20 +809,21 @@ Imported[Community.Lighting.name] = true;
 * - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 * - y           y offset [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color [pauseDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight [bl] [bw] [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color [pauseDuration]>... [enable] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight [bl] [bw] [{CycleProps}...] [enable] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - bl:         Beam length:  Any number, optionally preceded by "L" or "l", so 8, L8, l8, etc.
+* - bw:         Beam width:  Any number, optionally preceded by "W", or 'w', so 12, W12, w12, etc.
 * - cycle       Allows any number of color + duration pairs to follow that will be cycled
 *               through before repeating from the beginning. See the examples below for usage.
 *               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
@@ -832,19 +834,21 @@ Imported[Community.Lighting.name] = true;
 *               Lighting section for more details. * Any non-cyclic properties are inherited
 *               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
-* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 * - day         Sets the event's light to only show during the day [optional]
 * - night       Sets the event's light to only show during night time [optional]
 * - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*               Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               Can be preceded by "D" or "d", so D4, d4, etc. If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A" or "a". If
 *               omitted, sdir is used. [optional]
 * - x           x[offset] Work the same as regular light [optional]
 * - y           y[offset] [optional]
 * - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*               These should not be in the format of 'aN', 'bN', dN', 'lN', 'wN' 'xN' or 'yN'
-*               where N is a number otherwise they will be mistaken for one of the previous
-*               optional parameters.
+*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+*               where N is a number following any supported optional parameter prefix
+*               otherwise it will be mistaken for one of the previous optional parameters.
+*               Generally, it is adviseable to avoid any single letter followed by a number.
 *
 * Example note tags:
 *
@@ -852,10 +856,10 @@ Imported[Community.Lighting.name] = true;
 * Creates a basic light
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
-* <cl: light 300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
+* <cl: light r300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
+* <cl: light r300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
 * <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
@@ -884,7 +888,7 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
+* <cl: light r300 {a#990000 t15} {a#999900} {a#009900} {a#009999} {a#000099}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
@@ -2069,34 +2073,38 @@ class ColorDelta {
     this._cl.type = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._cl.type) {
-      let isFL       = ()        => this._cl.type.is(LightType.Flashlight); // is flashlight
-      let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
-      let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
-      let isNul      = (e)       => e == null;
-      let isDayNight = (e)       => isEq(e, "night", "day");
-      let clip       = (e)       => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
+      let isFL       = ()          => this._cl.type.is(LightType.Flashlight); // is flashlight
+      let isEq       = (e, s0, s1) => s0 && e.equalsIC(s0)     || s1 && e.equalsIC(s1);
+      let isPre      = (e, p0, p1) => p0 && e.startsWithIC(p0) || p1 && e.startsWithIC(p1);
+      let isPreNum   = (e, p, n)   => p  && e.startsWithIC(p)  && !isNaN(n);
+      let isNul      = (e)         => e == null;
+      let isDayNight = (e)         => isEq(e, "night", "day");
+      let clipNum    = (e)         => orNaN(+e.slice(1)); // clip prefix & convert to number or undefined
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
-        let n = clip(e);
-        if      (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
+        let n = clipNum(e);
+        console.log()
+        if      (!isFL() && isPreNum(e, 'r', n) && isNul(this._cl.radius))     this._cl.radius     = n;
+        else if (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamWidth))  this._cl.beamWidth  = +e;
-        else if (isFL()  && isPre(e, "l") && n  && isNul(this._cl.beamLength)) this._cl.beamLength = n;
-        else if (isFL()  && isPre(e, "w") && n  && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
-        else if (           isEq(e, "cycle")    && isNul(this._cl.color))      hasCycle            = true;
-        else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
-        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
-        else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
+        else if (isFL()  && isPreNum(e, 'l', n) && isNul(this._cl.beamLength)) this._cl.beamLength = n;
+        else if (isFL()  && isPreNum(e, 'w', n) && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
+        else if (           isEq(e, 'cycle')    && isNul(this._cl.color))      hasCycle            = true;
+        else if (           isPre(e, '#', 'a#') && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex] .push('p' + e);
+        else if (           isPre(e, '#', 'a#') && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
+        else if (           isPreNum(e, 'e', n) && isNul(this._cl.enable))     this._cl.enable     = Boolean(n);
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable     = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable     = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
-        else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;
+        else if (           isPreNum(e, 'b', n) && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = n;
         else if ( isFL() && !isNaN(+e)          && isNul(this._cl.direction))  this._cl.direction  = +e;
-        else if ( isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
-        else if ( isFL() && isPre(e, "a") && n  && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
-        else if (           isPre(e, "x") && n  && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
-        else if (           isPre(e, "y") && n  && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
+        else if ( isFL() && isPreNum(e, 'd', n) && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
+        else if ( isFL() && isPreNum(e, 'a', n) && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
+        else if (           isPreNum(e, 'x', n) && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
+        else if (           isPreNum(e, 'y', n) && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
         else if (           e.length > 0        && isNul(this._cl.id))         this._cl.id         = e;
         cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1197,13 +1197,13 @@ Imported[Community.Lighting.name] = true;
 const M_2PI    = 2 * Math.PI;   // cache 2PI - this is faster
 const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
 
-Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
-Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
-Number.prototype.clone        = function()        { return this; };
-Boolean.prototype.clone       = function()        { return this; };
-String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
+Number.prototype.is           = function(...a)     { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max) { return this >= min && this <= max; };
+Number.prototype.clone        = function()         { return this; };
+Boolean.prototype.clone       = function()         { return this; };
+String.prototype.equalsIC     = function(...a)     { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)        { return this.toLowerCase().startsWith(s.toLowerCase()); };
+Math.minmax                   = (minOrMax, ...a) =>  minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
@@ -1308,7 +1308,7 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
  * @param {Number} a
  * @returns {String}
  */
- function rgba(r, g, b, a) {
+function rgba(r, g, b, a) {
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
@@ -2513,8 +2513,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distpart > lightsOnRadius) {
+        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distanceApart > lightsOnRadius) {
           continue;
         }
       }
@@ -2674,7 +2674,7 @@ class ColorDelta {
   * @param {Number} brightness
   * @param {VRGBA} c1
   * @param {VRGBA} c2
-   */
+  */
   CanvasGradient.prototype.addTransparentColorStops = function (brightness, c1, c2) {
     if (brightness) {
       if (!useSmootherLights) {

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -3119,7 +3119,7 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, battleMaxX + lightMaskPadding, battleMaxY);
 
     // Prevent the battle scene from being too dark
-    let c = $gameTemp._BattleTintTarget.next().get(); // reference
+    let c = $gameTemp._BattleTintTarget.next().get(); // get next color
     if (c.magnitude() < 0x66 * 3 && c.r < 0x66 && c.g < 0x66 && c.b < 0x66) {
       c.set({ v: false, r: 0x66, g: 0x66, b: 0x66, a: 0xff });
       $gameTemp._BattleTintTarget.current = c; // reassign if out of bounds. Shouldn't be possible.

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -765,12 +765,15 @@ Imported[Community.Lighting.name] = true;
 * --------------------------------------------------------------------------
 * Events
 * --------------------------------------------------------------------------
-* Light radius [cycle] color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color + duration pairs to follow that will be
-*               cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 #0f0 15 #00f 15 ...etc>
+* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
+*               that will be cycled through before repeating from the beginning:
+*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
+*               fadeDuration and growRadius are optional argument used to transition between colors
+*               and radius sizes over the provided cycle interval.
 *               In Terrax Lighting, there was a hard limit of 4, but now you can use
 *               as many as you want. [optional]
 * - color       #ffffff, #ff0000, etc
@@ -791,14 +794,17 @@ Imported[Community.Lighting.name] = true;
 * Fire ...params
 * - Same as Light params above, but adds a subtle flicker
 *
-* Flashlight bl bw [cycle] color [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw cycle <color onDuration [fadeDuration]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
 * - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
 * - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color + duration pairs to follow that will be
-*             cycled through before repeating from the beginning:
+* - cycle     Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
+*             that will be cycled through before repeating from the beginning:
 *             <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15 on someId d3>
+*             fadeDuration is an optional argument used to transition between colors
+*             over the provided cycle interval.
 *             There's no limit to how many colors can be cycled. [optional]
 * - color     #ffffff, #ff0000, etc
 * - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
@@ -821,6 +827,13 @@ Imported[Community.Lighting.name] = true;
 *
 * <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
+*
+* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
+*
+* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
+* and transitions to the next color and size over 60 frames.
 *
 * <cl: fire 150 #ff8800 b15 night>
 * Creates a fire that only lights up at night.

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1358,12 +1358,22 @@ class VRGBA {
   }
 
   /**
-   * Creates an empty VRGBA object will all properties initialized to false and 0.
+   * Creates an VRGBA object will r,g,b,a = 0 and v = false.
    * @returns {VRGBA}
    */
-  static empty() {
+  static minRGBA() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
+    return that;
+  }
+
+  /**
+   * Creates an VRGBA object will r,g,b,a = 255 and v = false.
+   * @returns {VRGBA}
+   */
+  static maxRGBA() {
+    let that = new VRGBA();
+    [that.v, that.r, that.g, that.b, that.a] = [false, 255, 255, 255, 255];
     return that;
   }
 
@@ -1916,7 +1926,7 @@ class ColorDelta {
     catch (e) {
       let CL = Community.Lighting;
       console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
-      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
+      result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.minRGBA(), "isNight": false }));
     }
     return result;
   })(parameters["DayNight Colors"], parameters["Night Hours"]);
@@ -2068,7 +2078,7 @@ class ColorDelta {
 
       // normalize parameters
       this._cl.radius        = orNaN(this._cl.radius, 0);
-      this._cl.color         = orNullish(this._cl.color, VRGBA.empty());
+      this._cl.color         = orNullish(this._cl.color, VRGBA.minRGBA());
       this._cl.enable        = orBoolean(this._cl.enable, true);
       this._cl.brightness    = orNaN(this._cl.brightness, 0);
       this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
@@ -2561,9 +2571,9 @@ class ColorDelta {
             let flashlength = cur.getLightFlashlightLength();
             let flashwidth  = cur.getLightFlashlightWidth();
             if (!isNaN(direction)) ldir = direction;
-            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
+            this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.minRGBA(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.minRGBA(), objectflicker,
                                                      brightness, direction);
           }
         }
@@ -2595,7 +2605,7 @@ class ColorDelta {
         tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
         tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.minRGBA(), objectflicker,
                                                tile.brightness);
     });
 
@@ -3103,7 +3113,7 @@ class ColorDelta {
     // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
-            $gameVariables.GetTint() : new VRGBA("#ffffff");
+            $gameVariables.GetTint() : VRGBA.maxRGBA();
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {
@@ -3564,7 +3574,7 @@ Game_Variables.prototype.SetTint = function (value) {
   this._Community_Tint_Value = value.clone();
 };
 Game_Variables.prototype.GetTint = function () {
-  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.empty();
+  if (!this._Community_Tint_Value) this._Community_Tint_Value = VRGBA.minRGBA();
   return this._Community_Tint_Value.clone();
 };
 Game_Variables.prototype.SetTintAtHour = function (hour, color) {
@@ -3577,7 +3587,7 @@ Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   while (hours >= hoursinDay) hours -= hoursinDay;
   while (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
-  return result ? result.color.clone() : VRGBA.empty();
+  return result ? result.color.clone() : VRGBA.minRGBA();
 };
 Game_Variables.prototype.SetTintTarget = function (delta) {
   this._Community_TintTarget = delta;
@@ -3617,7 +3627,7 @@ Game_Variables.prototype.SetPlayerColor = function (value) { // don't set if emp
   if (value) this._Community_Lighting_PlayerColor = new VRGBA(value);
 };
 Game_Variables.prototype.GetPlayerColor = function () {
-  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = new VRGBA("#ffffff");
+  if (!this._Community_Lighting_PlayerColor) this._Community_Lighting_PlayerColor = VRGBA.maxRGBA();
   return this._Community_Lighting_PlayerColor.clone();
 };
 Game_Variables.prototype.SetPlayerBrightness = function (value) { // don't set if invalid.
@@ -3672,7 +3682,7 @@ Game_Variables.prototype.GetDaynightColorArray = function () {
   if (hoursInDay > result.length) { // lazy check bounds before returning and add colors if too small
     let origLength = result.length;
     result.length = hoursInDay;     // more efficient than a for loop
-    result.fill({ "color": new VRGBA("#ffffff"), "isNight": false }, origLength);
+    result.fill({ "color": VRGBA.maxRGBA(), "isNight": false }, origLength);
   }
   this._Community_Lighting_DayNightColorArray = result; // assign reference
   return result;

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1135,11 +1135,11 @@ Imported[Community.Lighting.name] = true;
 * ....where # is the max distance you want in tiles.
 */
 
-Number.prototype.is           = function (...a) { return a.includes(Number(this)); };
-Number.prototype.inRange      = function (min, max) { return this >= min && this <= max; };
-String.prototype.equalsIC     = function (...a) { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
-String.prototype.startsWithIC = function (s) { return this.toLowerCase().startsWith(s.toLowerCase()); };
-Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Math.min(...a) : Math.max(...a); }; // min if positive
+Number.prototype.is           = (...a)           => a.includes(Number(this));
+Number.prototype.inRange      = (min, max)       => this >= min && this <= max;
+String.prototype.equalsIC     = (...a)           => a.map(s => s.toLowerCase()).includes(this.toLowerCase());
+String.prototype.startsWithIC = (s)              => this.toLowerCase().startsWith(s.toLowerCase());
+Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
@@ -1169,18 +1169,18 @@ const isValidColorRegex = /^[Aa]?#[A-F\d]{8}$/i; // a|A before # for additive li
   return "rgba(" + r + "," + g + "," + b + "," + a + ")";
 }
 
-/** Class to handle volumetric/additive coloring with rgba colors uniformly.
- *  Additive coloring prefixes an 'a' on a normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
+/** Class to handle volumetric/additive coloring with rgba colors uniformly. Additive coloring prefixes an 'a' on a
+ *  normal hex color. E.g. a#ccddeeff, a#ccddee, a#cdef, a#cde.
  */
 class VRGBA {
   /**
-   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a hex String
-   * can be passed with an optional default alternative Hex string, or another VRGBA object can be passed to create a clone.
+   * Creates a VRGBA object representing a VRGBA color string. Either v, r, g, b, a values can be passed directly, or a
+   * hex String can be passed with an optional default alternative Hex string which is used in case of parsing failure.
    * @param {String|Boolean|VRGBA} vOrHex     - Boolean representing the additive component, or
    *                                            String representing the hex color, or
    *                                            other VRGBA object to clone.
    * @param {String|Number}        rOrDefault - Number representing the red component, or
-   *                                            String representing a default hex string in case the provided one cannot be parsed.
+   *                                            String representing a default hex string.
    * @param {null|Number}          g          - Number representing the green component.
    * @param {null|Number}          b          - Number representing the blue component.
    * @param {null|Number}          a          - Number representing the alpha component.
@@ -1237,8 +1237,9 @@ class VRGBA {
   magnitude() { return this.r + this.g + this.b; }
 
   /**
-   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String. If invalid, a default
-   * value of "#000000ff" is returned. If either provided String is valid, it will be returned as an 'a#rrggbbaa' formatted color hex String.
+   * Attempts to normalize the provided hex String. If invalid, it then tries to normalize the provided altHex String.
+   * If invalid, a default value of "#000000ff" is returned. If either provided String is valid, it will be returned
+   * as an 'a#rrggbbaa' formatted color hex String.
    * @param {String} hex
    * @param {String} alt
    * @returns {String}
@@ -1258,9 +1259,10 @@ class VRGBA {
   }
 
   /**
-   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the hex is additive or not.
-   * The setWebSafe parameter is used to to strip the additive property (v) so that the resulting color can be used with Canvas APIs. An
-   * override Object can be provided to override the existing v, r, g, b, or a properties in the output.
+   * Converts the VRGBA Object into an 'a#rrggbbaa' formatted color hex string where the first 'a' tells whether the
+   * hex is additive or not. The setWebSafe parameter is used to to strip the additive property (v) so that the
+   * resulting color can be used with Canvas APIs. An override Object can be provided to override the existing v, r, g,
+   * b, or a properties in the output.
    * @param {Boolean} setWebSafe
    * @param {VRGBA} override
    * @returns {String}
@@ -1289,8 +1291,9 @@ class VRGBA {
 }
 
 /**
- * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability to compute deltas
- * between the current parameter values and the target values, and allows for current values to be extracted.
+ * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability
+ * to compute deltas between the current parameter values and the target values, and allows for current values to be
+ * extracted.
  **/
 class ConditionalLight {
   /**
@@ -1481,7 +1484,9 @@ class ConditionalLight {
   finished() { return this.fDuration <= 0 && this.pDuration <= 0; }
 }
 
-/** Class representing individual number deltas for providing number changes over time at different speeds. **/
+/**
+ * Class representing individual number deltas for providing number changes over time at different speeds.
+ **/
 class NumberDelta {
   /**
    * Creates a number delta from the start number, target number, and duration.
@@ -1523,7 +1528,7 @@ class NumberDelta {
    */
   next() {
     if (this.finished()) return this; // lazy-short-circuit
-    if(this.current != this.target) this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
+    if (this.current != this.target) this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
     this.duration -= 1;
     this.finished();
     return this;
@@ -1547,29 +1552,31 @@ class NumberDelta {
   }
 }
 
-/** Class representing a color delta for providing color changes over time at different speeds. **/
+/**
+ * Class representing a color delta for providing color changes over time at different speeds.
+ **/
 class ColorDelta {
   /**
    * Create a color delta from the start color, target color, fade duration, and
    * whether to consider the remaining ticks or not for speed purposes.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
-   * @param {Number} fadeDuration
+   * @param {Number} fDuration
    * @param {Number} useTicksRemaining
    * @returns {ColorDelta}
    */
-  constructor(start, target = start, fadeDuration = 0, useTicksRemaining = false) {
+  constructor(start, target = start, fDuration = 0, useTicksRemaining = false) {
     if (arguments.length == 0) return;
-    this.current      = start.clone();           // - deep copy
-    this.target       = target.clone();          // - deep copy
-    this.fadeDuration = orNaN(fadeDuration, 0);  // - use either the remaining time (of the hour) or total fade duration
-    fadeDuration     -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
-    this.lazyEquals   = false;                   // - true when current value == target value
-    this.delta        = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
-                                 (this.target.r - this.current.r) / fadeDuration,
-                                 (this.target.g - this.current.g) / fadeDuration,
-                                 (this.target.b - this.current.b) / fadeDuration,
-                                 (this.target.a - this.current.a) / fadeDuration);
+    this.current    = start.clone();           // - deep copy
+    this.target     = target.clone();          // - deep copy
+    this.fDuration  = orNaN(fDuration, 0);     // - use the remaining time (of the hour) or total fade duration
+    fDuration      -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+    this.lazyEqual  = false;                   // - true when current value == target value
+    this.delta      = new VRGBA(this.target.v, // - divide by zero is +inf or -inf so deltas work for speed = 0
+                               (this.target.r - this.current.r) / fDuration,
+                               (this.target.g - this.current.g) / fDuration,
+                               (this.target.b - this.current.b) / fDuration,
+                               (this.target.a - this.current.a) / fDuration);
     this.finished(); // check for duration = 0
   }
   /**
@@ -1577,9 +1584,12 @@ class ColorDelta {
    * @returns {ColorDelta}
    **/
   clone() {
-    let that = new ColorDelta();
-    [that.current,           that.target,         that.fadeDuration, that.lazyEquals, that.delta] =
-    [this.current.clone(),   this.target.clone(), this.fadeDuration, this.lazyEquals, this.delta.clone()];
+    let that = new  ColorDelta();
+    that.current    = this.current.clone();
+    that.target     = this.target.clone();
+    that.fDuration  = this.fDuration;
+    that.lazyEquals = this.lazyEquals;
+    that.delta      = this.delta.clone();
     return that;
   }
 
@@ -1587,28 +1597,32 @@ class ColorDelta {
    * Creates a light delta from the start color, target color, and fade duration.
    * @param {VRGBA}  start
    * @param {VRGBA}  target
-   * @param {Number} fadeDuration
+   * @param {Number} fDuration
    * @returns {ColorDelta}
    */
-  static create(start, target, fadeDuration) {
-    return new ColorDelta(start, target, fadeDuration, false /* don't use remaining ticks */);
+  static create(start, target, fDuration) {
+    return new ColorDelta(start, target, fDuration, false /* don't use remaining ticks */);
   }
 
   /**
    * Creates a map color delta from the current map tint, target tint, and fade duration.
    * @param {VRGBA}  targetTint
-   * @param {Number} fadeDuration
+   * @param {Number} fDuration
    * @returns {ColorDelta}
    */
-  static createTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameVariables.GetTint(), targetTint, fadeDuration); }
+  static createTint(targetTint, fDuration = 0) {
+    return new ColorDelta($gameVariables.GetTint(), targetTint, fDuration);
+  }
 
   /**
    * Creates a battle color delta from the current battle tint, target tint, and fade duration.
    * @param {VRGBA}  targetTint
-   * @param {Number} fadeDuration
+   * @param {Number} fDuration
    * @returns {ColorDelta}
    */
-  static createBattleTint(targetTint, fadeDuration = 0) { return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fadeDuration); }
+  static createBattleTint(targetTint, fDuration = 0) {
+    return new ColorDelta($gameTemp._BattleTintTarget.current, targetTint, fDuration);
+  }
 
   /**
    * Creates a time color delta from the current time and speed. useCurrentTint specifies whether to
@@ -1618,13 +1632,14 @@ class ColorDelta {
    * @returns {ColorDelta}
    */
   static createTimeTint(useCurrentTint = true) {
-    let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
+    let fDuration = 60 * $gameVariables.GetDaynightSpeed(); // fade duration
     if (useCurrentTint) { // delta should fade from current color to target
-      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fadeDuration, true);
+      return new ColorDelta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), fDuration, true);
     } else {              // start color should be the color it would normally be at the given time
-      let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
-      fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a ref speed to compute the start color
-      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fadeDuration);
+      let CL = Community.Lighting; // reference CL
+      let ticks    = fDuration == 0 ? CL.minutes() * 60 + CL.seconds() : CL.ticks();
+      fDuration = fDuration == 0 ? 60 * 60 : fDuration; // dur = 0 needs a ref speed to compute the start color
+      let delta = new ColorDelta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), fDuration);
       delta.next(ticks); // get current color based off of ticks elapsed in hour
       return delta;
     }
@@ -1638,12 +1653,13 @@ class ColorDelta {
    */
   next(scale = 1) {
     if (this.finished()) return this; // lazy-short-circuit
-    this.current.v = this.delta.v;  // Compute next color step and clamp to target -- check for reference match to avoid recomputing
-    if(this.current.r != this.target.r) this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
-    if(this.current.g != this.target.g) this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
-    if(this.current.b != this.target.b) this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
-    if(this.current.a != this.target.a) this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
-    this.fadeDuration -= 1;
+    let c = this.current, t = this.target, d = this.delta; // reference
+    if(c.v != t.v) c.v = t.v;  // Compute next step and clamp to target, check to avoid recomputing
+    if(c.r != t.r) c.r = Math.minmax(d.r > 0, c.r + scale * d.r, t.r);
+    if(c.g != t.g) c.g = Math.minmax(d.g > 0, c.g + scale * d.g, t.g);
+    if(c.b != t.b) c.b = Math.minmax(d.b > 0, c.b + scale * d.b, t.b);
+    if(c.a != t.a) c.a = Math.minmax(d.a > 0, c.a + scale * d.a, t.a);
+    this.fDuration -= 1;
     return this;
   }
 
@@ -1659,7 +1675,7 @@ class ColorDelta {
    */
   finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
-    if ((this.lazyEquals = this.fadeDuration <= 0)) return (this.current = this.target, true); // set cur to refer to target
+    if ((this.lazyEquals = this.fDuration <= 0)) return (this.current = this.target, true);
     return false;
    }
 }
@@ -1725,7 +1741,8 @@ class ColorDelta {
       this.enabled    = isOn(onoff);
       this.color      = new VRGBA(color);
       this.radius     = +radius || 0;
-      this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) || $$.defaultBrightness || 0;
+      this.brightness = brightness && (brightness.slice(1, brightness.length) / 100).clamp(0, 1) ||
+                        $$.defaultBrightness || 0;
     }
   }
 
@@ -1784,7 +1801,8 @@ class ColorDelta {
         result[i] = { "color": new VRGBA(dayNight[i]), "isNight": nightHours.contains(i) };
     }
     catch (e) {
-      console.log(`${Community.Lighting.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
+      let CL = Community.Lighting;
+      console.log(`${CL.name} - Night Hours and/or DayNight Colors contain invalid JSON data - cannot parse.`);
       result = new Array(24).fill(undefined).map(() => ({ "color": VRGBA.empty(), "isNight": false }));
     }
     return result;
@@ -1872,7 +1890,8 @@ class ColorDelta {
   $$.hours   = () => Math.floor($gameVariables.GetDaynightSeconds () / (60 * 60));
   $$.minutes = () => Math.floor($gameVariables.GetDaynightSeconds () / 60) % 60;
   $$.seconds = () => Math.floor($gameVariables.GetDaynightSeconds() % 60);
-  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() * $gameVariables.GetDaynightSpeed());
+  $$.ticks   = () => Math.floor($$.seconds() / $gameVariables.GetDaynightTick() + $$.minutes() *
+                                $gameVariables.GetDaynightSpeed());
   $$.time = function (showSeconds) {
     let result = $$.hours() + ":" + $$.minutes().padZero(2);
     if (showSeconds) result = result + ":" + $$.seconds().padZero(2);
@@ -1919,31 +1938,33 @@ class ColorDelta {
     this._clType = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
     if (this._clType) {
-      let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
-      let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
-      let isPre        = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
-      let isUndef      = (x)       => x === undefined;
+      let t = this;
+      let isFL     = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+      let isEq     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
+      let isPre    = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
+      let isNul   = (x)       => x == null;
+      let clip     = (e)       => +e.slice(1); // clip prefix & convert to number
       let hasCycle = false;
       tagData.forEach((e) => {
-        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength = +(e.slice(1));
-        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth  = +(e.slice(1));
-        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      hasCycle           = true;
-        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor      = new VRGBA(e);
-        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff      = true;
-        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff      = false;
-        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch     = e;
-        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness = Number(+(e.slice(1)) / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = +(e.slice(1));
-        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection  = CLDirectionMap[+(e.slice(1))];
-        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection  = Math.PI / 180 * +(e.slice(1));
-        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset    = +(e.slice(1));
-        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset    = +(e.slice(1));
-        else if (           e.length > 0                   && isUndef(this._clId))         this._clId         = e;
-      }, this);
+        if      (!isFL() && !isNaN(+e)              && isNul(t._clRadius))     t._clRadius     = +e;
+        else if (isFL()  && !isNaN(+e)              && isNul(t._clBeamLength)) t._clBeamLength = +e;
+        else if (isFL()  && !isNaN(+e)              && isNul(t._clBeamWidth))  t._clBeamWidth  = +e;
+        else if (isFL()  && isPre(e, "l")           && isNul(t._clBeamLength)) t._clBeamLength = clip(e);
+        else if (isFL()  && isPre(e, "w")           && isNul(t._clBeamWidth))  t._clBeamWidth  = clip(e);
+        else if (           isEq(e, "cycle")        && isNul(t._clColor))      hasCycle        = true;
+        else if (           isPre(e, "#", "a#")     && isNul(t._clColor))      t._clColor      = new VRGBA(e);
+        else if (           isOn(e)                 && isNul(t._clOnOff))      t._clOnOff      = true;
+        else if (           isOff(e)                && isNul(t._clOnOff))      t._clOnOff      = false;
+        else if (           isEq(e, "night", "day") && isNul(t._clSwitch))     t._clSwitch     = e;
+        else if (           isPre(e, "b")           && isNul(t._clBrightness)) t._clBrightness = (clip(e) / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d")           && isNul(t._clDirection))  t._clDirection  = clip(e);
+        else if ( isFL() && !isNaN(+e)              && isNul(t._clDirection))  t._clDirection  = +e;
+        else if ( isFL() && isPre(e, "d")           && isNul(t._clDirection))  t._clDirection  = CLDirectionMap[clip(e)];
+        else if ( isFL() && isPre(e, "a")           && isNul(t._clDirection))  t._clDirection  = Math.PI / 180 * clip(e);
+        else if (           isPre(e, "x")           && isNul(t._clXOffset))    t._clXOffset    = clip(e);
+        else if (           isPre(e, "y")           && isNul(t._clYOffset))    t._clYOffset    = clip(e);
+        else if (           e.length > 0            && isNul(t._clId))         t._clId         = e;
+      });
 
       // normalize parameters
       this._clRadius     = this._clRadius || 0;
@@ -1962,7 +1983,8 @@ class ColorDelta {
       if (hasCycle && cycleGroups.length) {             // check if tag included color cycling
         this._clCycle = [];                             // only define if cycle exists
         let t         = this;                           // refer to this as t
-        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
+        let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius,
+                         t._clBeamLength, t._clBeamWidth];
         let condLight = new ConditionalLight(...args);  // create conditional light with initial properties
 
         cycleGroups.forEach((e, i, a) => {              // ------ loop each group
@@ -1984,7 +2006,8 @@ class ColorDelta {
       // Process conditional lighting
       if (this._clId) {                                 // check for a conditional lighting ID
         let t          = this;                          // refer to this as t
-        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
+        let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius,
+                          t._clBeamLength, t._clBeamWidth];
         let condLight  = new ConditionalLight(...args); // create conditional light
         condLight.setTargets(...args);                  // create matching targets
         condLight.createDeltas();                       // compute deltas (zeroes)
@@ -2087,8 +2110,9 @@ class ColorDelta {
     command = command.toLowerCase();
 
     const allCommands = {
-      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight', tilefire: 'addTileLight', regionfire: 'addTileLight',
-      tileglow: 'addTileLight', regionglow: 'addTileLight', tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
+      tileblock: 'addTileBlock', regionblock: 'addTileBlock', tilelight: 'addTileLight', regionlight: 'addTileLight',
+      tilefire: 'addTileLight', regionfire: 'addTileLight', tileglow: 'addTileLight', regionglow: 'addTileLight',
+      tint: 'tint', daynight: 'dayNight', flashlight: 'flashLight', setfire: 'setFire', fire: 'fire', light: 'light',
       script: 'scriptF', reload: 'reload', tintbattle: 'tintbattle'
     };
     const result = allCommands[command];
@@ -2096,36 +2120,36 @@ class ColorDelta {
   };
 
   if (isRMMZ()) { // RMMZ only command interface
-    let mapOnOff = (args) => args.enabled === "true" ? "on" : "off";
-    let tileType = (args) => (args.tileType === "terrain" ? "tile" : "region") + (args.lightType ? args.lightType : "block");
-    let tintType = (    ) => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  (args) => args.instant === "true" ? "instant" : "";
-    let tintMode = (args) => args.color ? "set" : "reset";
-    let mathMode = (args) => args.mode === "set" ? "hour" : args.mode; // set, add, or subtract.
-    let showMode = (args) => args.enabled.equalsIC("true") ? (args.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
-    let radMode  = (args) => +args.fadeSpeed ? "radiusgrow" : "radius";
+    let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
+    let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
+    let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
+    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let tintMode = a  => a.color ? "set" : "reset";
+    let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
+    let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
+    let radMode  = a  => +a.fadeSpeed ? "radiusgrow" : "radius";
 
-    let reg = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
-    let f = (cmd, args) => $gameMap._interpreter.communityLighting_Commands(cmd, args.filter(_ => _ !== "")); //command wrapper.
+    let r = PluginManager.registerCommand.bind(PluginManager, $$.name); // registar bound with first parameter.
+    let f = (c, a) => $gameMap._interpreter.communityLighting_Commands(c, a.filter(_ => _ !== "")); //command wrapper.
 
-    reg("masterSwitch",       (a)  => f("script",     [mapOnOff(a)]));
-    reg("tileBlock",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.shape,          a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
-    reg("tileLight",          (a)  => f(tileType(a),  [a.id,            mapOnOff(a),     a.color,        a.radius,         a.brightness]));
-    reg("setTint",            (a)  => f(tintType(),   [tintMode(a),     a.color,         a.fadeSpeed]));
-    reg("daynightEnable",     (a)  => f("daynight",   [mapOnOff(a),     dayMode(a)]));
-    reg("setTimeSpeed",       (a)  => f("dayNight",   ["speed",         a.speed]));
-    reg("setTime",            (a)  => f("dayNight",   [mathMode(a),     a.hours,         a.minutes,      dayMode(a)]));
-    reg("setHoursInDay",      (a)  => f("dayNight",   ["hoursinday",    a.hours,         dayMode(a)]));
-    reg("showTime",           (a)  => f("dayNight",   [showMode(a)]));
-    reg("setHourColor",       (a)  => f("dayNight",   ["color", a.hour, a.color,         dayMode(a)]));
-    reg("flashlight",         (a)  => f("flashLight", [mapOnOff(a),     a.beamLength,    a.beamWidth,    a.color,          a.density]));
-    reg("setFire",            (a)  => f("setFire",    [a.radiusShift,   a.redYellowShift]));
-    reg("playerLightRadius",  (a)  => f("light",      [radMode(a),      a.radius,        a.color,        "B"+a.brightness, a.fadeSpeed]));
-    reg("activateById",       (a)  => f("light",      [mapOnOff(a),     a.id]));
-    reg("lightColor",         (a)  => f("light",      ["color",         a.id,            a.color]));
-    reg("resetLightSwitches", ( )  => f("light",      ["switch",        "reset"]));
-    reg("resetTint",          (a)  => f(tintType(),   ["reset",         a.fadeSpeed]));
-    reg("condLight",          (a)  => f("light",      ["cond",          a.id,            a.properties]));
+    r("masterSwitch",       a  => f("script",     [mapOnOff(a)]));
+    r("tileBlock",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.shape,  a.xOffset, a.yOffset, a.blockWidth, a.blockHeight]));
+    r("tileLight",          a  => f(tileType(a),  [a.id, mapOnOff(a), a.color, a.radius, a.brightness]));
+    r("setTint",            a  => f(tintType(),   [tintMode(a), a.color, a.fadeSpeed]));
+    r("daynightEnable",     a  => f("daynight",   [mapOnOff(a), dayMode(a)]));
+    r("setTimeSpeed",       a  => f("dayNight",   ["speed", a.speed]));
+    r("setTime",            a  => f("dayNight",   [mathMode(a), a.hours, a.minutes, dayMode(a)]));
+    r("setHoursInDay",      a  => f("dayNight",   ["hoursinday", a.hours, dayMode(a)]));
+    r("showTime",           a  => f("dayNight",   [showMode(a)]));
+    r("setHourColor",       a  => f("dayNight",   ["color", a.hour, a.color, dayMode(a)]));
+    r("flashlight",         a  => f("flashLight", [mapOnOff(a), a.beamLength, a.beamWidth, a.color, a.density]));
+    r("setFire",            a  => f("setFire",    [a.radiusShift, a.redYellowShift]));
+    r("playerLightRadius",  a  => f("light",      [radMode(a), a.radius, a.color, "B"+a.brightness, a.fadeSpeed]));
+    r("activateById",       a  => f("light",      [mapOnOff(a), a.id]));
+    r("lightColor",         a  => f("light",      ["color", a.id, a.color]));
+    r("resetLightSwitches", () => f("light",      ["switch", "reset"]));
+    r("resetTint",          a  => f(tintType(),   ["reset", a.fadeSpeed]));
+    r("condLight",          a  => f("light",      ["cond", a.id, a.properties]));
   }
 
   /**
@@ -2138,7 +2162,8 @@ class ColorDelta {
     let [tileType, lightType] = TileLightType[command] || [undefined, undefined];
     let [id, enabled, color, radius, brightness] = args;
     let tile = new TileLight(tileType, lightType, id, enabled, color, radius, brightness);
-    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType && e.id === tile.id);
+    let index = tilearray.findIndex(e => e.tileType === tile.tileType && e.lightType === tile.lightType &&
+                                    e.id === tile.id);
     void (index === -1 ? tilearray.push(tile) : tilearray[index] = tile);
     $gameVariables.SetTileLightArray(tilearray);
     $$.ReloadTagArea();
@@ -2270,7 +2295,9 @@ class ColorDelta {
   Lightmask.prototype.update = function () { this._updateMask(); };
 
   //@method _createBitmaps
-  Lightmask.prototype._createBitmaps = function () { this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY); };
+  Lightmask.prototype._createBitmaps = function () {
+    this._maskBitmaps = new Mask_Bitmaps(maxX + lightMaskPadding, maxY);
+  };
 
   let _Game_Map_prototype_setupEvents = Game_Map.prototype.setupEvents;
   Game_Map.prototype.setupEvents = function () {
@@ -2332,7 +2359,7 @@ class ColorDelta {
     let lightgrow_target = $gameVariables.GetRadiusTarget();
     let lightgrow_speed = (player_radius < lightgrow_target ? 1 : -1) * $gameVariables.GetRadiusSpeed();
     if (lightgrow_speed != 0 && player_radius != lightgrow_target) {
-      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // compute and clamp
+      player_radius = Math.minmax(lightgrow_speed > 0, player_radius + lightgrow_speed, lightgrow_target); // clamp
       $gameVariables.SetRadius(player_radius);
     }
 
@@ -2374,7 +2401,8 @@ class ColorDelta {
     let iplayer_radius = Math.floor(player_radius);
 
     if (playerflashlight == true) {
-      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength, flashlightwidth);
+      this._maskBitmaps.radialgradientFlashlight(x1, y1, playercolor, radialColor2, pd, flashlightlength,
+                                                 flashlightwidth);
     }
     if (iplayer_radius > 0) {
       x1 = x1 - flashlightXoffset;
@@ -2387,9 +2415,11 @@ class ColorDelta {
         c.b = Math.max(0, c.b - 50);
         let newcolor = c;
 
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker,
+                                                 playerbrightness);
       } else {
-        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2, playerflicker, playerbrightness);
+        this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
+                                                 playerflicker, playerbrightness);
       }
 
     }
@@ -2423,8 +2453,8 @@ class ColorDelta {
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
-        let distanceApart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
-        if (distanceApart > lightsOnRadius) {
+        let distpart = Math.round(Community.Lighting.distance($gamePlayer.x, $gamePlayer.y, cur._realX, cur._realY));
+        if (distpart > lightsOnRadius) {
           continue;
         }
       }
@@ -2473,7 +2503,8 @@ class ColorDelta {
             if (!isNaN(direction)) ldir = direction;
             this._maskBitmaps.radialgradientFlashlight(lx1, ly1, color, VRGBA.empty(), ldir, flashlength, flashwidth);
           } else if (lightType.is(LightType.Light, LightType.Fire)) {
-            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker, brightness, direction);
+            this._maskBitmaps.radialgradientFillRect(lx1, ly1, 0, light_radius, color, VRGBA.empty(), objectflicker,
+                                                     brightness, direction);
           }
         }
       }
@@ -2506,7 +2537,8 @@ class ColorDelta {
         c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
         tile_color = c;
       }
-      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker, tile.brightness);
+      this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
+                                               tile.brightness);
     });
 
     // Tile blocks
@@ -2860,7 +2892,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2871,7 +2904,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2883,7 +2917,8 @@ class ColorDelta {
       ctxMul.moveTo(xRightBeamStart, yRightBeamStart);
       ctxMul.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
       ctxMul.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+      ctxMul.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                           yRightBeamEnd);
       ctxMul.lineTo(xRightBeamStart, yRightBeamStart);
       ctxMul.fill();
       if (c1.v) {
@@ -2894,7 +2929,8 @@ class ColorDelta {
         ctxAdd.moveTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.quadraticCurveTo(xStartCtrlPoint, yStartCtrlPoint, xLeftBeamStart, yLeftBeamStart);
         ctxAdd.lineTo(xLeftBeamEnd, yLeftBeamEnd);
-        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd, yRightBeamEnd);
+        ctxAdd.bezierCurveTo(xLeftCtrlPoint, yLeftCtrlPoint, xRightCtrlPoint, yRightCtrlPoint, xRightBeamEnd,
+                             yRightBeamEnd);
         ctxAdd.lineTo(xRightBeamStart, yRightBeamStart);
         ctxAdd.fill();
       }
@@ -2913,7 +2949,7 @@ class ColorDelta {
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
         ctxMul.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2);
       } else {
-        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are always guarded
+        ctxAdd.shadowColor = "#000000"; // Clear shadow style inside of check as ctxAdd state changes are conditional
         ctxAdd.shadowBlur = 0;
         ctxAdd.fillStyle = grad;
         ctxAdd.fillRect(x1 - r2, y1 - r2, r2 * 2, r2 * 2); // single call as to not blur things so much.
@@ -3302,7 +3338,7 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for default (i.e. no passed color)
+      if (condLight) { condLight.color = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************
@@ -3348,7 +3384,7 @@ class ColorDelta {
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));
       else if (cmd.equalsIC('reset', 'daylight')) {
-        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0)); // battle initial color
+        $gameTemp._BattleTintTarget = ColorDelta.createBattleTint($gameTemp._BattleTintInitial, 60 * (+args[1] || 0));
       }
     }
   };
@@ -3380,7 +3416,7 @@ class ColorDelta {
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
         let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed()); // whether to change tint instantly
+        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }
@@ -3390,13 +3426,13 @@ class ColorDelta {
     let [gV, a]                    = [$gameVariables, args];
     let [secondsTotal, hoursInDay] = [gV.GetDaynightSeconds(), gV.GetDaynightHoursinDay()];
     let [hours, minutes, seconds]  = [$$.hours(), $$.minutes(), $$.seconds()];
-    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint changes
-    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disabled daynight tint changes
-    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // daynight speed
-    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to current time
-    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // subtract from current time
-    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the current time
-    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day (must be >0, err = 24)
+    if      (isCmd('on'))          void (daynightTintEnabled = true, setTimeColorDelta());              // enable daynight tint
+    else if (isCmd('off'))         void (daynightTintEnabled = false, setColorDelta());                 // disable daynight tint
+    else if (isCmd('speed'))       void (gV.SetDaynightSpeed(a[1]), setTimeColorDelta());               // set daynight speed
+    else if (isCmd('add'))         void modTime(hoursInDay, +a[1],   +a[2],   secondsTotal, 0);         // add to cur time
+    else if (isCmd('subtract'))    void modTime(hoursInDay, -+a[1], -+a[2],   secondsTotal, 0);         // sub from cur time
+    else if (isCmd('hour'))        void modTime(hoursInDay, +a[1],   +a[2],   0);                       // set the cur time
+    else if (isCmd('hoursinday'))  void modTime(+a[1],      hours,   minutes, seconds);                 // set number of hours in day
     else if (isCmd('show'))        void showTime(true, false);                                          // show clock
     else if (isCmd('showseconds')) void showTime(true, true);                                           // show clock seconds
     else if (isCmd('hide'))        void showTime(false, false);                                         // hide clock

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -3584,8 +3584,8 @@ Game_Variables.prototype.SetTintAtHour = function (hour, color) {
 Game_Variables.prototype.GetTintByTime = function (inc = 0) {
   let hours = Community.Lighting.hours() + inc; // increment from current hour
   let hoursinDay = this.GetDaynightHoursinDay();
-  while (hours >= hoursinDay) hours -= hoursinDay;
-  while (hours < 0) hours += hoursinDay;
+  hours %= hoursinDay; // clamp to within total hours in day
+  if (hours < 0) hours += hoursinDay;
   let result = this.GetDaynightColorArray()[hours];
   return result ? result.color.clone() : VRGBA.minRGBA();
 };

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2025,7 +2025,7 @@ class ColorDelta {
       let isDayNight = (e)       => isEq(e, "night", "day");
       let clip       = (e)       => orNaN(e.slice(1)); // clip prefix & convert to number or undefined
       let cycleIndex, hasCycle = false;
-      tagData.forEach((e, i) => {
+      tagData.forEach((e) => {
         let n = clip(e);
         if      (!isFL() && !isNaN(+e)          && isNul(this._clRadius))     this._clRadius     = +e;
         else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamLength)) this._clBeamLength = +e;

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1255,37 +1255,55 @@ class Delta {
    * @param {VRGBA} targetColor
    * @param {Number} startRadius
    * @param {Number} targetRadius
+   * @param {Number} startBeamLength
+   * @param {Number} targetBeamLength
+   * @param {Number} startBeamWidth
+   * @param {Number} targetBeamWidth
    * @param {Number} fadeDuration
    * @param {Number} onDuration
    * @param {Number} useTicksRemaining
    * @returns {Delta}
    */
-  constructor(startColorOrDelta, targetColor, startRadius, targetRadius, fadeDuration, onDuration, useTicksRemaining) {
+  constructor(startColorOrDelta, targetColor, startRadius, targetRadius, startBeamLength, targetBeamLength, startBeamWidth, targetBeamWidth, fadeDuration, onDuration, useTicksRemaining) {
     if (startColorOrDelta != null &&
-        startColorOrDelta.constructor === Delta) {        // passed another Delta instance - clone
-      let delta = startColorOrDelta;                      // - rename
-      this.currentColor  = new VRGBA(delta.currentColor); // - deep copy
-      this.targetColor   = new VRGBA(delta.targetColor);  // - deep copy
-      this.currentRadius = delta.currentRadius;           // - copy
-      this.targetRadius  = delta.targetRadius;            // - copy
-      this.onDuration    = delta.onDuration;              // - copy
-      this.lazyEquals    = delta.lazyEquals;              // - copy
-      this.deltaColor    = new VRGBA(delta.deltaColor);   // - deep copy
-      this.deltaRadius   = delta.deltaRadius;             // - copy
-    } else {                                              // passed normal parameters - build delta
-      let startColor     = startColorOrDelta;             // - rename
-      this.currentColor  = new VRGBA(startColor);         // - deep copy
-      this.targetColor   = new VRGBA(targetColor);        // - deep copy
-      this.currentRadius = startRadius;                   // - copy
-      this.targetRadius  = targetRadius;                  // - copy
-      this.onDuration    = orNaN(onDuration, 0);          // - parse onDuration
-      this.lazyEquals    = false;                         // - true when current value == target value
-      fadeDuration       = orNaN(fadeDuration, 0);        // - use either the remaining time (of the hour) or total fade duration
-      fadeDuration      -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
-      this.deltaColor    = new VRGBA(this.targetColor.v,  // - divide by zero is +inf or -inf so deltas work for speed = 0
-                                    (this.targetColor.r - this.currentColor.r) / fadeDuration, (this.targetColor.g - this.currentColor.g) / fadeDuration,
-                                    (this.targetColor.b - this.currentColor.b) / fadeDuration, (this.targetColor.a - this.currentColor.a) / fadeDuration);
-      this.deltaRadius   = (targetRadius - startRadius) / fadeDuration; // compute radius delta
+        startColorOrDelta.constructor === Delta) {            // passed another Delta instance - clone
+      let delta = startColorOrDelta;                          // - rename
+      this.currentColor      = new VRGBA(delta.currentColor); // - deep copy
+      this.targetColor       = new VRGBA(delta.targetColor);  // - deep copy
+      this.currentRadius     = delta.currentRadius;           // - copy
+      this.targetRadius      = delta.targetRadius;            // - copy
+      this.currentBeamLength = delta.currentBeamLength;       // - copy
+      this.targetBeamLength  = delta.targetBeamLength;        // - copy
+      this.currentBeamWidth  = delta.currentBeamWidth;        // - copy
+      this.targetBeamWidth   = delta.targetBeamWidth;         // - copy
+      this.onDuration        = delta.onDuration;              // - copy
+      this.lazyEquals        = delta.lazyEquals;              // - copy
+      this.deltaColor        = new VRGBA(delta.deltaColor);   // - deep copy
+      this.deltaRadius       = delta.deltaRadius;             // - copy
+      this.deltaBeamLength   = delta.deltaBeamLength;         // - copy
+      this.deltaBeamWidth    = delta.deltaBeamWidth;          // - copy
+    } else {                                                  // passed normal parameters - build delta
+      let startColor         = startColorOrDelta;             // - rename
+      this.currentColor      = new VRGBA(startColor);         // - deep copy
+      this.targetColor       = new VRGBA(targetColor);        // - deep copy
+      this.currentRadius     = startRadius;                   // - copy
+      this.targetRadius      = targetRadius;                  // - copy
+      this.currentBeamLength = startBeamLength;               // - copy
+      this.targetBeamLength  = targetBeamLength;              // - copy
+      this.currentBeamWidth  = startBeamWidth;                // - copy
+      this.targetBeamWidth   = targetBeamWidth;               // - copy
+      this.onDuration        = orNaN(onDuration, 0);          // - parse onDuration
+      this.lazyEquals        = false;                         // - true when current value == target value
+      fadeDuration           = orNaN(fadeDuration, 0);        // - use either the remaining time (of the hour) or total fade duration
+      fadeDuration          -= (useTicksRemaining ? Community.Lighting.ticks() : 0);
+      this.deltaColor        = new VRGBA(this.targetColor.v,  // - divide by zero is +inf or -inf so deltas work for speed = 0
+                                        (this.targetColor.r - this.currentColor.r) / fadeDuration,
+                                        (this.targetColor.g - this.currentColor.g) / fadeDuration,
+                                        (this.targetColor.b - this.currentColor.b) / fadeDuration,
+                                        (this.targetColor.a - this.currentColor.a) / fadeDuration);
+      this.deltaRadius       = (targetRadius - startRadius) / fadeDuration;         // compute radius delta
+      this.deltaBeamLength   = (targetBeamLength - startBeamLength) / fadeDuration; // compute beam length delta
+      this.deltaBeamWidth    = (targetBeamWidth - startBeamWidth) / fadeDuration;   // compute beam width delta
     }
   }
 
@@ -1299,8 +1317,8 @@ class Delta {
    * @param {Number} onDuration
    * @returns {Delta}
    */
-  static createLight(startColor, targetColor, startRadius, targetRadius, fadeDuration, onDuration) {
-    return new Delta(startColor, targetColor, startRadius, targetRadius, fadeDuration, onDuration, false /* don't use remaining ticks */);
+  static createLight(startColor, targetColor, startRadius, targetRadius, startBeamLength, targetBeamLength, startBeamWidth, targetBeamWidth, fadeDuration, onDuration) {
+    return new Delta(startColor, targetColor, startRadius, targetRadius, startBeamLength, targetBeamLength, startBeamWidth, targetBeamWidth, fadeDuration, onDuration, false /* don't use remaining ticks */);
   }
 
   /**
@@ -1309,7 +1327,7 @@ class Delta {
    * @param {Number} fadeDuration
    * @returns {Delta}
    */
-  static createTint(targetTint, fadeDuration = 0) { return new Delta($gameVariables.GetTint(), targetTint, null, null, fadeDuration, 0, false); }
+  static createTint(targetTint, fadeDuration = 0) { return new Delta($gameVariables.GetTint(), targetTint, null, null, null, null, null, null, fadeDuration, 0, false); }
 
   /**
    * Create battle color delta from the current battle tint, target tint, and fade duration.
@@ -1317,7 +1335,7 @@ class Delta {
    * @param {Number} fadeDuration
    * @returns {Delta}
    */
-  static createBattleTint(targetTint, fadeDuration = 0) { return new Delta($gameTemp._BattleTintTarget.currentColor, targetTint, null, null, fadeDuration, 0, false); }
+  static createBattleTint(targetTint, fadeDuration = 0) { return new Delta($gameTemp._BattleTintTarget.currentColor, targetTint, null, null, null, null, null, null, fadeDuration, 0, false); }
 
   /**
    * Create a time color delta from the current time and speed. useCurrentTint specifies whether to
@@ -1329,11 +1347,11 @@ class Delta {
   static createTimeTint(useCurrentTint = true) {
     let fadeDuration = 60 * $gameVariables.GetDaynightSpeed();
     if (useCurrentTint) { // delta should fade from current color to target
-      return new Delta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), null, null, fadeDuration, 0 /*on duration*/, true /* use remaining ticks for speed computation */);
+      return new Delta($gameVariables.GetTint(), $gameVariables.GetTintByTime(1), null, null, null, null, null, null, fadeDuration, 0 /*on duration*/, true /* use remaining ticks for speed computation */);
     } else {              // start color should be the color it would normally be at the given time
       let ticks    = fadeDuration == 0 ? Community.Lighting.minutes() * 60 + Community.Lighting.seconds() : Community.Lighting.ticks();
       fadeDuration = fadeDuration == 0 ? 60 * 60 : fadeDuration; // speed = 0 needs a reference speed to compute the color at the current time so use 1 tick = 1 second
-      let delta = new Delta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), null, null, fadeDuration, 0 /*on duration*/, false);
+      let delta = new Delta($gameVariables.GetTintByTime(), $gameVariables.GetTintByTime(1), null, null, null, null, null, null, fadeDuration, 0 /*on duration*/, false);
       delta.next(ticks); // get current color based off of ticks elapsed in hour
       return delta;
     }
@@ -1352,7 +1370,9 @@ class Delta {
     this.currentColor.g = Math.minmax(this.deltaColor.g > 0, this.currentColor.g + scale * this.deltaColor.g, this.targetColor.g);
     this.currentColor.b = Math.minmax(this.deltaColor.b > 0, this.currentColor.b + scale * this.deltaColor.b, this.targetColor.b);
     this.currentColor.a = Math.minmax(this.deltaColor.a > 0, this.currentColor.a + scale * this.deltaColor.a, this.targetColor.a);
-    this.currentRadius  = Math.minmax(this.deltaRadius > 0, this.currentRadius   + scale * this.deltaRadius,  this.targetRadius);
+    if (this.currentRadius)     this.currentRadius     = Math.minmax(this.deltaRadius > 0,     this.currentRadius     + scale * this.deltaRadius,     this.targetRadius);
+    if (this.currentBeamLength) this.currentBeamLength = Math.minmax(this.deltaBeamLength > 0, this.currentBeamLength + scale * this.deltaBeamLength, this.targetBeamLength);
+    if (this.currentBeamWidth)  this.currentBeamWidth  = Math.minmax(this.deltaBeamWidth > 0,  this.currentBeamWidth  + scale * this.deltaBeamWidth,  this.targetBeamWidth);
     if (this.equals()) this.onDuration = Math.max(this.onDuration - 1, 0); // check if done and if so subtract onDuration
     return this;
   }
@@ -1368,6 +1388,18 @@ class Delta {
    * @returns {Number}
    **/
   getRadius() { return this.currentRadius; }
+
+  /**
+   * Returns the current delta beam length.
+   * @returns {Number}
+   **/
+  getBeamLength() { return this.currentBeamLength; }
+
+  /**
+   * Returns the current delta beam width.
+   * @returns {Number}
+   **/
+   getBeamWidth() { return this.currentBeamWidth; }
 
   /**
    * Returns true if the current color is equal to the target color; otherwise false.
@@ -1649,42 +1681,52 @@ class Delta {
       let cycleIndex = -1;
       let colorCycle, p;
       tagData.forEach((e, i) => {
-        if      (!isFL() && !isNaN(+e)                  && isUndef(this._clRadius))     this._clRadius           = +e;
-        else if (isFL()  && !isNaN(+e)                  && isUndef(this._clBeamLength)) this._clBeamLength       = +e;
-        else if (isFL()  && !isNaN(+e)                  && isUndef(this._clBeamWidth))  this._clBeamWidth        = +e;
-        else if (isFL()  && isPrefix(e, "l")            && isUndef(this._clBeamLength)) this._clBeamLength       = +(e.slice(1));
-        else if (isFL()  && isPrefix(e, "w")            && isUndef(this._clBeamWidth))  this._clBeamWidth        = +(e.slice(1));
-        else if (           isEquals(e, "cycle")        && isUndef(this._clColor))      colorCycle               = [];
-        else if (           isPrefix(e, "#", "a#")      && colorCycle)                { colorCycle.push({ "color": new VRGBA(e) }); cycleIndex = i; }
-        else if (           !isNaN(+e)                  && cycleIndex + 1 == i)         cycleLast().onDuration   = +e;
-        else if (           !isNaN(+p) && !isNaN(+e)    && cycleIndex + 2 == i)         cycleLast().fadeDuration = +e; // check previous
-        else if (           !isNaN(+p) && !isNaN(+e)    && cycleIndex + 3 == i)         cycleLast().radiusGrow   = +e; // check previous
-        else if (           isPrefix(e, "#", "a#")      && isUndef(this._clColor))      this._clColor            = new VRGBA(e);
-        else if (           isOn(e)                     && isUndef(this._clOnOff))      this._clOnOff            = true;
-        else if (           isOff(e)                    && isUndef(this._clOnOff))      this._clOnOff            = false;
-        else if (           isEquals(e, "night", "day") && isUndef(this._clSwitch))     this._clSwitch           = e;
-        else if (           isPrefix(e, "b")            && isUndef(this._clBrightness)) this._clBrightness       = Number(+(e.slice(1)) / 100).clamp(0, 1);
-        else if (!isFL() && isPrefix(e, "d")            && isUndef(this._clDirection))  this._clDirection        = +(e.slice(1));
-        else if ( isFL() && !isNaN(+e)                  && isUndef(this._clDirection))  this._clDirection        = +e;
-        else if ( isFL() && isPrefix(e, "d")            && isUndef(this._clDirection))  this._clDirection        = CLDirectionMap[+(e.slice(1))];
-        else if ( isFL() && isPrefix(e, "a")            && isUndef(this._clDirection))  this._clDirection        = Math.PI / 180 * +(e.slice(1));
-        else if (           isPrefix(e, "x")            && isUndef(this._clXOffset))    this._clXOffset          = +(e.slice(1));
-        else if (           isPrefix(e, "y")            && isUndef(this._clYOffset))    this._clYOffset          = +(e.slice(1));
-        else if (           e.length > 0                && isUndef(this._clId))         this._clId               = e;
+        if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius           = +e;
+        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength       = +e;
+        else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth        = +e;
+        else if (isFL()  && isPrefix(e, "l")               && isUndef(this._clBeamLength)) this._clBeamLength       = +(e.slice(1));
+        else if (isFL()  && isPrefix(e, "w")               && isUndef(this._clBeamWidth))  this._clBeamWidth        = +(e.slice(1));
+        else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      colorCycle               = [];
+        else if (           isPrefix(e, "#", "a#")         && colorCycle)                { colorCycle.push({ "color": new VRGBA(e) }); cycleIndex = i; }
+        else if (           !isNaN(+e)                     && cycleIndex + 1 == i)         cycleLast().onDuration   = +e;
+        else if (           !isNaN(+p) && !isNaN(+e)       && cycleIndex + 2 == i)         cycleLast().fadeDuration = +e; // check previous
+        else if (!isFL() && !isNaN(+p) && !isNaN(+e)       && cycleIndex + 3 == i)         cycleLast().radiusGrow   = +e; // check previous
+        else if (isFL() &&  !isNaN(+p) && !isNaN(+e)       && cycleIndex + 3 == i)         cycleLast().beamLength   = +e; // check previous
+        else if (isFL() &&  !isNaN(+p) && !isNaN(+e)       && cycleIndex + 4 == i)         cycleLast().beamWidth    = +e; // check previous
+        else if (           isPrefix(e, "#", "a#")         && isUndef(this._clColor))      this._clColor            = new VRGBA(e);
+        else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff            = true;
+        else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff            = false;
+        else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch           = e;
+        else if (           isPrefix(e, "b")               && isUndef(this._clBrightness)) this._clBrightness       = Number(+(e.slice(1)) / 100).clamp(0, 1);
+        else if (!isFL() && isPrefix(e, "d")               && isUndef(this._clDirection))  this._clDirection        = +(e.slice(1));
+        else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection        = +e;
+        else if ( isFL() && isPrefix(e, "d")               && isUndef(this._clDirection))  this._clDirection        = CLDirectionMap[+(e.slice(1))];
+        else if ( isFL() && isPrefix(e, "a")               && isUndef(this._clDirection))  this._clDirection        = Math.PI / 180 * +(e.slice(1));
+        else if (           isPrefix(e, "x")               && isUndef(this._clXOffset))    this._clXOffset          = +(e.slice(1));
+        else if (           isPrefix(e, "y")               && isUndef(this._clYOffset))    this._clYOffset          = +(e.slice(1));
+        else if (           e.length > 0                   && isUndef(this._clId))         this._clId               = e;
         p = e;
       }, this);
 
-      if (colorCycle && colorCycle.length) {                             // check if tag included color cycling
-        this._clCycle = [];                                              // only define if colorCycle exists
-        colorCycle.forEach((e, i, a) => {                                // preprocess color cycle deltas
-          let n = a[++i < colorCycle.length ? i : 0];                    // get next element
-          let fadeDuration = orNullish(e.fadeDuration, 0);               // grab fade duration for this color since we are fading from it
-          let onDuration   = orNullish(n.onDuration, 1);                 // grab on duration for the next color since we are fading to it
-          let thisRadius   = orNullish(e.radiusGrow, this._clRadius, 0); // grab this radius or use the default
-          let nextRadius   = orNullish(n.radiusGrow, this._clRadius, 0); // grab next radius or use the default
-          let thisColor    = orNullish(e.color, colorCycle[0].color);    // grab this color
-          let nextColor    = orNullish(n.color, colorCycle[0].color);    // grab next color
-          this._clCycle.push(Delta.createLight(thisColor, nextColor, thisRadius, nextRadius, fadeDuration, onDuration)); // create and push delta
+      if (colorCycle && colorCycle.length) {                                   // check if tag included color cycling
+        this._clCycle = [];                                                    // only define if colorCycle exists
+        colorCycle.forEach((e, i, a) => {                                      // preprocess color cycle deltas
+          let n = a[++i < colorCycle.length ? i : 0];                          // get next element
+          let fadeDuration   = orNullish(e.fadeDuration, 0);                   // grab fade duration for this color since we are fading from it
+          let onDuration     = orNullish(n.onDuration, 1);                     // grab on duration for the next color since we are fading to it
+          let thisRadius     = orNullish(e.radiusGrow, this._clRadius, 0);     // grab this radius or use the default (light only)
+          let nextRadius     = orNullish(n.radiusGrow, this._clRadius, 0);     // grab next radius or use the default (light only)
+          let thisBeamLength = orNullish(e.beamLength, this._clBeamLength, 0); // grab this beam length or use the default (flashlight only)
+          let nextBeamLength = orNullish(n.beamLength, this._clBeamLength, 0); // grab next beam length or use the default (flashlight only)
+          let thisBeamWidth  = orNullish(e.beamWidth, this._clBeamWidth, 0);   // grab this beam width or use the default (flashlight only)
+          let nextBeamWidth  = orNullish(n.beamWidth, this._clBeamWidth, 0);   // grab next beam width or use the default (flashlight only)
+          let thisColor      = orNullish(e.color, colorCycle[0].color);        // grab this color
+          let nextColor      = orNullish(n.color, colorCycle[0].color);        // grab next color
+          this._clCycle.push(Delta.createLight(thisColor,      nextColor,      // push colors
+                                               thisRadius,     nextRadius,     // push radius (light only)
+                                               thisBeamLength, nextBeamLength, // push beam length (flashlight only)
+                                               thisBeamWidth,  nextBeamWidth,  // push beam width (flashlight only)
+                                               fadeDuration,   onDuration));   // push durations, and create and push delta
         }, this);
       }
     }
@@ -1753,17 +1795,21 @@ class Delta {
     let cycleList = this.getLightCycle();
     if (cycleList) {
       if (this._clCycleDelta != null && !this._clCycleDelta.finished()) {
-        this._clCycleDelta.next();                       // compute next delta
-        this._clColor  = this._clCycleDelta.getColor();  // assign color
-        this._clRadius = this._clCycleDelta.getRadius(); // assign radius
+        this._clCycleDelta.next();                               // compute next delta
+        this._clColor      = this._clCycleDelta.getColor();      // assign color
+        this._clRadius     = this._clCycleDelta.getRadius();     // assign radius
+        this._clBeamLength = this._clCycleDelta.getBeamLength(); // assign beam length
+        this._clBeamWidth  = this._clCycleDelta.getBeamWidth();  // assign beam width
       }
       else {
-        let delta = cycleList.shift();                   // pop delta from front
-        this._clCycleDelta = new Delta(delta);           // duplicate delta
-        cycleList.push(delta);                           // push delta on back
-        this._clCycleDelta.next();                       // compute next delta
-        this._clColor  = this._clCycleDelta.getColor();  // assign color
-        this._clRadius = this._clCycleDelta.getRadius(); // assign radius
+        let delta = cycleList.shift();                           // pop delta from front
+        this._clCycleDelta = new Delta(delta);                   // duplicate delta
+        cycleList.push(delta);                                   // push delta on back
+        this._clCycleDelta.next();                               // compute next delta
+        this._clColor      = this._clCycleDelta.getColor();      // assign color
+        this._clRadius     = this._clCycleDelta.getRadius();     // assign radius
+        this._clBeamLength = this._clCycleDelta.getBeamLength(); // assign beam length
+        this._clBeamWidth  = this._clCycleDelta.getBeamWidth();  // assign beam width
       }
     }
   };

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -302,8 +302,8 @@ Imported[Community.Lighting.name] = true;
 * @----------------------------
 *
 * @command condLight
-* @text Conditional Lighting
-* @desc Set conditional lighting properties. Supports: Fade, color, angle, brightness, x offset, y offset, radius, length, width.
+* @text Set Conditional Lighting
+* @desc Supports transition & pause durations, color, angle, brightness, x offset, y offset, radius, beam length & width.
 *
 * @arg id
 * @text Event ID
@@ -312,9 +312,9 @@ Imported[Community.Lighting.name] = true;
 *
 * @arg properties
 * @text properties
-* @desc Supported prefixes: f, #, #a, a, b, x, y, r, l, w.
+* @desc Format: [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
 * @type text
-* @default f5 #ffffff b0 x0 y0 r150
+* @default t5 #ffffff -a90 b0 x0 y0 r150 l12 w12
 *
 * @----------------------------
 *
@@ -783,16 +783,13 @@ Imported[Community.Lighting.name] = true;
 * Events
 * --------------------------------------------------------------------------
 * Light radius color [onoff] [day|night] [brightness] [direction] [x] [y] [id]
-* Light radius cycle <color onDuration [fadeDuration [growRadius]]>... [onoff] [day|night] [brightness] [direction] [x] [y] [id]
+* Light [radius] [color] [{CycleProps}...] [onoff] [day|night] [brightness] [direction] [x] [y] [id]
 * - Light
 * - radius      100, 250, etc
-* - cycle       Allows any number of color, onDuration, fadeDuration, growRadius tuples to follow
-*               that will be cycled through before repeating from the beginning:
-*               <cl: light 100 cycle #f00 15 15 15 #0f0 15 15 15 #00f 15 15 15 ...etc>
-*               fadeDuration and growRadius are optional argument used to transition between colors
-*               and radius sizes over the provided cycle interval. If growRadius is not provided
-*               the default radius is used for the given color. In Terrax Lighting, there was a hard
-*               limit of 4, but now you can use as many as you want. [optional]
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
 * - color       #ffffff, #ff0000, etc
 * - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
 * - day         Causes the light to only come on during the day [optional]
@@ -812,46 +809,41 @@ Imported[Community.Lighting.name] = true;
 * - Same as Light params above, but adds a subtle flicker
 *
 * Flashlight bl bw color [onoff] [day|night] [sdir|angle] [x] [y] [id]
-* Flashlight bl bw cycle <color onDuration [fadeDuration [grow_bl [grow_bw]]]>... [onoff] [day|night] [sdir|angle] [x] [y] [id]
+* Flashlight bl bw [{CycleProps}...] [onoff] [day|night] [sdir|angle] [x] [y] [id]
 * - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 *      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-* - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
-* - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-* - cycle     Allows any number of color, onDuration, fadeDuration, grow_bl, and
-*             grow_bw tuples to follow that will be cycled through before repeating
-*             from the beginning:
-*             <cl: Flashlight l8 w12 cycle #f00 15 15 8 11 #ff0 15 15 7 10 #0f0 15 6 10 on someId d3>
-*             fadeDuration, grow_bl, and grow_bw are optional arguments used to
-*             transition between colors and beam lengths & widths over the provided
-*             cycle interval. If grow_bl or grow_bw are not provided, the default
-*             length or width is used for the given color. There's no limit to how
-*             many colors can be cycled. [optional]
-* - color     #ffffff, #ff0000, etc
-* - onoff:    Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
-* - day       Sets the event's light to only show during the day [optional]
-* - night     Sets the event's light to only show during night time [optional]
-* - sdir:     Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-*             Can be preceded by "D", so D4.  If omitted, defaults to 0
-* - angle:    Forced direction in degrees (optional): must be preceded by "A". If
-*             omitted, sdir is used. [optional]
-* - x         x[offset] Work the same as regular light [optional]
-* - y         y[offset] [optional]
-* - id        1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-*             These should not begin with 'a', 'd', 'x' or 'y' otherwise
-*             they will be mistaken for one of the previous optional parameters.
+* - bl:         Beam length:  Any number, optionally preceded by "L", so 8, L8
+* - bw:         Beam width:  Any number, optionally preceded by "W", so 12, W12
+* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+*               The can be used to create transitioning light patterns See the Conditional
+*               Lighting section for more details. * Any non-cyclic properties are inherited
+*               unless overridden by the first cyclic properties [Optional]
+* - color       #ffffff, #ff0000, etc
+* - onoff:      Initial state:  0, 1, off, on (default). Ignored if day|night passed [optional]
+* - day         Sets the event's light to only show during the day [optional]
+* - night       Sets the event's light to only show during night time [optional]
+* - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
+*               Can be preceded by "D", so D4.  If omitted, defaults to 0
+* - angle:      Forced direction in degrees (optional): must be preceded by "A". If
+*               omitted, sdir is used. [optional]
+* - x           x[offset] Work the same as regular light [optional]
+* - y           y[offset] [optional]
+* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+*               These should not begin with 'a', 'd', 'x' or 'y' otherwise
+*               they will be mistaken for one of the previous optional parameters.
 *
 * Example note tags:
 *
 * <cl: light 250 #ffffff>
 * Creates a basic light
 *
-* <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
+* <cl: light 300 {#ff0000 t15} {#ffff00 t15} {#00ff00 t15} {#00ffff t15} {#0000ff t15}>
 * Creates a cycling light that rotates every 15 frames.  Great for parties!
 *
-* <cl: light 300 cycle #ff0000 30 60 #ffff00 30 60 #00ff00 30 60 #00ffff 30 60 #0000ff 30 60>
+* <cl: light 300 {#ff0000 t30 p60} {#ffff00 t30 p60} {#00ff00 t30 p60} {#00ffff t30 p60}>
 * Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
 *
-* <cl: light 300 cycle #ff0000 30 60 250 #ffff00 30 60 300 #00ff00 30 60 250 #00ffff 30 60 300>
+* <cl: light {#ff0000 t30 p60 r250} {#ffff00 t30 p60 r300} {#00ff00 t30 p60 r250} {#00ffff t30 p60 r300}>
 * Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
 * and transitions to the next color and size over 60 frames.
 *
@@ -862,7 +854,7 @@ Imported[Community.Lighting.name] = true;
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
-* <cl: Flashlight l8 w12 cycle #ff0000 on asdf>
+* <cl: Flashlight l8 w12 {#ff0000} on asdf>
 * Creates a flashlight beam with id asdf which can be turned on or off via
 * plugin commands.
 *
@@ -873,12 +865,54 @@ Imported[Community.Lighting.name] = true;
 * in front of any color light color.
 *
 * Example note tags:
-* <cl: light 300 cycle a#990000 15 a#999900 15 a#009900 15 a#009999 15 a#000099 15>
+* <cl: light 300 {a#990000 t15} {a#999900 t15} {a#009900 t15} {a#009999 t15} {a#000099 t15}>
 * Creates a cycling volumetric light that rotates every 15 frames.
 *
 * <cl: Flashlight l8 w12 a#660000 on asdf>
 * Creates a red volumetric flashlight beam with id asdf which can be turned on or off
 * via plugin commands.
+*
+* --------------------------------------------------------------------------
+* Conditional Lighting
+* --------------------------------------------------------------------------
+* Conditional Lighting allows light properties to be changed either cyclically or
+* dynamically over time via properties that consist of a prefix followed by a property
+* value. This is useful for creating any number of transitional lighting effects.
+*
+* The properties are supported in light tags or via the 'light cond' command. Light tags
+* support any number of light properties wrapped in {} brackets See the example note tags
+* above.
+*
+* The 'light cond' command allows for conditional lights to be dynamically changed on demand.
+* See the Plugin Commands section for more details.
+*
+* The following chart shows all supported properties:
+* --------------------------------------------------------------------------------------------------------------------
+* |   Property     |  Prefix   |        Format           | Examples          | Description                            |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     pause      |     p     |           pN            |    p0, p1, p20    | time period in cycles to pause after   |
+* |    duration    |           |                         |                   | transitioning for cycling lights       |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   transition   |     t     |           tN            |    t0, t1, t30    | time period to transition the          |
+* |    duration    |           |                         |                   | specified properties over              |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     color      |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | a#FFEEDD, #ffeedd | color or additive color                |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     angle      | a, +a, -a |       <a|+a|-a>N        |  a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |                |           |                         |                   | clockwise, '-' moves counterclockwise  |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   brightness   |     b     |           bN            |    b0, b1, b5     | brightness                             |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    x offset    |     x     |           xN            |     x2, x-2       | x offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |    y offset    |     y     |           yN            |     y2, y-2       | y offset                               |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |     radius     |     r     |           rN            |    r50, r150      | light radius                           |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam length  |     l     |           lN            |   l8, l9, l10     | flashlight beam length                 |
+* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
+* |   beam width   |     w     |           wN            |  w12, w13, w14    | flashlight beam width                  |
+* --------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
 * Easy hex color references
@@ -960,6 +994,13 @@ Imported[Community.Lighting.name] = true;
 *
 * Light off id
 * - Turn off light with matching id number
+*
+* Light cond id [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+* - transitions a conditional light to the specified properties over the the given
+* - time period in cycles. Supported propreties are color, flashlight angle (a),
+* - brightness (b), x offset (x), y offset (y), radius (r), flashlight beam length (l),
+* - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
+* - ignored. See the Conditional Light section for more detail on each property.
 *
 * Light color id c
 * - Change the color (c) of lightsource with id (id)
@@ -1310,16 +1351,16 @@ class ConditionalLight {
   constructor(currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
               currentBeamLength, currentBeamWidth) {
     if (arguments.length == 0) return;
-    this.fadeDuration      = 0;
-    this.pauseDuration     = 0;
-    this.currentColor      = currentColor;
-    this.currentDirection  = currentDirection;
-    this.currentBrightness = currentBrightness;
-    this.currentXOffset    = currentXOffset;
-    this.currentYOffset    = currentYOffset;
-    this.currentRadius     = currentRadius;
-    this.currentBeamLength = currentBeamLength;
-    this.currentBeamWidth  = currentBeamWidth;
+    this.transitionDuration = 0;
+    this.pauseDuration      = 0;
+    this.currentColor       = currentColor;
+    this.currentDirection   = currentDirection;
+    this.currentBrightness  = currentBrightness;
+    this.currentXOffset     = currentXOffset;
+    this.currentYOffset     = currentYOffset;
+    this.currentRadius      = currentRadius;
+    this.currentBeamLength  = currentBeamLength;
+    this.currentBeamWidth   = currentBeamWidth;
   }
 
   /**
@@ -1329,40 +1370,40 @@ class ConditionalLight {
   clone() {
     let that = new ConditionalLight();
     // clone durations
-    if (this.fadeDuration      != null) that.fadeDuration      = this.fadeDuration;
-    if (this.pauseDuration     != null) that.pauseDuration     = this.pauseDuration;
+    if (this.transitionDuration != null) that.transitionDuration = this.transitionDuration;
+    if (this.pauseDuration      != null) that.pauseDuration      = this.pauseDuration;
     // clone currents
-    if (this.currentColor      != null) that.currentColor      = this.currentColor.clone();
-    if (this.currentDirection  != null) that.currentDirection  = this.currentDirection;
-    if (this.currentBrightness != null) that.currentBrightness = this.currentBrightness;
-    if (this.currentXOffset    != null) that.currentXOffset    = this.currentXOffset;
-    if (this.currentYOffset    != null) that.currentYOffset    = this.currentYOffset;
-    if (this.currentRadius     != null) that.currentRadius     = this.currentRadius;
-    if (this.currentBeamLength != null) that.currentBeamLength = this.currentBeamLength;
-    if (this.currentBeamWidth  != null) that.currentBeamWidth  = this.currentBeamWidth;
+    if (this.currentColor       != null) that.currentColor       = this.currentColor.clone();
+    if (this.currentDirection   != null) that.currentDirection   = this.currentDirection;
+    if (this.currentBrightness  != null) that.currentBrightness  = this.currentBrightness;
+    if (this.currentXOffset     != null) that.currentXOffset     = this.currentXOffset;
+    if (this.currentYOffset     != null) that.currentYOffset     = this.currentYOffset;
+    if (this.currentRadius      != null) that.currentRadius      = this.currentRadius;
+    if (this.currentBeamLength  != null) that.currentBeamLength  = this.currentBeamLength;
+    if (this.currentBeamWidth   != null) that.currentBeamWidth   = this.currentBeamWidth;
     // clone targets
-    if (this.targetColor       != null) that.targetColor       = this.targetColor.clone();
-    if (this.targetDirection   != null) that.targetDirection   = this.targetDirection;
-    if (this.targetBrightness  != null) that.targetBrightness  = this.targetBrightness;
-    if (this.targetXOffset     != null) that.targetXOffset     = this.targetXOffset;
-    if (this.targetYOffset     != null) that.targetYOffset     = this.targetYOffset;
-    if (this.targetRadius      != null) that.targetRadius      = this.targetRadius;
-    if (this.targetBeamLength  != null) that.targetBeamLength  = this.targetBeamLength;
-    if (this.targetBeamWidth   != null) that.targetBeamWidth   = this.targetBeamWidth;
+    if (this.targetColor        != null) that.targetColor        = this.targetColor.clone();
+    if (this.targetDirection    != null) that.targetDirection    = this.targetDirection;
+    if (this.targetBrightness   != null) that.targetBrightness   = this.targetBrightness;
+    if (this.targetXOffset      != null) that.targetXOffset      = this.targetXOffset;
+    if (this.targetYOffset      != null) that.targetYOffset      = this.targetYOffset;
+    if (this.targetRadius       != null) that.targetRadius       = this.targetRadius;
+    if (this.targetBeamLength   != null) that.targetBeamLength   = this.targetBeamLength;
+    if (this.targetBeamWidth    != null) that.targetBeamWidth    = this.targetBeamWidth;
     // clone deltas
-    if (this.deltaColor        != null) that.deltaColor        = this.deltaColor     .clone();
-    if (this.deltaDirection    != null) that.deltaDirection    = this.deltaDirection .clone();
-    if (this.deltaBrightness   != null) that.deltaBrightness   = this.deltaBrightness.clone();
-    if (this.deltaXOffset      != null) that.deltaXOffset      = this.deltaXOffset   .clone();
-    if (this.deltaYOffset      != null) that.deltaYOffset      = this.deltaYOffset   .clone();
-    if (this.deltaRadius       != null) that.deltaRadius       = this.deltaRadius    .clone();
-    if (this.deltaBeamLength   != null) that.deltaBeamLength   = this.deltaBeamLength.clone();
-    if (this.deltaBeamWidth    != null) that.deltaBeamWidth    = this.deltaBeamWidth .clone();
+    if (this.deltaColor         != null) that.deltaColor         = this.deltaColor     .clone();
+    if (this.deltaDirection     != null) that.deltaDirection     = this.deltaDirection .clone();
+    if (this.deltaBrightness    != null) that.deltaBrightness    = this.deltaBrightness.clone();
+    if (this.deltaXOffset       != null) that.deltaXOffset       = this.deltaXOffset   .clone();
+    if (this.deltaYOffset       != null) that.deltaYOffset       = this.deltaYOffset   .clone();
+    if (this.deltaRadius        != null) that.deltaRadius        = this.deltaRadius    .clone();
+    if (this.deltaBeamLength    != null) that.deltaBeamLength    = this.deltaBeamLength.clone();
+    if (this.deltaBeamWidth     != null) that.deltaBeamWidth     = this.deltaBeamWidth .clone();
     return that;
   }
 
   /**
-   * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
+   * Sets up all supported targets.
    * @param {VRGBA}  targetColor
    * @param {Number} targetDirection
    * @param {Number} targetBrightness
@@ -1385,14 +1426,14 @@ class ConditionalLight {
   }
 
   /**
-   * Processes and sets target fade and pause duration properties from a string array.
+   * Processes and sets target transition and pause duration properties from a string array.
    * @param {String[]} properties
    **/
   parseDurationProps(properties) {
-    this.fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
-    this.pauseDuration = properties.find((e) => (e.startsWithIC('p')));
-    this.fadeDuration  = this.fadeDuration  ? +this.fadeDuration.slice(1)  : 0;
-    this.pauseDuration = this.pauseDuration ? +this.pauseDuration.slice(1) : 0;
+    this.transitionDuration = properties.find((e) => (e.startsWithIC('t')));
+    this.pauseDuration      = properties.find((e) => (e.startsWithIC('p')));
+    this.transitionDuration = this.transitionDuration ? +this.transitionDuration.slice(1) : 0;
+    this.pauseDuration      = this.pauseDuration      ? +this.pauseDuration.slice(1)      : 0;
   }
 
   /**
@@ -1447,21 +1488,21 @@ class ConditionalLight {
   }
 
   /**
-   * Create deltas from currents, targets, and fade duration.
+   * Create deltas from currents, targets, and transition duration.
    **/
   createDeltas() {
     let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
     let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
     // assign deltas if current & targets exist
-    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.fadeDuration);
-    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.fadeDuration);
-    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.fadeDuration);
-    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.fadeDuration);
-    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.fadeDuration);
-    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.fadeDuration);
-    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.fadeDuration);
-    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.fadeDuration);
-    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.fadeDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
+    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.transitionDuration);
+    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.transitionDuration);
+    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.transitionDuration);
+    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.transitionDuration);
+    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.transitionDuration);
+    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.transitionDuration);
+    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.transitionDuration);
     // assign new currents for existing deltas (to propagate currents for duration = 0)
     if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
     if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
@@ -1479,7 +1520,7 @@ class ConditionalLight {
    */
   next() {
     if (this.finished()) return this;
-    if (this.fadeDuration > 0) { // only update if fade duration isn't 0
+    if (this.transitionDuration > 0) { // only update if transition duration isn't 0 (finished)
       if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
       if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
       if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
@@ -1488,7 +1529,7 @@ class ConditionalLight {
       if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
       if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
       if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
-      this.fadeDuration--;
+      this.transitionDuration--;
     } else
       this.pauseDuration--;
     return this;
@@ -1498,7 +1539,7 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() { return this.fadeDuration <= 0 && this.pauseDuration <= 0; }
+  finished() { return this.transitionDuration <= 0 && this.pauseDuration <= 0; }
 }
 
 /**
@@ -1960,14 +2001,12 @@ class ColorDelta {
       let isPre    = (x, ...a) => { for (let i of a) if (x.startsWithIC(i)) return true; return false; };
       let isNul   = (x)       => x == null;
       let clip     = (e)       => +e.slice(1); // clip prefix & convert to number
-      let hasCycle = false;
       tagData.forEach((e) => {
         if      (!isFL() && !isNaN(+e)              && isNul(this._clRadius))     this._clRadius     = +e;
         else if (isFL()  && !isNaN(+e)              && isNul(this._clBeamLength)) this._clBeamLength = +e;
         else if (isFL()  && !isNaN(+e)              && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
         else if (isFL()  && isPre(e, "l")           && isNul(this._clBeamLength)) this._clBeamLength = clip(e);
         else if (isFL()  && isPre(e, "w")           && isNul(this._clBeamWidth))  this._clBeamWidth  = clip(e);
-        else if (           isEq(e, "cycle")        && isNul(this._clColor))      hasCycle        = true;
         else if (           isPre(e, "#", "a#")     && isNul(this._clColor))      this._clColor      = new VRGBA(e);
         else if (           isOn(e)                 && isNul(this._clOnOff))      this._clOnOff      = true;
         else if (           isOff(e)                && isNul(this._clOnOff))      this._clOnOff      = false;
@@ -1996,7 +2035,7 @@ class ColorDelta {
       this._clCycle      = this._clCycle || null;
 
       // Process cycle parameters
-      if (hasCycle && cycleGroups.length) {             // check if tag included color cycling
+      if (cycleGroups.length) {                         // check if tag included color cycling
         this._clCycle = [];                             // only define if cycle exists
         let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
                     this._clRadius, this._clBeamLength, this._clBeamWidth];

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -267,9 +267,9 @@ Imported[Community.Lighting.name] = true;
 * @off Off
 * @default true
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -462,9 +462,9 @@ Imported[Community.Lighting.name] = true;
 * @value subtract
 * @default set
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -487,9 +487,9 @@ Imported[Community.Lighting.name] = true;
 * @type text
 * @default #ffffff
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -507,9 +507,9 @@ Imported[Community.Lighting.name] = true;
 * @min 0
 * @default 24
 *
-* @arg instant
-* @text Instant tint change
-* @desc If set to "off" then the tint will gradually transition to that of the next hour.
+* @arg fade
+* @text Fade tint over hour
+* @desc If set to "on" the tint will gradually transition to that of the next hour.
 * @type boolean
 * @on On
 * @off Off
@@ -1052,31 +1052,27 @@ Imported[Community.Lighting.name] = true;
 * Flashlight off
 * - Turn off the flashlight.  yup.
 *
-* DayNight on|off [instant]
-* - Activates or deactivates the day/night cycle. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* DayNight on|off [fade]
+* - Activates or deactivates the day/night cycle. Specifying 'fade' will gradually
+*   transition the tint to that of the next hour.
 *
 * Daynight speed n
 * - Changes the speed by which hours pass in game in relation to real life seconds
 *
-* Daynight hour h m [instant]
-* - Sets the in game time to hh:mm. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hour h m [fade]
+* - Sets the in game time to hh:mm. Specifying 'fade' will gradually transition the
+*   tint to that of the next hour.
 *
 * Daynight color h c
 * - Sets the hour (h) to use color (c)
 *
-* Daynight add h m [instant]
-* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight add h m [fade]
+* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying
+*   'fade' will gradually transition the tint to that of the next hour.
 *
-* Daynight subtract h m [instant]
-* - Subtracts the specified hours (h) and minutes (m) from the in game clock. Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight subtract h m [fade]
+* - Subtracts the specified hours (h) and minutes (m) from the in game clock.
+*   Specifying  'fade' will gradually transition the tint to that of the next hour.
 *
 * Daynight show
 * - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -1087,10 +1083,9 @@ Imported[Community.Lighting.name] = true;
 * Daynight hide
 * - Hides the current time of day mini-window
 *
-* Daynight hoursinday h [instant]
-* - Sets the number of hours in a day to [h] (set hour colors if doing this), Specifying 'instant' will set the
-*   tint for the current hour instantly, otherwise it will change gradually to that of
-*   the next hour
+* Daynight hoursinday h [fade]
+* - Sets the number of hours in a day to [h] (set hour colors if doing this).
+*   Specifying 'fade' will gradually transition the tint to that of the next hour.
 *
 * Tint set c [s]
 * Tint fade c [s]
@@ -2192,7 +2187,7 @@ class ColorDelta {
     let mapOnOff = a  => a.enabled === "true" ? "on" : "off";
     let tileType = a  => (a.tileType === "terrain" ? "tile" : "region") + (a.lightType ? a.lightType : "block");
     let tintType = () => $gameParty.inBattle() ? "tintbattle" : "tint";
-    let dayMode =  a  => a.instant === "true" ? "instant" : "";
+    let dayMode =  a  => a.fade === "true" ? "fade" : "";
     let tintMode = a  => a.color ? "set" : "reset";
     let mathMode = a  => a.mode === "set" ? "hour" : a.mode; // set, add, or subtract.
     let showMode = a  => a.enabled.equalsIC("true") ? (a.showSeconds.equalsIC("true") ? "showseconds" : "show") : "hide";
@@ -3476,8 +3471,8 @@ class ColorDelta {
     };
     let setTimeColorDelta = () => {
       if (daynightCycleEnabled && daynightTintEnabled) {
-        let isInstant = 'instant'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
-        let delta = ColorDelta.createTimeTint(!isInstant, 60 * $gameVariables.GetDaynightSpeed());
+        let hasFade = 'fade'.equalsIC(...a) || gV.GetDaynightSpeed() == 0;
+        let delta = ColorDelta.createTimeTint(hasFade, 60 * $gameVariables.GetDaynightSpeed());
         $gameVariables.SetTint(delta.get());
         $gameVariables.SetTintTarget(delta);
       }

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1682,7 +1682,7 @@ class Delta {
     if (this._clType) {
       let isFL         = ()        => this._clType.is(LightType.Flashlight); // is flashlight
       let isEquals     = (x, ...a) => { for (let i of a) if (x.equalsIC(i)) return true; return false; };
-      let isPrefix     = (x, ...a) => { for (let i of a) if (x.slice(0, i.length).equalsIC(i)) return true; return false; };
+      let isPre     = (x, ...a) => { for (let i of a) if (x.slice(0, i.length).equalsIC(i)) return true; return false; };
       let isUndef      = (x)       => x === undefined;
       let cycleLast    = ()        => colorCycle[colorCycle.length - 1]; // get last element of cycle array
       let cycleIndex   = -1;
@@ -1691,26 +1691,28 @@ class Delta {
         if      (!isFL() && !isNaN(+e)                     && isUndef(this._clRadius))     this._clRadius           = +e;
         else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamLength)) this._clBeamLength       = +e;
         else if (isFL()  && !isNaN(+e)                     && isUndef(this._clBeamWidth))  this._clBeamWidth        = +e;
-        else if (isFL()  && isPrefix(e, "l")               && isUndef(this._clBeamLength)) this._clBeamLength       = +(e.slice(1));
-        else if (isFL()  && isPrefix(e, "w")               && isUndef(this._clBeamWidth))  this._clBeamWidth        = +(e.slice(1));
+        else if (isFL()  && isPre(e, "l")                  && isUndef(this._clBeamLength)) this._clBeamLength       = +(e.slice(1));
+        else if (isFL()  && isPre(e, "w")                  && isUndef(this._clBeamWidth))  this._clBeamWidth        = +(e.slice(1));
         else if (           isEquals(e, "cycle")           && isUndef(this._clColor))      colorCycle               = [];
-        else if (           isPrefix(e, "#", "a#")         && colorCycle)                { colorCycle.push({ "color": new VRGBA(e) }); cycleIndex = i; }
+        else if (           isPre(e, "#", "a#")            && colorCycle)                { colorCycle.push({ "color": new VRGBA(e) }); cycleIndex = i; }
         else if (           !isNaN(+e)                     && cycleIndex + 1 == i)         cycleLast().onDuration   = +e;
-        else if (           !isNaN(+p) && !isNaN(+e)       && cycleIndex + 2 == i)         cycleLast().fadeDuration = +e; // check previous
-        else if (!isFL() && !isNaN(+p) && !isNaN(+e)       && cycleIndex + 3 == i)         cycleLast().radiusGrow   = +e; // check previous
-        else if (isFL() &&  !isNaN(+p) && !isNaN(+e)       && cycleIndex + 3 == i)         cycleLast().beamLength   = +e; // check previous
-        else if (isFL() &&  !isNaN(+p) && !isNaN(+e)       && cycleIndex + 4 == i)         cycleLast().beamWidth    = +e; // check previous
-        else if (           isPrefix(e, "#", "a#")         && isUndef(this._clColor))      this._clColor            = new VRGBA(e);
+        else if (           !isNaN(+p) && !isNaN(+e)       && cycleIndex + 2 == i)         cycleLast().fadeDuration = +e;            // check previous
+        else if (!isFL() && !isNaN(+p) && !isNaN(+e)       && cycleIndex + 3 == i)         cycleLast().radiusGrow   = +e;            // check previous
+        else if ( isFL() && !isNaN(+p) && !isNaN(+e)       && cycleIndex + 3 == i)         cycleLast().beamLength   = +e;            // check previous
+        else if ( isFL() && !isNaN(+p) && !isNaN(+e)       && cycleIndex + 4 == i)         cycleLast().beamWidth    = +e;            // check previous
+        else if ( isFL() && !isNaN(+p)    && isPre(e, "l") && cycleIndex + 3 == i)         cycleLast().beamLength   = +(e.slice(1)); // check previous
+        else if ( isFL() && isPre(p, "l") && isPre(e, "w") && cycleIndex + 4 == i)         cycleLast().beamWidth    = +(e.slice(1)); // check previous
+        else if (           isPre(e, "#", "a#")            && isUndef(this._clColor))      this._clColor            = new VRGBA(e);
         else if (           isOn(e)                        && isUndef(this._clOnOff))      this._clOnOff            = true;
         else if (           isOff(e)                       && isUndef(this._clOnOff))      this._clOnOff            = false;
         else if (           isEquals(e, "night", "day")    && isUndef(this._clSwitch))     this._clSwitch           = e;
-        else if (           isPrefix(e, "b")               && isUndef(this._clBrightness)) this._clBrightness       = Number(+(e.slice(1)) / 100).clamp(0, 1);
-        else if (!isFL() && isPrefix(e, "d")               && isUndef(this._clDirection))  this._clDirection        = +(e.slice(1));
+        else if (           isPre(e, "b")                  && isUndef(this._clBrightness)) this._clBrightness       = Number(+(e.slice(1)) / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection        = +(e.slice(1));
         else if ( isFL() && !isNaN(+e)                     && isUndef(this._clDirection))  this._clDirection        = +e;
-        else if ( isFL() && isPrefix(e, "d")               && isUndef(this._clDirection))  this._clDirection        = CLDirectionMap[+(e.slice(1))];
-        else if ( isFL() && isPrefix(e, "a")               && isUndef(this._clDirection))  this._clDirection        = Math.PI / 180 * +(e.slice(1));
-        else if (           isPrefix(e, "x")               && isUndef(this._clXOffset))    this._clXOffset          = +(e.slice(1));
-        else if (           isPrefix(e, "y")               && isUndef(this._clYOffset))    this._clYOffset          = +(e.slice(1));
+        else if ( isFL() && isPre(e, "d")                  && isUndef(this._clDirection))  this._clDirection        = CLDirectionMap[+(e.slice(1))];
+        else if ( isFL() && isPre(e, "a")                  && isUndef(this._clDirection))  this._clDirection        = Math.PI / 180 * +(e.slice(1));
+        else if (           isPre(e, "x")                  && isUndef(this._clXOffset))    this._clXOffset          = +(e.slice(1));
+        else if (           isPre(e, "y")                  && isUndef(this._clYOffset))    this._clYOffset          = +(e.slice(1));
         else if (           e.length > 0                   && isUndef(this._clId))         this._clId               = e;
         p = e;
       }, this);
@@ -1719,14 +1721,14 @@ class Delta {
         this._clCycle = [];                                                    // only define if colorCycle exists
         colorCycle.forEach((e, i, a) => {                                      // preprocess color cycle deltas
           let n = a[++i < colorCycle.length ? i : 0];                          // get next element
-          let fadeDuration   = orNullish(e.fadeDuration, 0);                   // grab fade duration for this color since we are fading from it
-          let onDuration     = orNullish(n.onDuration, 1);                     // grab on duration for the next color since we are fading to it
-          let thisRadius     = orNullish(e.radiusGrow, this._clRadius, 0);     // grab this radius or use the default (light only)
-          let nextRadius     = orNullish(n.radiusGrow, this._clRadius, 0);     // grab next radius or use the default (light only)
-          let thisBeamLength = orNullish(e.beamLength, this._clBeamLength, 0); // grab this beam length or use the default (flashlight only)
-          let nextBeamLength = orNullish(n.beamLength, this._clBeamLength, 0); // grab next beam length or use the default (flashlight only)
-          let thisBeamWidth  = orNullish(e.beamWidth, this._clBeamWidth, 0);   // grab this beam width or use the default (flashlight only)
-          let nextBeamWidth  = orNullish(n.beamWidth, this._clBeamWidth, 0);   // grab next beam width or use the default (flashlight only)
+          let fadeDuration   =     orNaN(e.fadeDuration, 0);                   // grab fade duration for this color since we are fading from it
+          let onDuration     =     orNaN(n.onDuration,   1);                   // grab on duration for the next color since we are fading to it
+          let thisRadius     =     orNaN(e.radiusGrow, this._clRadius, 0);     // grab this radius or use the default (light only)
+          let nextRadius     =     orNaN(n.radiusGrow, this._clRadius, 0);     // grab next radius or use the default (light only)
+          let thisBeamLength =     orNaN(e.beamLength, this._clBeamLength, 0); // grab this beam length or use the default (flashlight only)
+          let nextBeamLength =     orNaN(n.beamLength, this._clBeamLength, 0); // grab next beam length or use the default (flashlight only)
+          let thisBeamWidth  =     orNaN(e.beamWidth,  this._clBeamWidth,  0); // grab this beam width or use the default (flashlight only)
+          let nextBeamWidth  =     orNaN(n.beamWidth,  this._clBeamWidth,  0); // grab next beam width or use the default (flashlight only)
           let thisColor      = orNullish(e.color, colorCycle[0].color);        // grab this color
           let nextColor      = orNullish(n.color, colorCycle[0].color);        // grab next color
           this._clCycle.push(Delta.createLight(thisColor,      nextColor,      // push colors

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2113,7 +2113,6 @@ class ColorDelta {
           lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
         let targetProps = lightArray[this._cl.id];                          // get target prop reference
         this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
-        console.log(this._cl.delta);
       }
       // Non-conditional light
       else {
@@ -3404,8 +3403,7 @@ class ColorDelta {
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
       let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      console.log(args[2]);
-      if (targetProps) targetProps.parseProps([args[2] != null ? args[2] : "#"]);
+      if (targetProps) targetProps.parseProps([(args[2] != null && !args[2].equalsIC("defaultcolor")) ? args[2] : "#"]);
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1295,26 +1295,27 @@ class VRGBA {
 class ConditionalLight {
   /**
    * Creates a ConditionalLight object with the provided parameters
-   * @param {VRGBA}  color
-   * @param {Number} direction
-   * @param {Number} brightness
-   * @param {Number} xOffset
-   * @param {Number} yOffset
-   * @param {Number} radius
-   * @param {Number} beamLength
-   * @param {Number} beamWidth
+   * @param {VRGBA}  cColor
+   * @param {Number} cDirection
+   * @param {Number} cBrightness
+   * @param {Number} cXOffset
+   * @param {Number} cYOffset
+   * @param {Number} cRadius
+   * @param {Number} cBeamLength
+   * @param {Number} cBeamWidth
    **/
-  constructor(color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(cColor, cDirection, cBrightness, cXOffset, cYOffset, cRadius, cBeamLength, cBeamWidth) {
     if (arguments.length == 0) return;
-    this.duration   = 0;
-    this.color      = color;
-    this.direction  = direction;
-    this.brightness = brightness;
-    this.xOffset    = xOffset;
-    this.yOffset    = yOffset;
-    this.radius     = radius;
-    this.beamLength = beamLength;
-    this.beamWidth  = beamWidth;
+    this.fDuration   = 0;
+    this.pDuration   = 0;
+    this.cColor      = cColor;
+    this.cDirection  = cDirection;
+    this.cBrightness = cBrightness;
+    this.cXOffset    = cXOffset;
+    this.cYOffset    = cYOffset;
+    this.cRadius     = cRadius;
+    this.cBeamLength = cBeamLength;
+    this.cBeamWidth  = cBeamWidth;
   }
 
   /**
@@ -1323,32 +1324,41 @@ class ConditionalLight {
    **/
   clone() {
     let that = new ConditionalLight();
-    // clone properties
-    if (this.duration   != null) that.duration   = this.duration;
-    if (this.color      != null) that.color      = this.color.clone();
-    if (this.direction  != null) that.direction  = this.direction;
-    if (this.brightness != null) that.brightness = this.brightness;
-    if (this.xOffset    != null) that.xOffset    = this.xOffset;
-    if (this.yOffset    != null) that.yOffset    = this.yOffset;
-    if (this.radius     != null) that.radius     = this.radius;
-    if (this.beamLength != null) that.beamLength = this.beamLength;
-    if (this.beamWidth  != null) that.beamWidth  = this.beamWidth;
+    // clone durations
+    if (this.fDuration   != null) that.fDuration   = this.fDuration;
+    if (this.pDuration   != null) that.pDuration   = this.pDuration;
+    // clone currents
+    if (this.cColor      != null) that.cColor      = this.cColor.clone();
+    if (this.cDirection  != null) that.cDirection  = this.cDirection;
+    if (this.cBrightness != null) that.cBrightness = this.cBrightness;
+    if (this.cXOffset    != null) that.cXOffset    = this.cXOffset;
+    if (this.cYOffset    != null) that.cYOffset    = this.cYOffset;
+    if (this.cRadius     != null) that.cRadius     = this.cRadius;
+    if (this.cBeamLength != null) that.cBeamLength = this.cBeamLength;
+    if (this.cBeamWidth  != null) that.cBeamWidth  = this.cBeamWidth;
+    // clone targets
+    if (this.tColor      != null) that.tColor      = this.tColor.clone();
+    if (this.tDirection  != null) that.tDirection  = this.tDirection;
+    if (this.tBrightness != null) that.tBrightness = this.tBrightness;
+    if (this.tXOffset    != null) that.tXOffset    = this.tXOffset;
+    if (this.tYOffset    != null) that.tYOffset    = this.tYOffset;
+    if (this.tRadius     != null) that.tRadius     = this.tRadius;
+    if (this.tBeamLength != null) that.tBeamLength = this.tBeamLength;
+    if (this.tBeamWidth  != null) that.tBeamWidth  = this.tBeamWidth;
     // clone deltas
-    if (this.colorDelta      != null) that.colorDelta      = this.colorDelta     .clone();
-    if (this.directionDelta  != null) that.directionDelta  = this.directionDelta .clone();
-    if (this.brightnessDelta != null) that.brightnessDelta = this.brightnessDelta.clone();
-    if (this.xOffsetDelta    != null) that.xOffsetDelta    = this.xOffsetDelta   .clone();
-    if (this.yOffsetDelta    != null) that.yOffsetDelta    = this.yOffsetDelta   .clone();
-    if (this.radiusDelta     != null) that.radiusDelta     = this.radiusDelta    .clone();
-    if (this.beamLengthDelta != null) that.beamLengthDelta = this.beamLengthDelta.clone();
-    if (this.beamWidthDelta  != null) that.beamWidthDelta  = this.beamWidthDelta .clone();
+    if (this.dColor      != null) that.dColor      = this.dColor     .clone();
+    if (this.dDirection  != null) that.dDirection  = this.dDirection .clone();
+    if (this.dBrightness != null) that.dBrightness = this.dBrightness.clone();
+    if (this.dXOffset    != null) that.dXOffset    = this.dXOffset   .clone();
+    if (this.dYOffset    != null) that.dYOffset    = this.dYOffset   .clone();
+    if (this.dRadius     != null) that.dRadius     = this.dRadius    .clone();
+    if (this.dBeamLength != null) that.dBeamLength = this.dBeamLength.clone();
+    if (this.dBeamWidth  != null) that.dBeamWidth  = this.dBeamWidth .clone();
     return that;
   }
 
   /**
    * Sets up all supported deltas using the provided fade duration, pause duration, and target values.
-   * @param {Number} fadeDuration
-   * @param {Number} pauseDuration
    * @param {VRGBA}  tColor
    * @param {Number} tDirection
    * @param {Number} tBrightness
@@ -1358,57 +1368,89 @@ class ConditionalLight {
    * @param {Number} tBeamLength
    * @param {Number} tBeamWidth
    */
-  setupTargets(fadeDuration, pauseDuration, tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
-    if (this.color      != null) this.colorDelta      = ColorDelta.createLight(this.color,  tColor,      fadeDuration, pauseDuration);
-    if (this.direction  != null) this.directionDelta  = NumberDelta.create(this.direction,  tDirection,  fadeDuration);
-    if (this.brightness != null) this.brightnessDelta = NumberDelta.create(this.brightness, tBrightness, fadeDuration);
-    if (this.xOffset    != null) this.xOffsetDelta    = NumberDelta.create(this.xOffset,    tXOffset,    fadeDuration);
-    if (this.yOffset    != null) this.yOffsetDelta    = NumberDelta.create(this.yOffset,    tYOffset,    fadeDuration);
-    if (this.radius     != null) this.radiusDelta     = NumberDelta.create(this.radius,     tRadius,     fadeDuration);
-    if (this.beamLength != null) this.beamLengthDelta = NumberDelta.create(this.beamLength, tBeamLength, fadeDuration);
-    if (this.beamWidth  != null) this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  tBeamWidth,  fadeDuration);
+  setTargets(tColor, tDirection, tBrightness, tXOffset, tYOffset, tRadius, tBeamLength, tBeamWidth) {
+    this.tColor      = tColor;
+    this.tDirection  = tDirection;
+    this.tBrightness = tBrightness;
+    this.tXOffset    = tXOffset;
+    this.tYOffset    = tYOffset;
+    this.tRadius     = tRadius;
+    this.tBeamLength = tBeamLength;
+    this.tBeamWidth  = tBeamWidth;
   }
 
   /**
-   * Processes and sets current conditional light properties from a string array.
+   * Processes and sets target fade and pause duration properties from a string array.
    * @param {String[]} properties
    **/
-  parseCondLightProps(properties) {
+  parseDurationProps(properties) {
+    let fDuration  = properties.find((e) => (e.startsWithIC('f')));
+    let pDuration  = properties.find((e) => (e.startsWithIC('p')));
+    this.fDuration = fDuration ? +fDuration.slice(1) : 0;
+    this.pDuration = pDuration ? +pDuration.slice(1) : 0;
+  }
+
+  /**
+   * Processes and sets current properties from a string array.
+   * @param {String[]} properties
+   **/
+  parseCurrentProps(properties) {
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.color      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.direction  = orNaN(Math.PI / 180 * +(e.slice(1)));
-      else if (e.startsWithIC('b'))  this.brightness = orNaN(+e.slice(1));
-      else if (e.startsWithIC('x'))  this.xOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('y'))  this.yOffset    = orNaN(+e.slice(1));
-      else if (e.startsWithIC('r'))  this.radius     = orNaN(+e.slice(1));
-      else if (e.startsWithIC('l'))  this.beamLength = orNaN(+e.slice(1));
-      else if (e.startsWithIC('w'))  this.beamWidth  = orNaN(+e.slice(1));
+      if      (e.startsWithIC('#'))  this.cColor      = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.cColor      = new VRGBA(e);
+      else if (e.startsWithIC('a'))  this.cDirection  = orNaN(Math.PI / 180 * +(e.slice(1)));
+      else if (e.startsWithIC('b'))  this.cBrightness = orNaN(+e.slice(1));
+      else if (e.startsWithIC('x'))  this.cXOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('y'))  this.cYOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('r'))  this.cRadius     = orNaN(+e.slice(1));
+      else if (e.startsWithIC('l'))  this.cBeamLength = orNaN(+e.slice(1));
+      else if (e.startsWithIC('w'))  this.cBeamWidth  = orNaN(+e.slice(1));
     });
   }
 
   /**
-   * Processes and sets target conditional light properties from a string array.
+   * Processes and sets target properties from a string array.
    * @param {String[]} properties
    **/
-  parseTargetCondLightProps(properties) {
-    let fadeDuration  = properties.find((e) => (e.startsWithIC('f')));
-    let pauseDuration = properties.find((e) => (e.startsWithIC('p')));
-    fadeDuration      = fadeDuration ?  +fadeDuration.slice(1)  : 0;
-    pauseDuration     = pauseDuration ? +pauseDuration.slice(1) : 0;
-    this.duration     = fadeDuration + pauseDuration;
-
+  parseTargetProps(properties) {
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration);
-      else if (e.startsWithIC('a#')) this.colorDelta      = ColorDelta.createLight(this.color,  new VRGBA(e), fadeDuration);
-      else if (e.startsWithIC('a'))  this.directionDelta  = NumberDelta.create(this.direction,  Math.PI / 180 * +(e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('b'))  this.brightnessDelta = NumberDelta.create(this.brightness, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('x'))  this.xOffsetDelta    = NumberDelta.create(this.xOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('y'))  this.yOffsetDelta    = NumberDelta.create(this.yOffset,    orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('r'))  this.radiusDelta     = NumberDelta.create(this.radius,     orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('l'))  this.beamLengthDelta = NumberDelta.create(this.beamLength, orNaN(+e.slice(1)), fadeDuration);
-      else if (e.startsWithIC('w'))  this.beamWidthDelta  = NumberDelta.create(this.beamWidth,  orNaN(+e.slice(1)), fadeDuration);
+      if      (e.startsWithIC('#'))  this.tColor      = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.tColor      = new VRGBA(e);
+      else if (e.startsWithIC('a'))  this.tDirection  = orNaN(Math.PI / 180 * +(e.slice(1)));
+      else if (e.startsWithIC('b'))  this.tBrightness = orNaN(+e.slice(1));
+      else if (e.startsWithIC('x'))  this.tXOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('y'))  this.tYOffset    = orNaN(+e.slice(1));
+      else if (e.startsWithIC('r'))  this.tRadius     = orNaN(+e.slice(1));
+      else if (e.startsWithIC('l'))  this.tBeamLength = orNaN(+e.slice(1));
+      else if (e.startsWithIC('w'))  this.tBeamWidth  = orNaN(+e.slice(1));
     });
+  }
+
+  /**
+   * Create deltas from currents, targets, and fade duration.
+   **/
+  createDeltas() {
+    let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
+    let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
+    // assign deltas if current & targets exist
+    this.dColor      = createColor (this.cColor,      this.tColor,      this.fDuration);
+    this.dColor      = createColor (this.cColor,      this.tColor,      this.fDuration);
+    this.dDirection  = createNumber(this.cDirection,  this.tDirection,  this.fDuration);
+    this.dBrightness = createNumber(this.cBrightness, this.tBrightness, this.fDuration);
+    this.dXOffset    = createNumber(this.cXOffset,    this.tXOffset,    this.fDuration);
+    this.dYOffset    = createNumber(this.cYOffset,    this.tYOffset,    this.fDuration);
+    this.dRadius     = createNumber(this.cRadius,     this.tRadius,     this.fDuration);
+    this.dBeamLength = createNumber(this.cBeamLength, this.tBeamLength, this.fDuration);
+    this.dBeamWidth  = createNumber(this.cBeamWidth,  this.tBeamWidth,  this.fDuration);
+    // assign new currents for existing deltas (to propagate currents for duration = 0)
+    if (this.dColor      != null) this.cColor      = this.dColor     .get();
+    if (this.dDirection  != null) this.cDirection  = this.dDirection .get();
+    if (this.dBrightness != null) this.cBrightness = this.dBrightness.get();
+    if (this.dXOffset    != null) this.cXOffset    = this.dXOffset   .get();
+    if (this.dYOffset    != null) this.cYOffset    = this.dYOffset   .get();
+    if (this.dRadius     != null) this.cRadius     = this.dRadius    .get();
+    if (this.dBeamLength != null) this.cBeamLength = this.dBeamLength.get();
+    if (this.dBeamWidth  != null) this.cBeamWidth  = this.dBeamWidth .get();
   }
 
   /**
@@ -1417,15 +1459,18 @@ class ConditionalLight {
    */
   next() {
     if (this.finished()) return this;
-    if (this.colorDelta      != null) this.color      = this.colorDelta     .next().get();
-    if (this.directionDelta  != null) this.direction  = this.directionDelta .next().get();
-    if (this.brightnessDelta != null) this.brightness = this.brightnessDelta.next().get();
-    if (this.xOffsetDelta    != null) this.xOffset    = this.xOffsetDelta   .next().get();
-    if (this.yOffsetDelta    != null) this.yOffset    = this.yOffsetDelta   .next().get();
-    if (this.radiusDelta     != null) this.radius     = this.radiusDelta    .next().get();
-    if (this.beamLengthDelta != null) this.beamLength = this.beamLengthDelta.next().get();
-    if (this.beamWidthDelta  != null) this.beamWidth  = this.beamWidthDelta .next().get();
-    this.duration--;
+    if (this.fDuration > 0) { // only update if fade duration isn't 0
+      if (this.dColor      != null) this.cColor      = this.dColor     .next().get();
+      if (this.dDirection  != null) this.cDirection  = this.dDirection .next().get();
+      if (this.dBrightness != null) this.cBrightness = this.dBrightness.next().get();
+      if (this.dXOffset    != null) this.cXOffset    = this.dXOffset   .next().get();
+      if (this.dYOffset    != null) this.cYOffset    = this.dYOffset   .next().get();
+      if (this.dRadius     != null) this.cRadius     = this.dRadius    .next().get();
+      if (this.dBeamLength != null) this.cBeamLength = this.dBeamLength.next().get();
+      if (this.dBeamWidth  != null) this.cBeamWidth  = this.dBeamWidth .next().get();
+      this.fDuration--;
+    } else
+      this.pDuration--;
     return this;
   }
 
@@ -1433,7 +1478,7 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() { return this.duration <= 0; }
+  finished() { return this.fDuration <= 0 && this.pDuration <= 0; }
 }
 
 /** Class representing individual number deltas for providing number changes over time at different speeds. **/
@@ -1447,8 +1492,9 @@ class NumberDelta {
    */
   constructor(start, target, duration) {
     if (arguments.length == 0) return;
-    [this.current, this.target, this.duration, this.lazyEquals, this.delta] =
-    [start,        target,      duration,      false,           (target - start) / duration];
+    let delta = target == start ? 0 : (target - start) / duration;
+    [this.current, this.target, this.duration, this.lazyEquals, this.delta] = [start, target, duration, false, delta];
+    this.finished(); // check for duration = 0
   }
 
   /**
@@ -1477,7 +1523,7 @@ class NumberDelta {
    */
   next() {
     if (this.finished()) return this; // lazy-short-circuit
-    this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
+    if(this.current != this.target) this.current = Math.minmax(this.delta > 0, this.current + this.delta, this.target);
     this.duration -= 1;
     this.finished();
     return this;
@@ -1524,6 +1570,7 @@ class ColorDelta {
                                  (this.target.g - this.current.g) / fadeDuration,
                                  (this.target.b - this.current.b) / fadeDuration,
                                  (this.target.a - this.current.a) / fadeDuration);
+    this.finished(); // check for duration = 0
   }
   /**
    * Creates a copy of the ColorDelta object.
@@ -1543,7 +1590,7 @@ class ColorDelta {
    * @param {Number} fadeDuration
    * @returns {ColorDelta}
    */
-  static createLight(start, target, fadeDuration) {
+  static create(start, target, fadeDuration) {
     return new ColorDelta(start, target, fadeDuration, false /* don't use remaining ticks */);
   }
 
@@ -1591,11 +1638,11 @@ class ColorDelta {
    */
   next(scale = 1) {
     if (this.finished()) return this; // lazy-short-circuit
-    this.current.v = this.delta.v;  // Compute next color step and clamp to target
-    this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
-    this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
-    this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
-    this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
+    this.current.v = this.delta.v;  // Compute next color step and clamp to target -- check for reference match to avoid recomputing
+    if(this.current.r != this.target.r) this.current.r = Math.minmax(this.delta.r > 0, this.current.r + scale * this.delta.r, this.target.r);
+    if(this.current.g != this.target.g) this.current.g = Math.minmax(this.delta.g > 0, this.current.g + scale * this.delta.g, this.target.g);
+    if(this.current.b != this.target.b) this.current.b = Math.minmax(this.delta.b > 0, this.current.b + scale * this.delta.b, this.target.b);
+    if(this.current.a != this.target.a) this.current.a = Math.minmax(this.delta.a > 0, this.current.a + scale * this.delta.a, this.target.a);
     this.fadeDuration -= 1;
     return this;
   }
@@ -1612,8 +1659,7 @@ class ColorDelta {
    */
   finished() {
     if (this.lazyEquals) return true; // lazy-short-circuit comparison followed by real comparison
-    if ((this.lazyEquals = this.fadeDuration <= 0))
-      return (this.current = this.target, true); // set cur to refer to target on match
+    if ((this.lazyEquals = this.fadeDuration <= 0)) return (this.current = this.target, true); // set cur to refer to target
     return false;
    }
 }
@@ -1867,8 +1913,8 @@ class ColorDelta {
   Game_Event.prototype.initLightData = function () {
     this._lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
-    let CycleGroups = [];
-    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((CycleGroups.push(group.split(/\s+/)), '')));
+    let cycleGroups = [];
+    tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((cycleGroups.push(group.split(/\s+/)), '')));
     tagData = tagData.split(/\s+/);
     this._clType = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
@@ -1913,16 +1959,21 @@ class ColorDelta {
       this._clCycle      = this._clCycle || null;
 
       // Process cycle parameters
-      if (hasCycle && CycleGroups.length) {             // check if tag included color cycling
+      if (hasCycle && cycleGroups.length) {             // check if tag included color cycling
         this._clCycle = [];                             // only define if cycle exists
-        let t = this;                                   // refer to this as t
+        let t         = this;                           // refer to this as t
         let args      = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
-        let condLight = new ConditionalLight(...args);  // create conditional light
-        CycleGroups.forEach((e, i, a) => {              // ------ loop each group
+        let condLight = new ConditionalLight(...args);  // create conditional light with initial properties
+
+        cycleGroups.forEach((e, i, a) => {              // ------ loop each group
           condLight = condLight.clone();                // - clone existing conditional light (inherit properties)
-          let n = a[++i < CycleGroups.length ? i : 0];  // - get next element
-          condLight.parseCondLightProps(e);             // - parse for new properties
-          condLight.parseTargetCondLightProps(n);       // - parse for target properties
+          let n = a[++i < cycleGroups.length ? i : 0];  // - get next element
+          condLight.parseDurationProps(n);              // - parse durations
+          condLight.parseCurrentProps(e);               // - parse for new properties
+          if (i == cycleGroups.length)                  // - last group targets initial properties
+            condLight.setTargets(...args);              // -- setup targets based off of non-cycle properties
+          condLight.parseTargetProps(n);                // - parse for cycle target properties
+          condLight.createDeltas();                     // - compute deltas
           this._clCycle.push(condLight);                // - push to list
         }, this);                                       // ------
         condLight = this._clCycle.shift();              // pop front
@@ -1932,11 +1983,11 @@ class ColorDelta {
 
       // Process conditional lighting
       if (this._clId) {                                 // check for a conditional lighting ID
-        let t = this;                                   // refer to this as t
+        let t          = this;                          // refer to this as t
         let args       = [t._clColor, t._clDirection, t._clBrightness, t._clXOffset, t._clYOffset, t._clRadius, t._clBeamLength, t._clBeamWidth];
         let condLight  = new ConditionalLight(...args); // create conditional light
-        condLight.setupTargets(0, 0, ...args);          // create matching targets
-        condLight.next();                               // compute deltas (zeroes)
+        condLight.setTargets(...args);                  // create matching targets
+        condLight.createDeltas();                       // compute deltas (zeroes)
         $gameVariables.GetLightArray()[this._clId] = condLight;
         t._clCondLight = condLight;
       }
@@ -1960,20 +2011,20 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightRadius = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.radius, this._clRadius);
+    return orNullish(this._clCondLight.cRadius, this._clRadius);
   };
   Game_Event.prototype.getLightColor = function () {
     if (this._clType === undefined) this.initLightData();
     if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.color, this._clColor.clone());
+    return orNullish(this._clCondLight.cColor, this._clColor.clone());
   };
   Game_Event.prototype.getLightBrightness = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.brightness, this._clBrightness);
+    return orNullish(this._clCondLight.cBrightness, this._clBrightness);
   };
   Game_Event.prototype.getLightDirection = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.direction, this._clDirection);
+    return orNullish(this._clCondLight.cDirection, this._clDirection);
   };
   Game_Event.prototype.getLightId = function () {
     if (this._clType === undefined) this.initLightData();
@@ -1981,19 +2032,19 @@ class ColorDelta {
   };
   Game_Event.prototype.getLightFlashlightLength = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamLength, this._clBeamLength);
+    return orNullish(this._clCondLight.cBeamLength, this._clBeamLength);
   };
   Game_Event.prototype.getLightFlashlightWidth = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.beamWidth, this._clBeamWidth);
+    return orNullish(this._clCondLight.cBeamWidth, this._clBeamWidth);
   };
   Game_Event.prototype.getLightXOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.xOffset, this._clXOffset);
+    return orNullish(this._clCondLight.cXOffset, this._clXOffset);
   };
   Game_Event.prototype.getLightYOffset = function () {
     if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.yOffset, this._clYOffset);
+    return orNullish(this._clCondLight.cYOffset, this._clYOffset);
   };
   Game_Event.prototype.getLightEnabled = function () {
     if (!this._clSwitch) return this._clOnOff;
@@ -3257,7 +3308,12 @@ class ColorDelta {
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
       let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.parseTargetCondLightProps(args[2].split(/\s+/)); }
+      if (condLight) {
+        let properties = args[2].split(/\s+/);
+        condLight.parseDurationProps(properties);
+        condLight.parseTargetProps(properties);
+        condLight.createDeltas();
+      }
     }
 
     // **************************** RESET ALL SWITCHES ***********************

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1589,7 +1589,7 @@ class ConditionalLight {
       if (this.currentDirection < this.targetDirection) this.targetDirection -= M_2PI; // c-clockwise normalize
     };
     properties.forEach((e) => {
-      if      (                       e.startsWithIC('#'))       this.targetColor = new VRGBA(e);
+      if      (                       e.startsWithIC('#'))  this.targetColor = new VRGBA(e);
       else if (                       e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
       else if (this.isFlashlight() && e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
       else if (this.isFlashlight() && e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
@@ -2936,8 +2936,8 @@ class ColorDelta {
       let distance = 3 * (flashlength * (flashlength - 1));
 
       // Compute spotlight radiuses
-      r1 = (flashlength - 1) * flashlightdensity;
-      r2 = (flashlength - 1) * flashwidth;
+      r1 = Math.max((flashlength - 1) * flashlightdensity, 0);
+      r2 = Math.max((flashlength - 1) * flashwidth, 0);
 
       // Compute beam left start coordinates
       let xLeftBeamStart = x1 - (r2 / 7) * Math.sin(dirAngle);

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1144,8 +1144,6 @@ Math.minmax                   = function (minOrMax, ...a) { return minOrMax ? Ma
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
 let isRMMV = () => Utils.RPGMAKER_NAME === "MV";
 
-let cmpFloat = (x, y) => Math.abs(x - y) < 1e-3; // custom epsilon
-
 function orBoolean(...a) {
   for (let i = 0; i < a.length; i++) {
     if (typeof a[i] === "boolean") return a[i];

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1450,7 +1450,7 @@ class LightProperties {
    * @param {Number}    beamLength
    * @param {Number}    beamWidth
    */
-  constructor(type, enable, color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+  constructor(type, color, enable, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
     // Always define in case durations aren't passed to targets
     this.transitionDuration = 0;
     this.pauseDuration      = 0;
@@ -2048,8 +2048,8 @@ class ColorDelta {
         else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
         else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
         else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._cl.enable))      this._cl.enable    = true;
-        else if (           isOff(e)            && isNul(this._cl.enable))      this._cl.enable    = false;
+        else if (           isOn(e)             && isNul(this._cl.enable))     this._cl.enable    = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))     this._cl.enable    = false;
         else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
         else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
         else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1903,10 +1903,12 @@ class ColorDelta {
     }
   }
 
+  let ReloadMapEventsRequired = false;
   let colorcycle_count = [1000];
   let colorcycle_timer = [1000];
   let eventObjId = [];
   let event_id = [];
+  let events;
   let event_stacknumber = [];
   let event_eventcount = 0;
   let light_tiles = [];
@@ -1960,7 +1962,6 @@ class ColorDelta {
   let options_lighting_on = true;
   let maxX = (Number(parameters['Screensize X']) || 816) + 2 * lightMaskPadding;
   let maxY = Number(parameters['Screensize Y']) || 624;
-  let event_reload_counter = 0;
   let notetag_reg = RegExp("<" + noteTagKey + ":[ ]*([^>]+)>", "i");
   let radialColor2 = new VRGBA(useSmootherLights ? "#00000000" : "#000000");
   $$.getFirstComment = function (page) {
@@ -1992,14 +1993,6 @@ class ColorDelta {
     }
     else result = note.trim();
     return result;
-  };
-  Game_Event.prototype.getCLTag = function () {
-    let result;
-    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
-    let note = this.event().note;
-    if (pageNote) result = $$.getCLTag(pageNote);
-    if (!result) result = $$.getCLTag(note);
-    return result || "";
   };
   $$.getDayNightList = function () {
     return dayNightList;
@@ -2043,8 +2036,27 @@ class ColorDelta {
     return (this[index] = value, true);
   };
 
-  // Event note tag caching
-  Game_Event.prototype.initLightData = function () {
+  let _Game_Event_setupPage = Game_Event.prototype.setupPage;
+  Game_Event.prototype.setupPage = function () { // Hook Game_Event.setupPage() to detect page changes
+    _Game_Event_setupPage.call(this);
+    ReloadMapEventsRequired = true; // force refresh
+  };
+  let _Game_Map_setupEvents = Game_Map.prototype.setupEvents;
+  Game_Map.prototype.setupEvents = function () { // hook $GameMap.setupEvents() and _events to detect event changes.
+    _Game_Map_setupEvents.call(this);
+    this._events = new Proxy(this._events, { // called on events pop, push, splice, assign
+      set: function (...a) { ReloadMapEventsRequired = true; return Reflect.set(...a); }
+    }); // force refresh
+  };
+  Game_Event.prototype.getCLTag = function () {
+    let result;
+    let pageNote = noteTagKey ? $$.getFirstComment(this.page()) : null;
+    let note = this.event().note;
+    if (pageNote) result = $$.getCLTag(pageNote);
+    if (!result) result = $$.getCLTag(note);
+    return result || "";
+  };
+  Game_Event.prototype.initLightData = function () {   // Event note tag caching
     this._cl = {};
     this._cl.lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
@@ -2413,19 +2425,15 @@ class ColorDelta {
       $$.ReloadMapEvents();  // reload map events on map change
     }
 
-    // reload mapevents if event_data has changed (deleted or spawned events/saves)
-    if (event_eventcount != $gameMap.events().length) $$.ReloadMapEvents();
-
     // remove all old sprites
     for (let i = 0, len = this._sprites.length; i < len; i++) this._removeSprite();
 
     // No lighting on maps less than 1 || Plugin deactivated in options || Plugin deactivated by plugin command
     if (map_id <= 0 || !options_lighting_on || !$gameVariables.GetScriptActive()) return;
 
-    // reload map events every 200 cycles just in case or when a refresh is requested
-    event_reload_counter++;
-    if (event_reload_counter > 200) {
-      event_reload_counter = 0;
+    // reload map when a refresh is requested (event erase, page change, or _events object change)
+    if (ReloadMapEventsRequired) {
+      ReloadMapEventsRequired = false;
       $$.ReloadMapEvents();
     }
 
@@ -2531,8 +2539,8 @@ class ColorDelta {
     // ********** OTHER LIGHTSOURCES **************
     for (let i = 0, len = eventObjId.length; i < len; i++) {
       let evid = event_id[i];
-      let cur = $gameMap.events()[eventObjId[i]];
-      if (cur._cl == null || cur._cl.lastLightPage !== cur._pageIndex) cur.initLightData();
+      let cur  = events[eventObjId[i]];
+      if (cur._cl == null) cur.initLightData();
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
@@ -2569,10 +2577,10 @@ class ColorDelta {
         }
         // show light
         if (state === true) {
-          let lx1 = $gameMap.events()[event_stacknumber[i]].screenX();
-          let ly1 = $gameMap.events()[event_stacknumber[i]].screenY() - 24;
+          let lx1 = events[event_stacknumber[i]].screenX();
+          let ly1 = events[event_stacknumber[i]].screenY() - 24;
           if (!shift_lights_with_events) {
-            ly1 += $gameMap.events()[event_stacknumber[i]].shiftY();
+            ly1 += events[event_stacknumber[i]].shiftY();
           }
 
           // apply offsets
@@ -2580,7 +2588,7 @@ class ColorDelta {
           ly1 += +yOffset;
 
           if (lightType.is(LightType.Flashlight)) {
-            let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
+            let ldir = RMDirectionMap[events[event_stacknumber[i]]._direction] || 0;
             let flashlength = cur.getLightFlashlightLength();
             let flashwidth  = cur.getLightFlashlightWidth();
             if (!isNaN(direction)) ldir = direction;
@@ -3249,19 +3257,20 @@ class ColorDelta {
     //**********************fill up new map-array *************************
     eventObjId = [];
     event_id = [];
+    events = $gameMap.events(); // cache because events() API calls filter for each call
     event_stacknumber = [];
-    event_eventcount = $gameMap.events().length;
+    event_eventcount = events.length;
 
     for (let i = 0; i < event_eventcount; i++) {
-      if ($gameMap.events()[i]) {
-        if ($gameMap.events()[i].event() && !$gameMap.events()[i]._erased) {
-          let note = $gameMap.events()[i].getCLTag();
+      if (events[i]) {
+        if (events[i].event() && !events[i]._erased) {
+          let note = events[i].getCLTag();
 
           let note_args = note.split(" ");
           let note_command = LightType[note_args.shift().toLowerCase()];
           if (note_command) {
             eventObjId.push(i);
-            event_id.push($gameMap.events()[i]._eventId);
+            event_id.push(events[i]._eventId);
             event_stacknumber.push(i);
 
           }

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -3100,13 +3100,10 @@ class ColorDelta {
     this._maskBitmaps.additive.clearRect(0, 0, maxX, maxY);
 
     // if we came from a map, script is active, configuration authorizes using lighting effects,
-    // and there is lightsource on this map, then use the tint of the map, otherwise use full brightness
+    // then use the tint of the map, otherwise use full brightness
     let c = (!DataManager.isBattleTest() && !DataManager.isEventTest() && $gameMap.mapId() >= 0 &&
              $gameVariables.GetScriptActive() && options_lighting_on && lightInBattle) ?
             $gameVariables.GetTint() : new VRGBA("#ffffff");
-
-    // Set initial tint for battle
-    c = $$.daynightset ? $gameVariables.GetTintByTime() : c;
 
     let note = $$.getCLTag($$.getFirstComment($dataTroops[$gameTroop._troopId].pages[0]));
     if ((/^tintbattle\b/i).test(note)) {

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1135,10 +1135,10 @@ Imported[Community.Lighting.name] = true;
 * ....where # is the max distance you want in tiles.
 */
 
-Number.prototype.is           = (...a)           => a.includes(Number(this));
-Number.prototype.inRange      = (min, max)       => this >= min && this <= max;
-String.prototype.equalsIC     = (...a)           => a.map(s => s.toLowerCase()).includes(this.toLowerCase());
-String.prototype.startsWithIC = (s)              => this.toLowerCase().startsWith(s.toLowerCase());
+Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
+Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
+String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
+String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
 Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
 
 let isRMMZ = () => Utils.RPGMAKER_NAME === "MZ";
@@ -1681,9 +1681,9 @@ class ColorDelta {
 }
 
 (function ($$) {
-  let isOn = (x) => x.toLowerCase() === "on";
-  let isOff = (x) => x.toLowerCase() === "off";
-  let isActivate = (x) => x.toLowerCase() === "activate";
+  let isOn         = (x) => x.toLowerCase() === "on";
+  let isOff        = (x) => x.toLowerCase() === "off";
+  let isActivate   = (x) => x.toLowerCase() === "activate";
   let isDeactivate = (x) => x.toLowerCase() === "deactivate";
 
   // Map community light directions to polar angles (360 degrees)

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -1401,14 +1401,16 @@ class ConditionalLight {
     properties.forEach((e) => {
       if      (e.startsWithIC('#'))  this.cColor      = new VRGBA(e);
       else if (e.startsWithIC('a#')) this.cColor      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.cDirection  = orNaN(Math.PI / 180 * +(e.slice(1)));
+      else if (e.startsWithIC('a'))  this.cDirection  = Math.PI / 180 * orNaN(+e.slice(1), 0);
+      else if (e.startsWithIC('+a')) this.cDirection  = Math.PI / 180 * orNaN(+e.slice(2), 0);
+      else if (e.startsWithIC('-a')) this.cDirection  = Math.PI / 180 * orNaN(+e.slice(2), 0);
       else if (e.startsWithIC('b'))  this.cBrightness = orNaN(+e.slice(1));
       else if (e.startsWithIC('x'))  this.cXOffset    = orNaN(+e.slice(1));
       else if (e.startsWithIC('y'))  this.cYOffset    = orNaN(+e.slice(1));
       else if (e.startsWithIC('r'))  this.cRadius     = orNaN(+e.slice(1));
       else if (e.startsWithIC('l'))  this.cBeamLength = orNaN(+e.slice(1));
       else if (e.startsWithIC('w'))  this.cBeamWidth  = orNaN(+e.slice(1));
-    });
+    }, this);
   }
 
   /**
@@ -1416,17 +1418,32 @@ class ConditionalLight {
    * @param {String[]} properties
    **/
   parseTargetProps(properties) {
+    let normalizeAngle = (rads) => rads % (2 * Math.PI) + (rads < 0) * 2 * Math.PI; // normalize between 0 & 2*Pi
+    let normalizeClockwiseMovement = (target) => {
+      this.cDirection = normalizeAngle(this.cDirection); // normalize already assigned current
+      this.tDirection = normalizeAngle(Math.PI / 180 * target); // convert target to radians before normalization
+      if (this.cDirection > this.tDirection) this.tDirection += 2 * Math.PI; // normalize for clockwise movement
+    };
+    let normalizeCounterClockwiseMovement = (target) => {
+      this.cDirection = normalizeAngle(this.cDirection); // normalize already assigned current
+      this.tDirection = normalizeAngle(Math.PI / 180 * target); // convert target to radians before normalization
+      if (this.cDirection < this.tDirection) {
+        this.tDirection -= 2 * Math.PI; // normalize for counterclockwise movement
+      }
+    };
     properties.forEach((e) => {
-      if      (e.startsWithIC('#'))  this.tColor      = new VRGBA(e);
-      else if (e.startsWithIC('a#')) this.tColor      = new VRGBA(e);
-      else if (e.startsWithIC('a'))  this.tDirection  = orNaN(Math.PI / 180 * +(e.slice(1)));
+      if (e.startsWithIC('#'))       this.tColor = new VRGBA(e);
+      else if (e.startsWithIC('a#')) this.tColor = new VRGBA(e);
+      else if (e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
+      else if (e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
+      else if (e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
       else if (e.startsWithIC('b'))  this.tBrightness = orNaN(+e.slice(1));
       else if (e.startsWithIC('x'))  this.tXOffset    = orNaN(+e.slice(1));
       else if (e.startsWithIC('y'))  this.tYOffset    = orNaN(+e.slice(1));
       else if (e.startsWithIC('r'))  this.tRadius     = orNaN(+e.slice(1));
       else if (e.startsWithIC('l'))  this.tBeamLength = orNaN(+e.slice(1));
       else if (e.startsWithIC('w'))  this.tBeamWidth  = orNaN(+e.slice(1));
-    });
+    }, this);
   }
 
   /**

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -303,7 +303,7 @@ Imported[Community.Lighting.name] = true;
 *
 * @command condLight
 * @text Set Conditional Lighting
-* @desc Supports transition & pause durations, color, angle, brightness, x offset, y offset, radius, beam length & width.
+* @desc Supports transition & pause durations, on & off, color, angle, brightness, x offset, y offset, radius, beam length & width.
 *
 * @arg id
 * @text Event ID
@@ -312,9 +312,9 @@ Imported[Community.Lighting.name] = true;
 *
 * @arg properties
 * @text properties
-* @desc Format: [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+* @desc Format: [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [on|off] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
 * @type text
-* @default t5 #ffffff -a90 b0 x0 y0 r150 l12 w12
+* @default t5 #ffffff on -a90 b0 x0 y0 r150 l12 w12
 *
 * @----------------------------
 *
@@ -906,32 +906,36 @@ Imported[Community.Lighting.name] = true;
 * See the Plugin Commands section for more details.
 *
 * The following chart shows all supported properties:
-* --------------------------------------------------------------------------------------------------------------------
-* |   Property     |  Prefix   |        Format           | Examples          | Description                            |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     pause      |     p     |           pN            |    p0, p1, p20    | time period in cycles to pause after   |
-* |    duration    |           |                         |                   | transitioning for cycling lights       |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   transition   |     t     |           tN            |    t0, t1, t30    | time period to transition the          |
-* |    duration    |           |                         |                   | specified properties over              |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     color      |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | a#FFEEDD, #ffeedd | color or additive color                |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     angle      | a, +a, -a |       <a|+a|-a>N        |  a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
-* |                |           |                         |                   | clockwise, '-' moves counterclockwise  |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   brightness   |     b     |           bN            |    b0, b1, b5     | brightness                             |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |    x offset    |     x     |           xN            |     x2, x-2       | x offset                               |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |    y offset    |     y     |           yN            |     y2, y-2       | y offset                               |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |     radius     |     r     |           rN            |    r50, r150      | light radius                           |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   beam length  |     l     |           lN            |   l8, l9, l10     | flashlight beam length                 |
-* |----------------|-----------|-------------------------|-------------------|----------------------------------------|
-* |   beam width   |     w     |           wN            |  w12, w13, w14    | flashlight beam width                  |
-* --------------------------------------------------------------------------------------------------------------------
+* ---------------------------------------------------------------------------------------------------------------------
+* | Property    |  Prefix   |         Format*         |       Examples       |              Description               |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   pause     |     p     |           pN            |     p0, p1, p20      | time period in cycles to pause after   |
+* |  duration   |           |                         |                      | transitioning for cycling lights       |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | transition  |     t     |           tN            |     t0, t1, t30      | time period to transition the          |
+* |  duration   |           |                         |                      | specified properties over              |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   color     |   #, #a   | <#|#a><RRGGBBAA|RRGGBB> | #, a#FFEEDD, #ffeedd | color or additive color                |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |  enable     |     e     |         e<1|0>          |        e1, e0        | turns light on or off instantly        |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   angle     | a, +a, -a |       <a|+a|-a>N        |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+* |             |           |                         |                      | clockwise, '-' moves counterclockwise  |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | brightness  |     b     |           bN            |    b, b0, b1, b5     | brightness                             |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |  x offset   |     x     |           xN            |      x, x2, x-2      | x offset                               |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |  y offset   |     y     |           yN            |      y, y2, y-2      | y offset                               |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* |   radius    |     r     |           rN            |     r, r50, r150     | light radius                           |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | beam length |     l     |           lN            |    l, l8, l9, l10    | flashlight beam length                 |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | beam width  |     w     |           wN            |   w, w12, w13, w14   | flashlight beam width                  |
+* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+* | * Omitting N or RBG value will reset the given property back to its initial state                                 |
+* ---------------------------------------------------------------------------------------------------------------------
 *
 * --------------------------------------------------------------------------
 * Easy hex color references
@@ -1200,6 +1204,8 @@ const M_PI_180 = Math.PI / 180; // cache PI/180 - this is faster
 
 Number.prototype.is           = function(...a)    { return a.includes(Number(this)); };
 Number.prototype.inRange      = function(min, max){ return this >= min && this <= max; };
+Number.prototype.clone        = function()        { return this; };
+Boolean.prototype.clone       = function()        { return this; };
 String.prototype.equalsIC     = function(...a)    { return a.map(s => s.toLowerCase()).includes(this.toLowerCase()); };
 String.prototype.startsWithIC = function(s)       { return this.toLowerCase().startsWith(s.toLowerCase()); };
 Math.minmax                   = (minOrMax, ...a) => minOrMax ? Math.min(...a) : Math.max(...a); // min if positive
@@ -1349,7 +1355,7 @@ class VRGBA {
   /**
    * Creates a copy of the VRGBA object.
    * @returns {VRGBA}
-   **/
+   */
   clone() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [this.v, this.r, this.g, this.b, this.a];
@@ -1359,7 +1365,7 @@ class VRGBA {
   /**
    * Creates an empty VRGBA object will all properties initialized to false and 0.
    * @returns {VRGBA}
-   **/
+   */
   static empty() {
     let that = new VRGBA();
     [that.v, that.r, that.g, that.b, that.a] = [false, 0, 0, 0, 0];
@@ -1433,201 +1439,206 @@ class VRGBA {
 }
 
 /**
- * Class representing conditional lighting which encapsulates all possible conditional parameters, provides the ability
- * to compute deltas between the current parameter values and the target values, and allows for current values to be
- * extracted.
- **/
-class ConditionalLight {
+ * Class representing conditional light properties that can be changed.
+ */
+class LightProperties {
   /**
-   * Creates a ConditionalLight object with the provided parameters
+   * Creates a LightProperties object with the provided parameters
    * @param {LightType} type
-   * @param {VRGBA}     currentColor
-   * @param {Number}    currentDirection
-   * @param {Number}    currentBrightness
-   * @param {Number}    currentXOffset
-   * @param {Number}    currentYOffset
-   * @param {Number}    currentRadius
-   * @param {Number}    currentBeamLength
-   * @param {Number}    currentBeamWidth
-   **/
-  constructor(type, currentColor, currentDirection, currentBrightness, currentXOffset, currentYOffset, currentRadius,
-              currentBeamLength, currentBeamWidth) {
-    if (arguments.length == 0) return;
+   * @param {VRGBA}     color
+   * @param {Boolean}   enable
+   * @param {Number}    direction
+   * @param {Number}    brightness
+   * @param {Number}    xOffset
+   * @param {Number}    yOffset
+   * @param {Number}    radius
+   * @param {Number}    beamLength
+   * @param {Number}    beamWidth
+   */
+  constructor(type, enable, color, direction, brightness, xOffset, yOffset, radius, beamLength, beamWidth) {
+    // Always define in case durations aren't passed to targets
     this.transitionDuration = 0;
     this.pauseDuration      = 0;
-    this.type               = type;
-    this.currentColor       = currentColor;
-    this.currentDirection   = this.isFlashlight() ? currentDirection  : void(0);
-    this.currentBrightness  = currentBrightness;
-    this.currentXOffset     = currentXOffset;
-    this.currentYOffset     = currentYOffset;
-    this.currentRadius      = this.isOtherLight() ? currentRadius     : void(0);
-    this.currentBeamLength  = this.isFlashlight() ? currentBeamLength : void(0);
-    this.currentBeamWidth   = this.isFlashlight() ? currentBeamWidth  : void(0);
+    this.updateFrame        = 0;
+    if (arguments.length == 0) return;
+    // shared properties
+    this.type       = type;
+    this.color      = color;
+    this.enable     = enable;
+    this.brightness = brightness;
+    this.xOffset    = xOffset;
+    this.yOffset    = yOffset;
+    // light type dependent properties
+    let isOL = this.isOtherLight();
+    let isFL = this.isFlashlight();
+    if (isOL) this.radius     = radius;
+    if (isFL) this.clockwise  = true;
+    if (isFL) this.direction  = direction;
+    if (isFL) this.beamLength = beamLength;
+    if (isFL) this.beamWidth  = beamWidth;
   }
 
   /**
-   * Creates a copy of the ConditionalLight object.
-   * @returns {ConditionalLight}
-   **/
+   * Returns true if the light type is a flashlight or null; otherwise false.
+   */
+  isFlashlight() { return this.type == null || this.type.is(LightType.Flashlight); }
+
+  /**
+   * Returns true if the light type is light, fire, glow, or null; otherwise false.
+   */
+  isOtherLight() { return this.type == null || this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
+
+  /**
+   * Processes and sets properties from a string array.
+   * @param {String[]} properties
+   */
+  parseProps(properties) {
+    this.updateFrame = Graphics.frameCount; // set current frame as update frame
+    let isOL = this.isOtherLight();
+    let isFL = this.isFlashlight();
+    let hasTransitionDuration = false;
+    let haspauseDuration      = false;
+    // properties with no suffix 'clear' the target
+    properties.forEach((e) => {
+      // clear checks (back to initial value for the given property)
+      if      (        e.equalsIC('#'))        this.color      = void(0);
+      else if (        e.equalsIC('a#'))       this.color      = void(0);
+      else if (        e.equalsIC('e'))        this.enable     = void(0);
+      else if (        e.equalsIC('b'))        this.brightness = void(0);
+      else if (        e.equalsIC('x'))        this.xOffset    = void(0);
+      else if (        e.equalsIC('y'))        this.yOffset    = void(0);
+      else if (isOL && e.equalsIC('r'))        this.radius     = void(0);
+      else if (isFL && e.equalsIC('l'))        this.beamLength = void(0);
+      else if (isFL && e.equalsIC('w'))        this.beamWidth  = void(0);
+      else if (isFL && e.equalsIC('a'))        this.clockwise  = this.direction = void(0);
+      else if (isFL && e.equalsIC('+a'))       this.clockwise  = this.direction = void(0);
+      else if (isFL && e.equalsIC('-a'))       this.clockwise  = this.direction = void(0);
+      // on or off checks
+      // prefix checks
+      else if (        e.startsWithIC('t'))  { this.transitionDuration = orNaN(+e.slice(1), 0); hasTransitionDuration = true; }
+      else if (        e.startsWithIC('p'))  { this.pauseDuration      = orNaN(+e.slice(1), 0); haspauseDuration = true; }
+      else if (        e.startsWithIC('#'))    this.color      = new VRGBA(e);
+      else if (        e.startsWithIC('a#'))   this.color      = new VRGBA(e);
+      else if (        e.startsWithIC('e'))    this.enable     = Boolean(orNaN(+e.slice(1), 0));
+      else if (        e.startsWithIC('b'))    this.brightness = orNaN(+e.slice(1), 0);
+      else if (        e.startsWithIC('x'))    this.xOffset    = orNaN(+e.slice(1), 0);
+      else if (        e.startsWithIC('y'))    this.yOffset    = orNaN(+e.slice(1), 0);
+      else if (isOL && e.startsWithIC('r'))    this.radius     = orNaN(+e.slice(1), 0);
+      else if (isFL && e.startsWithIC('l'))    this.beamLength = orNaN(+e.slice(1), 0);
+      else if (isFL && e.startsWithIC('w'))    this.beamWidth  = orNaN(+e.slice(1), 0);
+      else if (isFL && e.startsWithIC('a'))  { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(1), 0); }
+      else if (isFL && e.startsWithIC('+a')) { this.clockwise  = true;  this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
+      else if (isFL && e.startsWithIC('-a')) { this.clockwise  = false; this.direction = M_PI_180 * orNaN(+e.slice(2), 0); }
+    }, this);
+    if (!hasTransitionDuration) this.transitionDuration = 0;
+    if (!haspauseDuration)      this.pauseDuration = 0;
+  }
+
+  /**
+   * Creates a copy of the LightProperties object.
+   * @returns {LightDelta}
+   */
   clone() {
-    let that = new ConditionalLight();
-    // clone durations
+    let that = new LightProperties();
     if (this.transitionDuration != null) that.transitionDuration = this.transitionDuration;
     if (this.pauseDuration      != null) that.pauseDuration      = this.pauseDuration;
-    // clone type
+    if (this.updateFrame        != null) that.updateFrame        = this.updateFrame;
     if (this.type               != null) that.type               = this.type;
-    // clone currents
-    if (this.currentColor       != null) that.currentColor       = this.currentColor.clone();
-    if (this.currentDirection   != null) that.currentDirection   = this.currentDirection;
-    if (this.currentBrightness  != null) that.currentBrightness  = this.currentBrightness;
-    if (this.currentXOffset     != null) that.currentXOffset     = this.currentXOffset;
-    if (this.currentYOffset     != null) that.currentYOffset     = this.currentYOffset;
-    if (this.currentRadius      != null) that.currentRadius      = this.currentRadius;
-    if (this.currentBeamLength  != null) that.currentBeamLength  = this.currentBeamLength;
-    if (this.currentBeamWidth   != null) that.currentBeamWidth   = this.currentBeamWidth;
-    // clone targets
-    if (this.targetColor        != null) that.targetColor        = this.targetColor.clone();
-    if (this.targetDirection    != null) that.targetDirection    = this.targetDirection;
-    if (this.targetBrightness   != null) that.targetBrightness   = this.targetBrightness;
-    if (this.targetXOffset      != null) that.targetXOffset      = this.targetXOffset;
-    if (this.targetYOffset      != null) that.targetYOffset      = this.targetYOffset;
-    if (this.targetRadius       != null) that.targetRadius       = this.targetRadius;
-    if (this.targetBeamLength   != null) that.targetBeamLength   = this.targetBeamLength;
-    if (this.targetBeamWidth    != null) that.targetBeamWidth    = this.targetBeamWidth;
-    // clone deltas
-    if (this.deltaColor         != null) that.deltaColor         = this.deltaColor     .clone();
-    if (this.deltaDirection     != null) that.deltaDirection     = this.deltaDirection .clone();
-    if (this.deltaBrightness    != null) that.deltaBrightness    = this.deltaBrightness.clone();
-    if (this.deltaXOffset       != null) that.deltaXOffset       = this.deltaXOffset   .clone();
-    if (this.deltaYOffset       != null) that.deltaYOffset       = this.deltaYOffset   .clone();
-    if (this.deltaRadius        != null) that.deltaRadius        = this.deltaRadius    .clone();
-    if (this.deltaBeamLength    != null) that.deltaBeamLength    = this.deltaBeamLength.clone();
-    if (this.deltaBeamWidth     != null) that.deltaBeamWidth     = this.deltaBeamWidth .clone();
+    if (this.enable             != null) that.enable             = this.enable;
+    if (this.color              != null) that.color              = this.color     .clone();
+    if (this.brightness         != null) that.brightness         = this.brightness.clone();
+    if (this.xOffset            != null) that.xOffset            = this.xOffset   .clone();
+    if (this.yOffset            != null) that.yOffset            = this.yOffset   .clone();
+    if (this.radius             != null) that.radius             = this.radius    .clone();
+    if (this.clockwise          != null) that.clockwise          = this.clockwise .clone();
+    if (this.direction          != null) that.direction          = this.direction .clone();
+    if (this.beamLength         != null) that.beamLength         = this.beamLength.clone();
+    if (this.beamWidth          != null) that.beamWidth          = this.beamWidth .clone();
+    return that;
+  }
+}
+
+/**
+ * Class representing conditional light deltas that provides the ability to compute deltas between the
+ * current parameter values and the target values.
+ */
+class LightDelta {
+  /**
+   * Creates a LightDelta object with the provided LightProperties.
+   * @param {LightProperties} current
+   * @param {LightProperties} target
+   */
+  constructor(current, target, defaults) {
+    if (arguments.length == 0) return;
+    this.current = current;
+    this.target  = target;
+    this.defaults = defaults;
+    this.delta   = new LightProperties();
+    this.createDeltas();
+  }
+
+  /**
+   * Creates a copy of the LightDelta object.
+   * @returns {LightDelta}
+   */
+  clone() {
+    let that = new LightDelta();
+    // clone durations
+    if (this.current != null) that.current = this.current.clone();
+    if (this.target  != null) that.target  = this.target.clone();
+    if (this.delta   != null) that.delta   = this.delta.clone();
     return that;
   }
 
   /**
-   * Returns true if the light type is a flashlight; otherwise false.
-   */
-  isFlashlight() { return this.type.is(LightType.Flashlight); }
-
-  /**
-   * Returns true if the light type is light, fire, or glow; otherwise false.
-   */
-  isOtherLight() { return this.type.is(LightType.Light, LightType.fire, LightType.Glow); }
-
-  /**
-   * Sets up all supported targets.
-   * @param {VRGBA}  targetColor
-   * @param {Number} targetDirection
-   * @param {Number} targetBrightness
-   * @param {Number} targetXOffset
-   * @param {Number} targetYOffset
-   * @param {Number} targetRadius
-   * @param {Number} targetBeamLength
-   * @param {Number} targetBeamWidth
-   */
-  setTargets(targetColor, targetDirection, targetBrightness, targetXOffset, targetYOffset, targetRadius,
-             targetBeamLength, targetBeamWidth) {
-    if (targetColor       != null) this.targetColor      = targetColor;
-    if (targetDirection   != null) this.targetDirection  = this.isFlashlight() ? targetDirection  : void(0);
-    if (targetBrightness  != null) this.targetBrightness = targetBrightness;
-    if (targetXOffset     != null) this.targetXOffset    = targetXOffset;
-    if (targetYOffset     != null) this.targetYOffset    = targetYOffset;
-    if (targetRadius      != null) this.targetRadius     = this.isOtherLight() ? targetRadius     : void(0);
-    if (targetBeamLength  != null) this.targetBeamLength = this.isFlashlight() ? targetBeamLength : void(0);
-    if (targetBeamWidth   != null) this.targetBeamWidth  = this.isFlashlight() ? targetBeamWidth  : void(0);
-  }
-
-  /**
-   * Processes and sets target transition and pause duration properties from a string array.
-   * @param {String[]} properties
-   **/
-  parseDurationProps(properties) {
-    this.transitionDuration = properties.find((e) => (e.startsWithIC('t')));
-    this.pauseDuration      = properties.find((e) => (e.startsWithIC('p')));
-    this.transitionDuration = this.transitionDuration ? +this.transitionDuration.slice(1) : 0;
-    this.pauseDuration      = this.pauseDuration      ? +this.pauseDuration.slice(1)      : 0;
-  }
-
-  /**
-   * Processes and sets current properties from a string array.
-   * @param {String[]} properties
-   **/
-  parseCurrentProps(properties) {
-    properties.forEach((e) => {
-      if      (                       e.startsWithIC('#'))  this.currentColor      = new VRGBA(e);
-      else if (                       e.startsWithIC('a#')) this.currentColor      = new VRGBA(e);
-      else if (this.isFlashlight() && e.startsWithIC('a'))  this.currentDirection  = M_PI_180 * orNaN(+e.slice(1), 0);
-      else if (this.isFlashlight() && e.startsWithIC('+a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
-      else if (this.isFlashlight() && e.startsWithIC('-a')) this.currentDirection  = M_PI_180 * orNaN(+e.slice(2), 0);
-      else if (                       e.startsWithIC('b'))  this.currentBrightness = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('x'))  this.currentXOffset    = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('y'))  this.currentYOffset    = orNaN(+e.slice(1));
-      else if (this.isOtherLight() && e.startsWithIC('r'))  this.currentRadius     = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('l'))  this.currentBeamLength = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('w'))  this.currentBeamWidth  = orNaN(+e.slice(1));
-    }, this);
-  }
-
-  /**
-   * Processes and sets target properties from a string array.
-   * @param {String[]} properties
-   **/
-  parseTargetProps(properties) {
-    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
-
-    let normalizeClockwiseMovement = (target) => {
-      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
-      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
-      if (this.currentDirection > this.targetDirection) this.targetDirection += M_2PI; // clockwise normalize
-    };
-    let normalizeCounterClockwiseMovement = (target) => {
-      this.currentDirection = normalizeAngle(this.currentDirection); // normalize already assigned current
-      this.targetDirection  = normalizeAngle(M_PI_180 * target);     // convert target to radians before normalization
-      if (this.currentDirection < this.targetDirection) this.targetDirection -= M_2PI; // c-clockwise normalize
-    };
-    properties.forEach((e) => {
-      if      (                       e.startsWithIC('#'))  this.targetColor = new VRGBA(e);
-      else if (                       e.startsWithIC('a#')) this.targetColor = new VRGBA(e);
-      else if (this.isFlashlight() && e.startsWithIC('a'))  normalizeClockwiseMovement(orNaN(+e.slice(1), 0));
-      else if (this.isFlashlight() && e.startsWithIC('+a')) normalizeClockwiseMovement(orNaN(+e.slice(2), 0));
-      else if (this.isFlashlight() && e.startsWithIC('-a')) normalizeCounterClockwiseMovement(orNaN(+e.slice(2), 0));
-      else if (                       e.startsWithIC('b'))  this.targetBrightness = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('x'))  this.targetXOffset    = orNaN(+e.slice(1));
-      else if (                       e.startsWithIC('y'))  this.targetYOffset    = orNaN(+e.slice(1));
-      else if (this.isOtherLight() && e.startsWithIC('r'))  this.targetRadius     = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('l'))  this.targetBeamLength = orNaN(+e.slice(1));
-      else if (this.isFlashlight() && e.startsWithIC('w'))  this.targetBeamWidth  = orNaN(+e.slice(1));
-    }, this);
-  }
-
-  /**
    * Create deltas from currents, targets, and transition duration.
-   **/
+   */
   createDeltas() {
+    // Helper functions
+    let normalizeAngle = (rads) => rads % (M_2PI) + (rads < 0) * M_2PI; // normalize between 0 & 2*Pi
+    let normalizeClockwiseMovement = () => {
+      this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
+      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
+      if (this.current.direction > this.target.direction) this.target.direction += M_2PI; // clockwise normalize
+    };
+    let normalizeCounterClockwiseMovement = () => {
+      this.current.direction = normalizeAngle(this.current.direction); // normalize already assigned current
+      this.target.direction  = normalizeAngle(this.target.direction);  // convert target to radians before normalization
+      if (this.current.direction < this.target.direction) this.target.direction -= M_2PI; // c-clockwise normalize
+    };
     let createColor  = (...a) => !a.some(x => x == null) && ColorDelta.create(...a)  || void (0);
     let createNumber = (...a) => !a.some(x => x == null) && NumberDelta.create(...a) || void (0);
+
+    // set delta creation at current frame time
+    this.current.updateFrame = Graphics.frameCount;
+
+    // Enable or disable the current immediately based off of target value
+    this.current.enable = this.target.enable != null ? this.target.enable : this.defaults.enable;
+
+    // For currents (flashlights) check the movement direction and normalize the current and target
+    if      (this.current.direction != null && this.target.clockwise)  normalizeClockwiseMovement();
+    else if (this.current.direction != null && !this.target.clockwise) normalizeCounterClockwiseMovement();
+
     // assign deltas if current & targets exist
-    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
-    this.deltaColor      = createColor (this.currentColor,      this.targetColor,      this.transitionDuration);
-    this.deltaDirection  = createNumber(this.currentDirection,  this.targetDirection,  this.transitionDuration);
-    this.deltaBrightness = createNumber(this.currentBrightness, this.targetBrightness, this.transitionDuration);
-    this.deltaXOffset    = createNumber(this.currentXOffset,    this.targetXOffset,    this.transitionDuration);
-    this.deltaYOffset    = createNumber(this.currentYOffset,    this.targetYOffset,    this.transitionDuration);
-    this.deltaRadius     = createNumber(this.currentRadius,     this.targetRadius,     this.transitionDuration);
-    this.deltaBeamLength = createNumber(this.currentBeamLength, this.targetBeamLength, this.transitionDuration);
-    this.deltaBeamWidth  = createNumber(this.currentBeamWidth,  this.targetBeamWidth,  this.transitionDuration);
-    // assign new currents for existing deltas (to propagate currents for duration = 0)
-    if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .get();
-    if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .get();
-    if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.get();
-    if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .get();
-    if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .get();
-    if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .get();
-    if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.get();
-    if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .get();
+    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
+    this.delta.color      = createColor (this.current.color,      this.target.color,      this.current.transitionDuration);
+    this.delta.direction  = createNumber(this.current.direction,  this.target.direction,  this.current.transitionDuration);
+    this.delta.brightness = createNumber(this.current.brightness, this.target.brightness, this.current.transitionDuration);
+    this.delta.xOffset    = createNumber(this.current.xOffset,    this.target.xOffset,    this.current.transitionDuration);
+    this.delta.yOffset    = createNumber(this.current.yOffset,    this.target.yOffset,    this.current.transitionDuration);
+    this.delta.radius     = createNumber(this.current.radius,     this.target.radius,     this.current.transitionDuration);
+    this.delta.beamLength = createNumber(this.current.beamLength, this.target.beamLength, this.current.transitionDuration);
+    this.delta.beamWidth  = createNumber(this.current.beamWidth,  this.target.beamWidth,  this.current.transitionDuration);
+
+    // assign new currents for existing deltas to propagate currents for duration = 0 or target.<value> = null
+    this.current.color      = this.delta.color      != null  ? this.delta.color     .get() : this.defaults.color;
+    this.current.direction  = this.delta.direction  != null  ? this.delta.direction .get() : this.defaults.direction;
+    this.current.brightness = this.delta.brightness != null  ? this.delta.brightness.get() : this.defaults.brightness;
+    this.current.xOffset    = this.delta.xOffset    != null  ? this.delta.xOffset   .get() : this.defaults.xOffset;
+    this.current.yOffset    = this.delta.yOffset    != null  ? this.delta.yOffset   .get() : this.defaults.yOffset;
+    this.current.radius     = this.delta.radius     != null  ? this.delta.radius    .get() : this.defaults.radius;
+    this.current.beamLength = this.delta.beamLength != null  ? this.delta.beamLength.get() : this.defaults.beamLength;
+    this.current.beamWidth  = this.delta.beamWidth  != null  ? this.delta.beamWidth .get() : this.defaults.beamWidth;
   }
 
   /**
@@ -1635,19 +1646,23 @@ class ConditionalLight {
    * @returns {this}
    */
   next() {
+    // Compared the last time a delta has been generated to the last time the target has been updated
+    if (this.current.updateFrame < this.target.updateFrame) this.createDeltas();
+    // Check if transition and pause durations have reached zero
     if (this.finished()) return this;
-    if (this.transitionDuration > 0) { // only update if transition duration isn't 0 (finished)
-      if (this.deltaColor      != null) this.currentColor      = this.deltaColor     .next().get();
-      if (this.deltaDirection  != null) this.currentDirection  = this.deltaDirection .next().get();
-      if (this.deltaBrightness != null) this.currentBrightness = this.deltaBrightness.next().get();
-      if (this.deltaXOffset    != null) this.currentXOffset    = this.deltaXOffset   .next().get();
-      if (this.deltaYOffset    != null) this.currentYOffset    = this.deltaYOffset   .next().get();
-      if (this.deltaRadius     != null) this.currentRadius     = this.deltaRadius    .next().get();
-      if (this.deltaBeamLength != null) this.currentBeamLength = this.deltaBeamLength.next().get();
-      if (this.deltaBeamWidth  != null) this.currentBeamWidth  = this.deltaBeamWidth .next().get();
-      this.transitionDuration--;
+    // only update if transition duration isn't 0 (finished)
+    if (this.current.transitionDuration > 0) {
+      if (this.delta.color      != null) this.current.color      = this.delta.color     .next().get();
+      if (this.delta.direction  != null) this.current.direction  = this.delta.direction .next().get();
+      if (this.delta.brightness != null) this.current.brightness = this.delta.brightness.next().get();
+      if (this.delta.xOffset    != null) this.current.xOffset    = this.delta.xOffset   .next().get();
+      if (this.delta.yOffset    != null) this.current.yOffset    = this.delta.yOffset   .next().get();
+      if (this.delta.radius     != null) this.current.radius     = this.delta.radius    .next().get();
+      if (this.delta.beamLength != null) this.current.beamLength = this.delta.beamLength.next().get();
+      if (this.delta.beamWidth  != null) this.current.beamWidth  = this.delta.beamWidth .next().get();
+      this.current.transitionDuration--;
     } else
-      this.pauseDuration--;
+      this.current.pauseDuration--;
     return this;
   }
 
@@ -1655,12 +1670,12 @@ class ConditionalLight {
    * Returns whether all deltas are finished or not.
    * @returns {Boolean}
    */
-  finished() { return this.transitionDuration <= 0 && this.pauseDuration <= 0; }
+  finished() { return this.current.transitionDuration <= 0 && this.current.pauseDuration <= 0; }
 }
 
 /**
  * Class representing individual number deltas for providing number changes over time at different speeds.
- **/
+ */
 class NumberDelta {
   /**
    * Creates a number delta from the start number, target number, and duration.
@@ -1679,7 +1694,7 @@ class NumberDelta {
   /**
    * Creates a copy of the NumberDelta object.
    * @returns {NumberDelta}
-   **/
+   */
   clone() {
     let that = new NumberDelta();
     [that.current, that.target, that.duration, that.lazyEquals, that.delta] =
@@ -1711,7 +1726,7 @@ class NumberDelta {
   /**
    * Returns the current delta number.
    * @returns {Number}
-   **/
+   */
   get() { return this.current; }
 
   /**
@@ -1728,7 +1743,7 @@ class NumberDelta {
 
 /**
  * Class representing a color delta for providing color changes over time at different speeds.
- **/
+ */
 class ColorDelta {
   /**
    * Create a color delta from the start color, target color, fade duration, and
@@ -1756,7 +1771,7 @@ class ColorDelta {
   /**
    * Creates a copy of the ColorDelta object.
    * @returns {ColorDelta}
-   **/
+   */
   clone() {
     let that = new  ColorDelta();
     that.current      = this.current.clone();
@@ -1840,7 +1855,7 @@ class ColorDelta {
   /**
    * Returns the current delta color.
    * @returns {Number}
-   **/
+   */
   get() { return this.current.clone(); } // duplicate color so reference can't be messed with
 
   /**
@@ -2007,26 +2022,9 @@ class ColorDelta {
   };
 
   // Event note tag caching
-  Game_Event.prototype.resetLightData = function () {
-    this._clType        = undefined;
-    this._lastLightPage = undefined;
-    this._clRadius      = undefined;
-    this._clColor       = undefined;
-    this._clCycle       = undefined;
-    this._clBrightness  = undefined;
-    this._clSwitch      = undefined;
-    this._clDirection   = undefined;
-    this._clXOffset     = undefined;
-    this._clYOffset     = undefined;
-    this._clId          = undefined;
-    this._clBeamLength  = undefined;
-    this._clBeamWidth   = undefined;
-    this._clOnOff       = undefined;
-    this._clCondLight   = {};
-    this.initLightData();
-  };
   Game_Event.prototype.initLightData = function () {
-    this._lastLightPage = this._pageIndex;
+    this._cl = {};
+    this._cl.lastLightPage = this._pageIndex;
     let tagData = this.getCLTag().toLowerCase();
 
     // parse new cycle groups format within {} braces and extract from tag data for separate handling
@@ -2034,10 +2032,10 @@ class ColorDelta {
     let cycleGroups = [];
     tagData = tagData.replace(/\{(.*?)\}/g, (_, group) => ((cycleGroups.push(group.split(/\s+/)), '')));
     tagData = tagData.split(/\s+/);
-    this._clType = LightType[tagData.shift()];
+    this._cl.type = LightType[tagData.shift()];
     // Handle parsing of light, fire, and flashlight
-    if (this._clType) {
-      let isFL       = ()        => this._clType.is(LightType.Flashlight); // is flashlight
+    if (this._cl.type) {
+      let isFL       = ()        => this._cl.type.is(LightType.Flashlight); // is flashlight
       let isEq       = (e, ...a) => { for (let i of a) if (e.equalsIC(i)) return true; return false; };
       let isPre      = (e, ...a) => { for (let i of a) if (e.startsWithIC(i)) return true; return false; };
       let isNul      = (e)       => e == null;
@@ -2046,139 +2044,110 @@ class ColorDelta {
       let cycleIndex, hasCycle = false;
       tagData.forEach((e) => {
         let n = clip(e);
-        if      (!isFL() && !isNaN(+e)          && isNul(this._clRadius))     this._clRadius     = +e;
-        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamLength)) this._clBeamLength = +e;
-        else if (isFL()  && !isNaN(+e)          && isNul(this._clBeamWidth))  this._clBeamWidth  = +e;
-        else if (isFL()  && isPre(e, "l") && n  && isNul(this._clBeamLength)) this._clBeamLength = n;
-        else if (isFL()  && isPre(e, "w") && n  && isNul(this._clBeamWidth))  this._clBeamWidth  = n;
-        else if (           isEq(e, "cycle")    && isNul(this._clColor))      hasCycle           = true;
-        else if (           isPre(e, "#", "a#") && hasCycle)                  cycleIndex = cycleGroups.push([e]) - 2;
-        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])   cycleGroups[cycleIndex].push('p' + e);
-        else if (           isPre(e, "#", "a#") && isNul(this._clColor))      this._clColor      = new VRGBA(e);
-        else if (           isOn(e)             && isNul(this._clOnOff))      this._clOnOff      = true;
-        else if (           isOff(e)            && isNul(this._clOnOff))      this._clOnOff      = false;
-        else if (           isDayNight(e)       && isNul(this._clSwitch))     this._clSwitch     = e;
-        else if (           isPre(e, "b") && n  && isNul(this._clBrightness)) this._clBrightness = (n / 100).clamp(0, 1);
-        else if (!isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = n;
-        else if ( isFL() && !isNaN(+e)          && isNul(this._clDirection))  this._clDirection  = +e;
-        else if ( isFL() && isPre(e, "d") && n  && isNul(this._clDirection))  this._clDirection  = CLDirectionMap[n];
-        else if ( isFL() && isPre(e, "a") && n  && isNul(this._clDirection))  this._clDirection  = Math.PI / 180 * n;
-        else if (           isPre(e, "x") && n  && isNul(this._clXOffset))    this._clXOffset    = n;
-        else if (           isPre(e, "y") && n  && isNul(this._clYOffset))    this._clYOffset    = n;
-        else if (           e.length > 0        && isNul(this._clId))         this._clId         = e;
+        if      (!isFL() && !isNaN(+e)          && isNul(this._cl.radius))     this._cl.radius     = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamLength)) this._cl.beamLength = +e;
+        else if (isFL()  && !isNaN(+e)          && isNul(this._cl.beamWidth))  this._cl.beamWidth  = +e;
+        else if (isFL()  && isPre(e, "l") && n  && isNul(this._cl.beamLength)) this._cl.beamLength = n;
+        else if (isFL()  && isPre(e, "w") && n  && isNul(this._cl.beamWidth))  this._cl.beamWidth  = n;
+        else if (           isEq(e, "cycle")    && isNul(this._cl.color))      hasCycle            = true;
+        else if (           isPre(e, "#", "a#") && hasCycle)                   cycleIndex = cycleGroups.push([e]) - 2;
+        else if (           !isNaN(+e)          && cycleGroups[cycleIndex])    cycleGroups[cycleIndex].push('p' + e);
+        else if (           isPre(e, "#", "a#") && isNul(this._cl.color))      this._cl.color      = new VRGBA(e);
+        else if (           isOn(e)             && isNul(this._cl.enable))      this._cl.enable    = true;
+        else if (           isOff(e)            && isNul(this._cl.enable))      this._cl.enable    = false;
+        else if (           isDayNight(e)       && isNul(this._cl.switch))     this._cl.switch     = e;
+        else if (           isPre(e, "b") && n  && isNul(this._cl.brightness)) this._cl.brightness = (n / 100).clamp(0, 1);
+        else if (!isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = n;
+        else if ( isFL() && !isNaN(+e)          && isNul(this._cl.direction))  this._cl.direction  = +e;
+        else if ( isFL() && isPre(e, "d") && n  && isNul(this._cl.direction))  this._cl.direction  = CLDirectionMap[n];
+        else if ( isFL() && isPre(e, "a") && n  && isNul(this._cl.direction))  this._cl.direction  = Math.PI / 180 * n;
+        else if (           isPre(e, "x") && n  && isNul(this._cl.xOffset))    this._cl.xOffset    = n;
+        else if (           isPre(e, "y") && n  && isNul(this._cl.yOffset))    this._cl.yOffset    = n;
+        else if (           e.length > 0        && isNul(this._cl.id))         this._cl.id         = e;
         cycleIndex += 1; // increment index. Valid for 1 iteration after a cycle color is parsed before OOB.
       }, this);
 
       // normalize parameters
-      this._clRadius        = orNaN(this._clRadius, 0);
-      this._clColor         = orNullish(this._clColor, VRGBA.empty());
-      this._clBrightness    = orNaN(this._clBrightness, 0);
-      this._clDirection     = orNaN(this._clDirection, undefined); // must be undefined for later checks
-      this._clId            = orNullish(this._clId, 0); // Alphanumeric
-      this._clBeamLength    = orNaN(this._clBeamLength, 0);
-      this._clBeamWidth     = orNaN(this._clBeamWidth, 0);
-      this._clOnOff         = orBoolean(this._clOnOff, true);
-      this._clXOffset       = orNaN(this._clXOffset, 0);
-      this._clYOffset       = orNaN(this._clYOffset, 0);
-      this._clCycle         = this._clCycle || null;
+      this._cl.radius        = orNaN(this._cl.radius, 0);
+      this._cl.color         = orNullish(this._cl.color, VRGBA.empty());
+      this._cl.enable        = orBoolean(this._cl.enable, true);
+      this._cl.brightness    = orNaN(this._cl.brightness, 0);
+      this._cl.direction     = orNaN(this._cl.direction, undefined); // must be undefined for later checks
+      this._cl.id            = orNullish(this._cl.id, 0); // Alphanumeric
+      this._cl.beamLength    = orNaN(this._cl.beamLength, 0);
+      this._cl.beamWidth     = orNaN(this._cl.beamWidth, 0);
+      this._cl.xOffset       = orNaN(this._cl.xOffset, 0);
+      this._cl.yOffset       = orNaN(this._cl.yOffset, 0);
+      this._cl.cycle         = this._cl.cycle || null;
 
-      // Process cycle parameters
-      if (cycleGroups.length) {                                       // check if tag included color cycling
-        this._clCycle = [];                                           // only define if cycle exists
-        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
-                    this._clRadius, this._clBeamLength, this._clBeamWidth];
-        let condLight = new ConditionalLight(this._clType, ...args);  // create cond light with initial properties
-        cycleGroups.forEach((e, i, a) => {                            // ------ loop each group
-          condLight = condLight.clone();                              // - clone existing light (inherit properties)
-          let n = a[++i < cycleGroups.length ? i : 0];                // - get next element
-          condLight.parseDurationProps(n);                            // - parse durations
-          condLight.parseCurrentProps(e);                             // - parse for new properties
-          if (i == cycleGroups.length)                                // - last group targets initial properties
-            condLight.setTargets(...args);                            // -- setup targets based off non-cycle properties
-          condLight.parseTargetProps(n);                              // - parse for cycle target properties
-          condLight.createDeltas();                                   // - compute deltas
-          this._clCycle.push(condLight);                              // - push to list
-        }, this);                                                     // ------
-        condLight = this._clCycle.shift();                            // pop front
-        this._clCondLight = condLight.clone();                        // clone it to be the current cond light delta
-        this._clCycle.push(condLight);                                // push original on back of list
+      // Store initial light properties
+      let props = [this._cl.color, this._cl.enable, this._cl.direction, this._cl.brightness, this._cl.xOffset,
+                   this._cl.yOffset, this._cl.radius, this._cl.beamLength, this._cl.beamWidth];
+
+      // create initial properties
+      let startProps = new LightProperties(this._cl.type, ...props);
+
+      // Process cycle parameters - for each cycle group create currentProps and targetProps and cooresponding light
+      // delta. Then put the deltas into a list to loop/cycle through repeatedly
+      if (cycleGroups.length) { // check if tag included color cycling
+        this._cl.cycle = [];     // only define if cycle exists
+        let currentProps = startProps, targetProps, delta;
+        cycleGroups.forEach((e, i, a) => {                                  // ------ loop each group ------
+          let n = a[++i < a.length ? i : 0];                                // - get next element: OOB goes to first
+          currentProps = currentProps.clone();                              // - inherit existing props
+          currentProps.parseProps(e);                                       // - parse for new props
+          targetProps = i == a.length ? startProps : currentProps.clone();  // - create target props: last targets start
+          targetProps.parseProps(n);                                        // - parse for new props: last targets start
+          let delta = new LightDelta(currentProps, targetProps, this._cl);  // - create light delta object
+          this._cl.cycle.push(delta);                                       // - push conditional light delta to list
+        }, this);                                                           // -----------------------------
+        delta = this._cl.cycle.shift(); // pop front
+        this._cl.delta = delta.clone(); // clone front as the initial lightDelta state for this cond light
+        this._cl.cycle.push(delta);     // push original on back of list
       }
-
-      // Process conditional lighting
-      if (this._clId) {                                               // check for a conditional lighting ID
-        let args = [this._clColor, this._clDirection, this._clBrightness, this._clXOffset, this._clYOffset,
-                    this._clRadius, this._clBeamLength, this._clBeamWidth];
-        let condLight  = new ConditionalLight(this._clType, ...args); // create conditional light
-        condLight.setTargets(...args);                                // create matching targets
-        condLight.createDeltas();                                     // compute deltas (zeroes)
-        $gameVariables.GetLightArray()[this._clId] = condLight;
-        this._clCondLight = condLight;
+      // Process conditional lighting - for a cond light, currentProps are light specific and targets are shared by ID
+      // a target can be updated on the fly using commands and all lights with matching IDs will use the properties
+      else if (this._cl.id) { // check for a conditional lighting ID
+        let lightArray = $gameVariables.GetLightArray();                    // get target light Object
+        if (lightArray[this._cl.id] == null)                                // check if target exists since it's shared
+          lightArray[this._cl.id] = new LightProperties();                  // -- if not, create empty reference
+        let targetProps = lightArray[this._cl.id];                          // get target prop reference
+        this._cl.delta = new LightDelta(startProps, targetProps, this._cl); // create conditional light delta
+        console.log(this._cl.delta);
+      }
+      // Non-conditional light
+      else {
+        this._cl.delta = { current: this._cl };// really just a self reference
       }
     }
   };
   Game_Event.prototype.cycleLightingNext = function () {
     let cycleList = this.getLightCycle();
-    if (cycleList && this._clCondLight.finished()) {
-      let condLight = cycleList.shift();     // pop delta from front
-      this._clCondLight = condLight.clone(); // duplicate delta
-      cycleList.push(condLight);             // push delta on back
+    if (cycleList && this._cl.delta.finished()) {
+      let delta = cycleList.shift();  // pop delta from front
+      this._cl.delta = delta.clone(); // duplicate delta
+      cycleList.push(delta);          // push delta on back
     }
   };
   Game_Event.prototype.conditionalLightingNext = function () {
-    if (this._clType === undefined) this.initLightData();
-    if (this.getLightCycle() || this.getLightId()) this._clCondLight.next();
+    if (this.getLightCycle() || this.getLightId()) this._cl.delta.next();
   };
-  Game_Event.prototype.getLightType = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clType;
+  Game_Event.prototype.getLightEnabled          = function () {
+    if (!this._cl.switch) return this._cl.delta.current.enable;
+    return (this._cl.switch.equalsIC("night") && $$.isNight()) ||
+           (this._cl.switch.equalsIC("day")   && !$$.isNight());
   };
-  Game_Event.prototype.getLightRadius = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentRadius, this._clRadius);
-  };
-  Game_Event.prototype.getLightColor = function () {
-    if (this._clType === undefined) this.initLightData();
-    if (!this._clColor) this._clColor = VRGBA.empty();
-    return orNullish(this._clCondLight.currentColor, this._clColor.clone());
-  };
-  Game_Event.prototype.getLightBrightness = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentBrightness, this._clBrightness);
-  };
-  Game_Event.prototype.getLightDirection = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentDirection, this._clDirection);
-  };
-  Game_Event.prototype.getLightId = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clId;
-  };
-  Game_Event.prototype.getLightFlashlightLength = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentBeamLength, this._clBeamLength);
-  };
-  Game_Event.prototype.getLightFlashlightWidth = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentBeamWidth, this._clBeamWidth);
-  };
-  Game_Event.prototype.getLightXOffset = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentXOffset, this._clXOffset);
-  };
-  Game_Event.prototype.getLightYOffset = function () {
-    if (this._clType === undefined) this.initLightData();
-    return orNullish(this._clCondLight.currentYOffset, this._clYOffset);
-  };
-  Game_Event.prototype.getLightEnabled = function () {
-    if (!this._clSwitch) return orNullish(this._clCondLight.enabled, this._clOnOff);
-    return orNullish(this._clCondLight.enabled,
-                    (this._clSwitch.equalsIC("night") && $$.isNight()) ||
-                    (this._clSwitch.equalsIC("day")   && !$$.isNight()));
-  };
-  Game_Event.prototype.getLightCycle = function () {
-    if (this._clType === undefined) this.initLightData();
-    return this._clCycle;
-  };
+  Game_Event.prototype.getLightType             = function () { return this._cl.type; };
+  Game_Event.prototype.getLightRadius           = function () { return this._cl.delta.current.radius; };
+  Game_Event.prototype.getLightColor            = function () { return this._cl.delta.current.color.clone(); };
+  Game_Event.prototype.getLightBrightness       = function () { return this._cl.delta.current.brightness; };
+  Game_Event.prototype.getLightDirection        = function () { return this._cl.delta.current.direction; };
+  Game_Event.prototype.getLightId               = function () { return this._cl.id; };
+  Game_Event.prototype.getLightFlashlightLength = function () { return this._cl.delta.current.beamLength; };
+  Game_Event.prototype.getLightFlashlightWidth  = function () { return this._cl.delta.current.beamWidth; };
+  Game_Event.prototype.getLightXOffset          = function () { return this._cl.delta.current.xOffset; };
+  Game_Event.prototype.getLightYOffset          = function () { return this._cl.delta.current.yOffset; };
+  Game_Event.prototype.getLightCycle            = function () { return this._cl.cycle; };
 
   let _Game_Interpreter_pluginCommand = Game_Interpreter.prototype.pluginCommand;
   /**
@@ -2548,7 +2517,7 @@ class ColorDelta {
     for (let i = 0, len = eventObjId.length; i < len; i++) {
       let evid = event_id[i];
       let cur = $gameMap.events()[eventObjId[i]];
-      if (cur._lastLightPage !== cur._pageIndex) cur.resetLightData();
+      if (cur._cl == null || cur._cl.lastLightPage !== cur._pageIndex) cur.initLightData();
 
       let lightsOnRadius = $gameVariables.GetActiveRadius();
       if (lightsOnRadius > 0) {
@@ -2568,8 +2537,8 @@ class ColorDelta {
         let color          = cur.getLightColor();      // light color
         let direction      = cur.getLightDirection();  // direction
         let brightness     = cur.getLightBrightness(); // brightness
-        let xoffset        = cur.getLightXOffset() * $gameMap.tileWidth();
-        let yoffset        = cur.getLightYOffset() * $gameMap.tileHeight();
+        let xOffset        = cur.getLightXOffset() * $gameMap.tileWidth();
+        let yOffset        = cur.getLightYOffset() * $gameMap.tileHeight();
         let state          = cur.getLightEnabled();    // checks for on, off, day, and night
 
         // Set kill switch to ON if the conditional light is deactivated,
@@ -2592,8 +2561,8 @@ class ColorDelta {
           }
 
           // apply offsets
-          lx1 += +xoffset;
-          ly1 += +yoffset;
+          lx1 += +xOffset;
+          ly1 += +yOffset;
 
           if (lightType.is(LightType.Flashlight)) {
             let ldir = RMDirectionMap[$gameMap.events()[event_stacknumber[i]]._direction] || 0;
@@ -3422,36 +3391,33 @@ class ColorDelta {
 
     // *********************** TURN SPECIFIC LIGHT ON *********************
     else if (isOn(args[0])) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.enabled = true; }
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) { targetProps.parseProps(["e1"]); }
     }
 
     // *********************** TURN SPECIFIC LIGHT OFF *********************
     else if (isOff(args[0])) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.enabled = false; }
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) { targetProps.parseProps(["e0"]); }
     }
 
     // *********************** SET COLOR *********************
     else if (args[0].equalsIC('color')) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) { condLight.currentColor = args[2] ? new VRGBA(args[2]) : null; } // null for no passed color
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      console.log(args[2]);
+      if (targetProps) targetProps.parseProps([args[2] != null ? args[2] : "#"]);
     }
 
     // *********************** SET CONDITIONAL LIGHT *********************
     else if (args[0].equalsIC('cond')) {
-      let condLight = $gameVariables.GetLightArray()[args[1].toLowerCase()];
-      if (condLight) {
-        let properties = args[2].split(/\s+/);
-        condLight.parseDurationProps(properties);
-        condLight.parseTargetProps(properties);
-        condLight.createDeltas();
-      }
+      let targetProps = $gameVariables.GetLightArray()[args[1].toLowerCase()];
+      if (targetProps) targetProps.parseProps(args[2] != null ? args[2].split(/\s+/) : ['']);
     }
 
     // **************************** RESET ALL SWITCHES ***********************
     else if (args[0].equalsIC('switch') && args[1].equalsIC('reset')) {
-      $gameVariables.SetLightArray({});
+      let lightArray = $gameVariables.GetLightArray();
+      for (let i in lightArray) lightArray[i].parseProps(['#', 'e', 'b', 'x', 'y', 'r', 'l', 'w', 'a']); // clear
     }
   };
 
@@ -3755,7 +3721,7 @@ Game_Variables.prototype.SetLightArray = function (value) {
 };
 Game_Variables.prototype.GetLightArray = function () {
   if (this._Community_Lighting_LightArray == null)
-    this._Community_Lighting_LightArray = { 0: {} };
+    this._Community_Lighting_LightArray = {};
   return this._Community_Lighting_LightArray;
 };
 Game_Variables.prototype.SetTileLightArray = function (value) {

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -2491,13 +2491,11 @@ class ColorDelta {
       y1 = y1 - flashlightYoffset;
       if (iplayer_radius < 100) {
         // dim the light a bit at lower lightradius for a less focused effect.
-        let c = playercolor;
-        c.r = Math.max(0, c.r - 50);
-        c.g = Math.max(0, c.g - 50);
-        c.b = Math.max(0, c.b - 50);
-        let newcolor = c;
+        playercolor.r = Math.max(0, playercolor.r - 50);
+        playercolor.g = Math.max(0, playercolor.g - 50);
+        playercolor.b = Math.max(0, playercolor.b - 50);
 
-        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, newcolor, radialColor2, playerflicker,
+        this._maskBitmaps.radialgradientFillRect(x1, y1, 0, iplayer_radius, playercolor, radialColor2, playerflicker,
                                                  playerbrightness);
       } else {
         this._maskBitmaps.radialgradientFillRect(x1, y1, lightMaskPadding, iplayer_radius, playercolor, radialColor2,
@@ -2610,14 +2608,12 @@ class ColorDelta {
       let y1 = (ph / 2) + (y - dy) * ph;
 
       let objectflicker = tile.lightType.is(LightType.Fire);
-      let tile_color = tile.color;
+      let tile_color = tile.color.clone();
       if (tile.lightType.is(LightType.Glow)) {
-        let c = tile.color.clone();
-        c.r = Math.floor(c.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.g = Math.floor(c.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.b = Math.floor(c.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        c.a = Math.floor(c.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
-        tile_color = c;
+        tile_color.r = Math.floor(tile_color.r + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.g = Math.floor(tile_color.g + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.b = Math.floor(tile_color.b + (60 - $gameTemp._glowAmount)).clamp(0, 255);
+        tile_color.a = Math.floor(tile_color.a + (60 - $gameTemp._glowAmount)).clamp(0, 255);
       }
       this._maskBitmaps.radialgradientFillRect(x1, y1, 0, tile.radius, tile_color, VRGBA.empty(), objectflicker,
                                                tile.brightness);
@@ -3483,8 +3479,8 @@ class ColorDelta {
       seconds = orNaN(seconds, 0);
       seconds += hours * 60 * 60 + minutes * 60;
       let totalSeconds = hoursInDay * 60 * 60;
-      while (seconds >= totalSeconds) seconds -= totalSeconds;
-      while (seconds < 0) seconds += totalSeconds;
+      seconds %= totalSeconds; // clamp to within total seconds
+      if (seconds < 0) seconds += totalSeconds;
       gV.SetDaynightSeconds(seconds);
       gV.SetDaynightHoursinDay(hoursInDay);
       setTimeColorDelta();

--- a/Community_Lighting_MZ.js
+++ b/Community_Lighting_MZ.js
@@ -3441,7 +3441,7 @@ class ColorDelta {
    * @param {String[]} args
    */
   $$.tintbattle = function (args, overrideInBattleCheck = false) {
-    if ($gameParty.inBattle() || overrideInBattleCheck) {
+    if ($gameVariables.GetScriptActive() && lightInBattle && ($gameParty.inBattle() || overrideInBattleCheck)) {
       let cmd = args[0].trim();
       if (cmd.equalsIC("set", 'fade'))
         $gameTemp._BattleTintTarget = ColorDelta.createBattleTint(new VRGBA(args[1], "#666666"), 60 * (+args[2] || 0));

--- a/README.md
+++ b/README.md
@@ -120,18 +120,23 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* --------------------------------------------------------------------------
 	* Events
 	* --------------------------------------------------------------------------
-	* DayNight
-	* - Activates day/night cycle.  Put in map note or event note
-	*
-	* Light radius [cycle] color [day|night] [brightness] [direction] [x] [y] [id]
+	* Light radius color [enable] [day|night] [brightness] [direction] [x] [y] [id]
+	* Light radius cycle <color [pauseDuration]>... [enable] [day|night] [brightness] [direction] [x] [y] [id]
+	* Light [radius] [color] [{CycleProps}...] [enable] [day|night] [brightness] [direction] [x] [y] [id]
 	* - Light
-	* - radius      100, 250, etc
-	* - cycle       Allows any number of color + duration pairs to follow that will be
-	*               cycled through before repeating from the beginning:
-	*               <cl: light 100 cycle #f00 15 #0f0 15 #00f 15 ...etc>
-	*               In Terrax Lighting, there was a hard limit of 4, but now you can use
-	*               as many as you want. [optional]
+	* - radius      Any number, optionally preceded by "R" or "r", so 100, R100, r100, etc.
+	* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+	*               through before repeating from the beginning. See the examples below for usage.
+	*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+	*               To cycle any light property or for fade transitions, use the cycleProps
+	*               format instead. [optional]
+	* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+	*               The can be used to create transitioning light patterns See the Conditional
+	*               Lighting section for more details. * Any non-cyclic properties are inherited
+	*               unless overridden by the first cyclic properties [Optional]
 	* - color       #ffffff, #ff0000, etc
+	* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+	*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
 	* - day         Causes the light to only come on during the day [optional]
 	* - night       Causes the light to only come on during the night [optional]
 	* - brightness  B50, B25, etc [optional]
@@ -141,32 +146,47 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	*               D11 s.-w. corner, D12 n.-w. corner  [optional]
 	* - x           x offset [optional] (0.5: half tile, 1 = full tile, etc)
 	* - y           y offset [optional]
-	* - id          1, 2, 2345, etc--an id number for plugin commands [optional]
+	* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+	*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+	*               where N is a number following any supported optional parameter prefix
+	*               otherwise it will be mistaken for one of the previous optional parameters.
+	*               Generally, it is adviseable to avoid any single letter followed by a number.
 	*
 	* Fire ...params
 	* - Same as Light params above, but adds a subtle flicker
 	*
-	* Flashlight [bl] [bw] [c] [onoff] [sdir|angle] [x] [y] [id]
+	* Flashlight bl bw color [enable] [day|night] [sdir|angle] [x] [y] [id]
+	* Flashlight bl bw cycle <color [pauseDuration]>... [enable] [day|night] [sdir|angle] [x] [y] [id]
+	* Flashlight [bl] [bw] [{CycleProps}...] [enable] [day|night] [sdir|angle] [x] [y] [id]
 	* - Sets the light as a flashlight with beam length (bl) beam width (bw) color (c),
 	*      0|1 (onoff), and 1=up, 2=right, 3=down, 4=left for static direction (sdir)
-	* - bl:       Beam length:  Any number, optionally preceded by "L", so 8, L8
-	* - bw:       Beam width:  Any number, optionally preceded by "W", so 12, W12
-	* - cycle     Allows any number of color + duration pairs to follow that will be
-	*             cycled through before repeating from the beginning:
-	*             <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15 on someId d3>
-	*             There's no limit to how many colors can be cycled. [optional]
-	* - onoff:    Initial state:  0, 1, off, on
-	* - sdir:     Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
-	*             Can be preceded by "D", so D4.  If omitted, defaults to 0
-	* - angle:    Forced direction in degrees (optional): must be preceded by "A". If
-	*             omitted, sdir is used.
-	* - x         x[offset] Work the same as regular light [optional]
-	* - y         y[offset] [optional]
-	* - day       Sets the event's light to only show during the day [optional]
-	* - night     Sets the event's light to only show during night time [optional]
-	* - id        1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
-	*             Those should not begin with 'a', 'd', 'x' or 'y' otherwise
-	*             they will be mistaken for one of the previous optional parameters.
+	* - bl:         Beam length:  Any number, optionally preceded by "L" or "l", so 8, L8, l8, etc.
+	* - bw:         Beam width:  Any number, optionally preceded by "W", or 'w', so 12, W12, w12, etc.
+	* - cycle       Allows any number of color + duration pairs to follow that will be cycled
+	*               through before repeating from the beginning. See the examples below for usage.
+	*               In Terrax Lighting, there was a hard limit of 4, but now there is no limit.
+	*               To cycle any light property or for fade transitions, use the cycleProps
+	*               format instead. [optional]
+	* - cycleProps  Cyclic conditional lighting properties can be specified within {} brackets.
+	*               The can be used to create transitioning light patterns See the Conditional
+	*               Lighting section for more details. * Any non-cyclic properties are inherited
+	*               unless overridden by the first cyclic properties [Optional]
+	* - color       #ffffff, #ff0000, etc
+	* - enable      Initial state: off, on (default). May optionally use 'E1|e1|E0|e0' syntax
+	*               where 1 is on, and 0 is off. Ignored if day|night passed [optional]
+	* - day         Sets the event's light to only show during the day [optional]
+	* - night       Sets the event's light to only show during night time [optional]
+	* - sdir:       Forced direction (optional): 0:auto, 1:up, 2:right, 3:down, 4:left
+	*               Can be preceded by "D" or "d", so D4, d4, etc. If omitted, defaults to 0
+	* - angle:      Forced direction in degrees (optional): must be preceded by "A" or "a". If
+	*               omitted, sdir is used. [optional]
+	* - x           x[offset] Work the same as regular light [optional]
+	* - y           y[offset] [optional]
+	* - id          1, 2, potato, etc. An id (alphanumeric) for plugin commands [optional]
+	*               These should not be in the format of '<a|b|d|e|l|w|x|y|A|B|D|E|L|W|X|Y>N'
+	*               where N is a number following any supported optional parameter prefix
+	*               otherwise it will be mistaken for one of the previous optional parameters.
+	*               Generally, it is adviseable to avoid any single letter followed by a number.
 	*
 	* Example note tags:
 	*
@@ -174,7 +194,15 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* Creates a basic light
 	*
 	* <cl: light 300 cycle #ff0000 15 #ffff00 15 #00ff00 15 #00ffff 15 #0000ff 15>
+	* <cl: light r300 {#ff0000 p15} {#ffff00} {#00ff00} {#00ffff} {#0000ff}>
 	* Creates a cycling light that rotates every 15 frames.  Great for parties!
+	*
+	* <cl: light r300 {#ff0000 t30 p60} {#ffff00} {#00ff00} {#00ffff}>
+	* Creates a cycling light that stays on for 30 frames and transitions to the next color over 60 frames.
+	*
+	* <cl: light {#ff0000 t30 p60 r250} {#ffff00 r300} {#00ff00 r250} {#00ffff r300}>
+	* Creates a cycling light that grows and shrink between radius sizes of 250 and 300, stays on for 30 frames,
+	* and transitions to the next color and size over 60 frames.
 	*
 	* <cl: fire 150 #ff8800 b15 night>
 	* Creates a fire that only lights up at night.
@@ -182,6 +210,14 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* <cl: Flashlight l8 w12 #ff0000 on asdf>
 	* Creates a flashlight beam with id asdf which can be turned on or off via
 	* plugin commands.
+	*
+	* <cl: Flashlight l8 w12 #ff0000 on asdf>
+	* Creates a flashlight beam with id asdf which can be turned on or off via
+	* plugin commands.
+	*
+	* <cl: Flashlight l8 w12 cycle #f00 15 #ff0 15 #0f0 15>
+	* <cl: Flashlight l8 w12 {#f00 p15} {#ff0} {#0f0}>
+	* Creates a flashlight beam that rotates every 15 frames.
 	*
 	* --------------------------------------------------------------------------
 	* Additive Lighting Effects
@@ -197,6 +233,62 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* <cl: Flashlight l8 w12 a#660000 on asdf>
 	* Creates a red volumetric flashlight beam with id asdf which can be turned on or off
 	* via plugin commands.
+	*
+	* --------------------------------------------------------------------------
+	* Conditional Lighting
+	* --------------------------------------------------------------------------
+	* Conditional Lighting allows light properties to be changed either cyclically or
+	* dynamically over time via properties that consist of a prefix followed by a property
+	* value. This is useful for creating any number of transitional lighting effects.
+	* Properties will hold their given value until a change or reset (including pause and
+	* transition durations).
+	*
+	* The properties are supported in light tags or via the 'light cond' command. Light tags
+	* support any number of light properties wrapped in {} brackets See the example note tags
+	* above.
+	*
+	* The 'light cond' command allows for conditional lights to be dynamically changed on demand.
+	* See the Plugin Commands section for more details.
+	*
+	* Ranges can be used if random values are desired. Cycle tags are statically generated at map
+	* load. If dynamic random property values are desired, use the 'light cond' command instead in
+	* combination with the 'light wait' command.
+	* See the table below for property specific formatting.
+	*
+	* The following table shows supported properties:
+	* ---------------------------------------------------------------------------------------------------------------------
+	* | Property    |  Prefix   |         Format*†        |       Examples       |              Description               |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |   pause     |     p     |         p<N|N:N>        |     p0, p1, p20,     | time period in cycles to pause after   |
+	* |  duration   |           |                         |    p0:20, p1:20      | transitioning for cycling lights       |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* | transition  |     t     |         t<N|N:N>        |     t0, t1, t30      | time period to transition the          |
+	* |  duration   |           |                         |    t0:30, t1:30      | specified properties over              |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |   color     |   #, #a   |   <#|#a><hex|hex:hex>   | #, #FFEEDD, #ffeedd, | color or additive color                |
+	* |             |           |                         |  a#000000:a#ffffff   |                                        |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |  enable     |     e     |        e<1|0|0:1>       |     e1, e0, e0:1     | turns light on or off instantly        |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |   angle     | a, +a, -a |     <a|+a|-a><N|N:N>    |  a, a30, +a30, -a30  | flashlight angle in degrees. '+' moves |
+	* |             |           |                         |    +a0:30, -a0:30    | clockwise, '-' moves counterclockwise  |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* | brightness  |     b     |         b<N|N:N>        | b, b0, b1, b5, b1:5  | brightness                             |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |  x offset   |     x     |         x<N|N:N>        |  x, x2, x-2, x-2:2   | x offset                               |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |  y offset   |     y     |         y<N|N:N>        |  y, y2, y-2, y-2:2   | y offset                               |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* |   radius    |     r     |         r<N|N:N>        | r, r50, r150, r50:75 | light radius                           |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* | beam length |     l     |         l<N|N:N>        | l, l8, l9, l10, l7:9 | flashlight beam length                 |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* | beam width  |     w     |         w<N|N:N>        |   w, w8, w14, w7:9   | flashlight beam width                  |
+	* |-------------|-----------|-------------------------|----------------------|----------------------------------------|
+	* | * Omitting N or hex value will transition the given property back to its initial state                            |
+	* |-------------------------------------------------------------------------------------------------------------------|
+	* | † using the N:N or hex:hex format allows for a randomly generated value within the given range (inclusive)        |
+	* ---------------------------------------------------------------------------------------------------------------------
 	*
 	* --------------------------------------------------------------------------
 	* Easy hex color references
@@ -215,7 +307,26 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* Migrating from Khas Ultra Lights
 	* -------------------------------------------------------------------------------
 	* Using the smooth lights options make it look extremely close.
-	* The default light radius that Khas appears to be around 122.
+	* The default light radius that Khas appears to be around 122. Smooth lights
+	* need to be turned on to get similar effects.
+	*
+	* All [light_size] tags should be combined with the initial light radius tag.
+	*
+	* Eg.
+	* Original:
+	* [light cyan]
+	* [light size 75]
+	*
+	* Replacement:
+	* <cl: light 75 #00FFFF>
+	*
+	* All [region_light] tags need to be replaced with <cl: region light> tags.
+	* Eg.
+	* Original:
+	* [region_light 5 red]
+	*
+	* Replacement:
+	* <cl: RegionLight 5 #FF0000 122>
 	* -------------------------------------------------------------------------------
 	* Maps
 	* -------------------------------------------------------------------------------
@@ -249,7 +360,7 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* Tint daylight
 	* - Sets the tint based on the current hour.
 	* -------------------------------------------------------------------------------
-	* Plugin Commands
+	* Plugin Commands (for MZ these use the new plugin interface)
 	* -------------------------------------------------------------------------------
 	* Light deactivate|activate
 	* - Completely disables the lighting effects of this plugin
@@ -259,6 +370,17 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	*
 	* Light off id
 	* - Turn off light with matching id number
+	*
+	* Light cond id [tN] [pN] [<#|#a><RRGGBBAA|RRGGBB>] [<a|+a|-a>N] [bN] [xN] [yN] [rN] [lN] [wN]
+	* - transitions a conditional light to the specified properties over the the given
+	* - time period in cycles. Supported propreties are color, flashlight angle (a),
+	* - brightness (b), x offset (x), y offset (y), radius (r), flashlight beam length (l),
+	* - flashlight beam width (w). Must use the specified prefixes. Unsupported prefixes are
+	* - ignored. See the Conditional Light section for more detail on each property.
+	*
+	* Light wait id
+	* - wait for the conditional light to finish both transitioning and pausing before continuing
+	* - the event script.
 	*
 	* Light color id c
 	* - Change the color (c) of lightsource with id (id)
@@ -287,20 +409,27 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* Flashlight off
 	* - Turn off the flashlight.  yup.
 	*
+	* DayNight on|off [fade]
+	* - Activates or deactivates the day/night cycle. Specifying 'fade' will gradually
+	*   transition the tint to that of the next hour.
+	*
 	* Daynight speed n
 	* - Changes the speed by which hours pass in game in relation to real life seconds
 	*
-	* Daynight hour h m
-	* - Sets the in game time to hh:mm
+	* Daynight hour h m [fade]
+	* - Sets the in game time to hh:mm. Specifying 'fade' will gradually transition the
+	*   tint to that of the next hour.
 	*
 	* Daynight color h c
 	* - Sets the hour (h) to use color (c)
 	*
-	* Daynight add h m
-	* - Adds the specified hours (h) and minutes (m) to the in game clock
+	* Daynight add h m [fade]
+	* - Adds the specified hours (h) and minutes (m) to the in game clock. Specifying
+	*   'fade' will gradually transition the tint to that of the next hour.
 	*
-	* Daynight subtract h m
-	* - Subtracts the specified hours (h) and minutes (m) from the in game clock
+	* Daynight subtract h m [fade]
+	* - Subtracts the specified hours (h) and minutes (m) from the in game clock.
+	*   Specifying  'fade' will gradually transition the tint to that of the next hour.
 	*
 	* Daynight show
 	* - Shows the current time of day in the upper right corner of the map screen (h:mm)
@@ -311,8 +440,9 @@ You can post your questions on the related thread on rpgmakerweb: https://forums
 	* Daynight hide
 	* - Hides the current time of day mini-window
 	*
-	* Daynight hoursinday h
-	* - Sets the number of hours in a day to [h] (set hour colors  if doing this)
+	* Daynight hoursinday h [fade]
+	* - Sets the number of hours in a day to [h] (set hour colors if doing this).
+	*   Specifying 'fade' will gradually transition the tint to that of the next hour.
 	*
 	* Tint set c [s]
 	* Tint fade c [s]


### PR DESCRIPTION
This PR is what all of the changes in the #85 #86 #87 #88 were leading up to. It's been pretty well tested, but of course it is possible that bugs have slipped through.

Essentially, it lands support for dynamic light transitions which allows for colors to change over a specified time period, flashlight angles to be changed, light x, y coordinates to move, etc.

I implemented a few examples of cycling in the CL demos. These are lights that changing color over time on a few of the buildings, the moving light around the dark cultist/slime, and the fairy light moving around over the fairy pond:
https://www.youtube.com/watch?v=OchjhgZiInI

## General
- Add ColorDelta type for uniform handling of color changes over time
- Add NumberDelta type for uniform handling of number changes over time
- Add ConditionalLight type for uniform handling of conditional lighting and cyclic lighting
- All new class APIs are jsdoc documented
- cache $GameMap._events object to avoid unnecessary filter() calls & remove 200 cycle forced refresh. Shouldn't be necessary anymore

## Bugfixes (none of these are in prior PRs)
- Fix tintbattle fade speed being too fast. Now consistent with field fade speeds
- Fix flashlight on/off in tag notes being ignored in all cases
- Fix lights turning on if the color is changed in cases where no previous on/off state was conditionally set
- fix on/off/color commands not allowing allowing alphanumeric IDs (they were being coerced to integers)
- fix 200 cycle delay before light shows if map state changes from no lights to having lights
- fix random 200 cycle delay if event page changes are missed (they cannot be missed now)

## Features
- new (additional) format for conditional lighting  
- Supports pause duration, transition duration, color, brightness, radius, x offset, y offset angle (flashlight), beam length (flashlight), beam width (flashlight)  
- allows colors to transition over time or lights to move over time (e.g. flashlight rotation)  
- Supported in cyclic lighting within {} braces  
- Supported in a new 'Light cond' command for dynamic in-game changing of properties
- Add ability to specify default on/off state for lights to bring in line with flashlights
- Add ability to gradually change the daylight tint when it is enabled via the new 'daylight on' command. Otherwise it will instantly change
- Add ability to gradually change tint with daynight add, subtract, and hoursinday
- Add ability to specify IDs beginning with parameter prefixes(a, d, x, y...) in light tags as long as the suffix isn't a number.
- Add random range support for new conditional lighting format.
- Add 'light wait' command which will stop an event script until a specified light transition has finished.

## Behavior changes
- resetBattleTint changed to resetTint in rmmz
- Remove support for using 0, 1 to turn lights on and off because it conflicts with setting numerical IDs and also the documentation